### PR TITLE
Disable recursive checkpoint

### DIFF
--- a/src/java.base/share/classes/jdk/crac/CheckpointException.java
+++ b/src/java.base/share/classes/jdk/crac/CheckpointException.java
@@ -43,7 +43,7 @@ public class CheckpointException extends Exception {
      * Constructs a {@code CheckpointException} with the specified
      * detail message.
      *
-     * @param   message   the detail message.
+     * @param message the detail message.
      */
     public CheckpointException(String message) {
         super(message);

--- a/src/java.base/share/classes/jdk/crac/CheckpointException.java
+++ b/src/java.base/share/classes/jdk/crac/CheckpointException.java
@@ -38,4 +38,14 @@ public class CheckpointException extends Exception {
     public CheckpointException() {
         super();
     }
+
+    /**
+     * Constructs a {@code CheckpointException} with the specified
+     * detail message.
+     *
+     * @param   message   the detail message.
+     */
+    public CheckpointException(String message) {
+        super(message);
+    }
 }

--- a/src/java.base/share/classes/jdk/crac/Core.java
+++ b/src/java.base/share/classes/jdk/crac/Core.java
@@ -181,7 +181,12 @@ public class Core {
     public static void checkpointRestore() throws
             CheckpointException,
             RestoreException {
+        // checkpointRestore protects against the simultaneous
+        // call of checkpointRestore from different threads.
         synchronized (checkpointRestoreLock) {
+            // checkpointInProgress protects against recursive
+            // checkpointRestore from resource's
+            // beforeCheckpoint/afterRestore methods
             if (!checkpointInProgress) {
                 try {
                     checkpointInProgress = true;
@@ -193,7 +198,6 @@ public class Core {
                     checkpointInProgress = false;
                 }
             } else {
-                // Recursive checkpoint/restore is not allowed
                 throw new CheckpointException("Recursive checkpoint is not allowed");
             }
         }

--- a/src/java.base/share/classes/jdk/crac/Core.java
+++ b/src/java.base/share/classes/jdk/crac/Core.java
@@ -49,6 +49,9 @@ public class Core {
     private static native Object[] checkpointRestore0();
 
     private static boolean traceStartupTime;
+    private static final Object checkpointRestoreLock = new Object();
+    private static boolean checkpointInProgress = false;
+
 
     private static final Context<Resource> globalContext = new OrderedContext();
     static {
@@ -178,11 +181,20 @@ public class Core {
     public static void checkpointRestore() throws
             CheckpointException,
             RestoreException {
-        try {
-            checkpointRestore1();
-        } finally {
-            if (traceStartupTime) {
-                System.out.println("STARTUPTIME " + System.nanoTime() + " restore-finish");
+        synchronized (checkpointRestoreLock) {
+            if (!checkpointInProgress) {
+                try {
+                    checkpointInProgress = true;
+                    checkpointRestore1();
+                } finally {
+                    if (traceStartupTime) {
+                        System.out.println("STARTUPTIME " + System.nanoTime() + " restore-finish");
+                    }
+                    checkpointInProgress = false;
+                }
+            } else {
+                // Recursive checkpoint/restore is not allowed
+                throw new CheckpointException("Recursive checkpoint is not allowed");
             }
         }
     }

--- a/src/java.base/share/classes/jdk/crac/RestoreException.java
+++ b/src/java.base/share/classes/jdk/crac/RestoreException.java
@@ -38,4 +38,14 @@ public class RestoreException extends Exception {
     public RestoreException() {
         super();
     }
+
+    /**
+     * Constructs a {@code RestoreException} with the specified
+     * detail message.
+     *
+     * @param   message   the detail message.
+     */
+    public RestoreException(String message) {
+        super(message);
+    }
 }

--- a/src/java.base/share/classes/jdk/crac/RestoreException.java
+++ b/src/java.base/share/classes/jdk/crac/RestoreException.java
@@ -43,7 +43,7 @@ public class RestoreException extends Exception {
      * Constructs a {@code RestoreException} with the specified
      * detail message.
      *
-     * @param   message   the detail message.
+     * @param message the detail message.
      */
     public RestoreException(String message) {
         super(message);

--- a/test/jdk/jdk/crac/recursiveCheckpoint/Test.java
+++ b/test/jdk/jdk/crac/recursiveCheckpoint/Test.java
@@ -1,0 +1,127 @@
+// Copyright 2019-2021 Azul Systems, Inc.  All Rights Reserved.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This code is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License version 2 only, as published by
+// the Free Software Foundation.
+//
+// This code is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.  See the GNU General Public License version 2 for more
+// details (a copy is included in the LICENSE file that accompanied this code).
+//
+// You should have received a copy of the GNU General Public License version 2
+// along with this work; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Please contact Azul Systems, 385 Moffett Park Drive, Suite 115, Sunnyvale,
+// CA 94089 USA or visit www.azul.com if you need additional information or
+// have any questions.
+
+
+import jdk.crac.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+public class Test implements Resource {
+
+    private static final AtomicInteger counter = new AtomicInteger(0);
+    private static Exception exception = null;
+
+    private static class TestThread extends Thread {
+
+        @Override
+        public void run() {
+            try {
+                jdk.crac.Core.checkpointRestore();
+            } catch (CheckpointException e) {
+                if (exception == null)
+                    exception = new RuntimeException("Checkpoint in thread ERROR " + e);
+            } catch (RestoreException e) {
+                if (exception == null)
+                    exception = new RuntimeException("Restore in thread ERROR " + e);
+            }
+        }
+    };
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        try {
+            int c = counter.incrementAndGet();
+            if (c > 1) {
+                if (exception == null)
+                    exception = new RuntimeException("Parallel checkpoint");
+            }
+            Thread.sleep(100);
+            jdk.crac.Core.checkpointRestore();
+            if (exception != null)
+                exception = new RuntimeException("Checkpoint Exception should be thrown");
+        } catch (CheckpointException e) {
+            // Expected Exception
+        } catch (RestoreException e) {
+            if (exception == null)
+                exception = new RuntimeException("Restore ERROR " + e);
+        }
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) throws Exception {
+        try {
+            int c = counter.get();
+            if (c > 1) {
+                if (exception == null)
+                    exception = new RuntimeException("Parallel checkpoint");
+            }
+            Thread.sleep(100);
+            jdk.crac.Core.checkpointRestore();
+            if (exception == null)
+                exception = new RuntimeException("Checkpoint Exception should be thrown");
+        } catch (CheckpointException e) {
+            // Expected Exception
+        } catch (RestoreException e) {
+            if (exception == null)
+                exception = new RuntimeException("Restore ERROR " + e);
+        } finally {
+            counter.decrementAndGet();
+        }
+    }
+
+    public static void main(String args[]) throws Exception {
+        if (args.length < 1) { throw new RuntimeException("number of threads is missing"); }
+        int numThreads;
+        try{
+            numThreads = Integer.parseInt(args[0]);
+        } catch (NumberFormatException ex){
+            throw new RuntimeException("invalid number of threads");
+        }
+
+        Core.getGlobalContext().register(new Test());
+
+        TestThread[] threads = new TestThread[numThreads];
+        for(int i=0; i<numThreads; i++) {
+            threads[i] = new TestThread();
+            threads[i].start();
+        };
+
+        Thread.currentThread().sleep(100);
+        try {
+            jdk.crac.Core.checkpointRestore();
+        } catch (CheckpointException e) {
+            throw new RuntimeException("Checkpoint ERROR " + e);
+        } catch (RestoreException e) {
+            throw new RuntimeException("Restore ERROR " + e);
+        }
+
+        for(int i=0; i<numThreads; i++) {
+            threads[i].join();
+        };
+
+        long ccounter = counter.get();
+        if (ccounter != 0)
+            throw new RuntimeException("Incorrect counter after restore: " + ccounter + " instead of 0");
+        if (exception != null) {
+            throw exception;
+        }
+        System.out.println("PASSED");
+    }
+}

--- a/test/jdk/jdk/crac/recursiveCheckpoint/Test.sh
+++ b/test/jdk/jdk/crac/recursiveCheckpoint/Test.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# Copyright 2019-2020 Azul Systems, Inc.  All Rights Reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 2 only, as published by
+# the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License version 2 for more
+# details (a copy is included in the LICENSE file that accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version 2
+# along with this work; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Azul Systems, 385 Moffett Park Drive, Suite 115, Sunnyvale,
+# CA 94089 USA or visit www.azul.com if you need additional information or
+# have any questions.
+
+
+##
+## @test Test.sh
+## @summary check that the recursive checkpoint is not allowed
+## @compile Test.java
+## @run shell/timeout=120 Test.sh Test0.sh
+##
+
+set -x
+
+    IMGDIR="cr"
+
+    set +e
+    ${TESTJAVA}/bin/java -cp ${TESTCLASSPATH} -XX:CRaCCheckpointTo=$IMGDIR -XX:CREngine=pauseengine Test $test 10
+    e=$?
+    for run in {1..11}; do
+        set -e
+        [ $e -eq 137 ]
+
+        ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR  -XX:CREngine=pauseengine Test 10
+    done
+    echo "PASSED $test"
+


### PR DESCRIPTION
This patch proposes restriction of the checkpoint/restore behavior: parallel or recursive checkpoint should be disabled.
CheckpointException will be thrown in case of checkpoint is requested from the beforeCheckpoint/afterRestore methods.
Checkpoint/restore will be suspended In case of another checkpoint already started by another thread.

This is a prerequisite for https://github.com/openjdk/crac/pull/5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.java.net/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/crac pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.java.net/crac pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/crac/pull/6.diff">https://git.openjdk.java.net/crac/pull/6.diff</a>

</details>
