### PR TITLE
Invalidate and reseed SHA1PRND during checkpoint/restore

### DIFF
--- a/src/java.base/share/classes/jdk/crac/CheckpointLock.java
+++ b/src/java.base/share/classes/jdk/crac/CheckpointLock.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, 2021, Azul Systems, Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.crac;
+
+/**
+ * A {@code CheckpointLock} allows creating critical sections that are not interrupted during checkpoint/restore.
+ */
+public class CheckpointLock implements AutoCloseable {
+
+    /**
+     * Creates a {@code CheckpointLock}.
+     */
+    public CheckpointLock() {
+        jdk.internal.crac.Core.getJDKContext().addLock(this);
+    }
+
+    @Override
+    public void close() {
+        jdk.internal.crac.Core.getJDKContext().removeLock(this);
+    }
+}


### PR DESCRIPTION
This is a proposal for the CRaC Critical Section interface and its usage in the SHA1PRNG SecureRandom implementation.
The changes in the SecureRandom implementation allow invalidating and reseeding SHA1PRNG secure random during checkpoint/restore.  SHA1PRNG can be invalidated and reseeded in case of being created with a default embedded seed generator. Also, SHA1PRNG is used as an additional seed generator to the SUN NativePRNG implementation, so it is desirable to have reseeded SHA1PRNG after restore.