### PR TITLE
JDKResource priorities

### DIFF
--- a/src/java.base/linux/classes/sun/nio/ch/EPollSelectorImpl.java
+++ b/src/java.base/linux/classes/sun/nio/ch/EPollSelectorImpl.java
@@ -29,6 +29,7 @@ package sun.nio.ch;
 import jdk.crac.Context;
 import jdk.crac.Resource;
 import jdk.internal.crac.JDKResource;
+import jdk.internal.crac.JDKResource.Priority;
 
 import java.io.IOException;
 import java.nio.channels.ClosedSelectorException;
@@ -404,7 +405,7 @@ class EPollSelectorImpl extends SelectorImpl implements JDKResource {
     }
 
     @Override
-    public int getPriority() {
-        return -1;
+    public Priority getPriority() {
+        return Priority.EPOLLSELECTOR;
     }
 }

--- a/src/java.base/share/classes/jdk/internal/crac/JDKContext.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKContext.java
@@ -35,7 +35,7 @@ public class JDKContext extends AbstractContextImpl<JDKResource, Void> {
     static class ContextComparator implements Comparator<Map.Entry<JDKResource, Void>> {
         @Override
         public int compare(Map.Entry<JDKResource, Void> o1, Map.Entry<JDKResource, Void> o2) {
-            return o1.getKey().getPriority().ordinal() - o2.getKey().getPriority().ordinal();
+            return o1.getKey().getPriority().compareTo(o2.getKey().getPriority());
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/crac/JDKContext.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKContext.java
@@ -35,7 +35,7 @@ public class JDKContext extends AbstractContextImpl<JDKResource, Void> {
     static class ContextComparator implements Comparator<Map.Entry<JDKResource, Void>> {
         @Override
         public int compare(Map.Entry<JDKResource, Void> o1, Map.Entry<JDKResource, Void> o2) {
-            return o2.getKey().getPriority().ordinal() - o1.getKey().getPriority().ordinal();
+            return o1.getKey().getPriority().ordinal() - o2.getKey().getPriority().ordinal();
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/crac/JDKContext.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKContext.java
@@ -35,7 +35,7 @@ public class JDKContext extends AbstractContextImpl<JDKResource, Void> {
     static class ContextComparator implements Comparator<Map.Entry<JDKResource, Void>> {
         @Override
         public int compare(Map.Entry<JDKResource, Void> o1, Map.Entry<JDKResource, Void> o2) {
-            return o2.getKey().getPriority() - o1.getKey().getPriority();
+            return o2.getKey().getPriority().ordinal() - o1.getKey().getPriority().ordinal();
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
@@ -29,5 +29,23 @@ package jdk.internal.crac;
 import jdk.crac.Resource;
 
 public interface JDKResource extends Resource {
-    int getPriority();
+    /**
+     * JDK Resource priorities.
+     * Most resources should use NORMAL.
+     * Other priorities define sequence of
+     * checkpoint notification for dependent resources
+     */
+    enum Priority {
+        /**
+         * Priority of the
+         * sun.nio.ch.EPollSelectorImpl resource
+         */
+        EPOLLSELECTOR,
+        /**
+         * Most resources should use this option.
+         */
+        NORMAL
+    };
+
+    Priority getPriority();
 }

--- a/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
@@ -31,14 +31,14 @@ import jdk.crac.Resource;
 public interface JDKResource extends Resource {
     /**
      * JDK Resource priorities.
-     * Most resources should use priority NORMAL.
+     * Priorities are defined in the order from lowest to highest.
+     * Most resources should use priority NORMAL (the lowest priority).
      * Other priorities define sequence of checkpoint notification
      * for dependent resources.
-     * If priority A is specified early in the enumeration than priority B,
-     * a JDK resource with priority A will be notified about checkpoint
-     * later than JDK resource with priority B. When restoring, the order
-     * is reversed: JDK resource with priority A will be notified about
-     * restore early than JDK resource with priority B.
+     * Checkpoint notification will be processed in the order from the lowest
+     * to the highest priorities.
+     * Restore notification will be processed in the revers order:
+     * from the highest to the lowest priorities.
      * JDK resources with the same priority will be notified about checkpoint
      * in the reverse order of registration.
      * JDK resources with the same priority will be notified about restore
@@ -46,14 +46,14 @@ public interface JDKResource extends Resource {
      */
     enum Priority {
         /**
+         * Most resources should use this option.
+         */
+        NORMAL,
+        /**
          * Priority of the
          * sun.nio.ch.EPollSelectorImpl resource
          */
-        EPOLLSELECTOR,
-        /**
-         * Most resources should use this option.
-         */
-        NORMAL
+        EPOLLSELECTOR
     };
 
     Priority getPriority();

--- a/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
@@ -31,9 +31,18 @@ import jdk.crac.Resource;
 public interface JDKResource extends Resource {
     /**
      * JDK Resource priorities.
-     * Most resources should use NORMAL.
-     * Other priorities define sequence of
-     * checkpoint notification for dependent resources
+     * Most resources should use priority NORMAL.
+     * Other priorities define sequence of checkpoint notification
+     * for dependent resources.
+     * If priority A is specified early in the enumeration than priority B,
+     * a JDK resource with priority A will be notified about checkpoint
+     * later than JDK resource with priority B. When restoring, the order
+     * is reversed: JDK resource with priority A will be notified about
+     * restore early than JDK resource with priority B.
+     * JDK resources with the same priority will be notified about checkpoint
+     * in the reverse order of registration.
+     * JDK resources with the same priority will be notified about restore
+     * in the direct order of registration.
      */
     enum Priority {
         /**

--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -76,6 +76,7 @@ import jdk.internal.access.JavaUtilZipFileAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.crac.Core;
 import jdk.internal.crac.JDKResource;
+import jdk.internal.crac.JDKResource.Priority;
 import jdk.internal.util.jar.InvalidJarIndexError;
 import jdk.internal.util.jar.JarIndex;
 import sun.net.util.URLUtil;
@@ -845,8 +846,8 @@ public class URLClassPath {
             }
 
             @Override
-            public int getPriority() {
-                return 0;
+            public Priority getPriority() {
+                return Priority.NORMAL;
             }
         }
 

--- a/src/java.base/unix/classes/java/net/PlainSocketImpl.java
+++ b/src/java.base/unix/classes/java/net/PlainSocketImpl.java
@@ -30,6 +30,7 @@ import jdk.crac.Context;
 import jdk.crac.Resource;
 import jdk.internal.crac.Core;
 import jdk.internal.crac.JDKResource;
+import jdk.internal.crac.JDKResource.Priority;
 
 /*
  * On Unix systems we simply delegate to native methods.
@@ -51,8 +52,8 @@ class PlainSocketImpl extends AbstractPlainSocketImpl
         }
 
         @Override
-        public int getPriority() {
-            return 0;
+        public Priority getPriority() {
+            return Priority.NORMAL;
         }
     }
 

--- a/src/java.base/unix/classes/sun/nio/ch/FileDispatcherImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/FileDispatcherImpl.java
@@ -34,6 +34,7 @@ import jdk.internal.access.JavaIOFileDescriptorAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.crac.Core;
 import jdk.internal.crac.JDKResource;
+import jdk.internal.crac.JDKResource.Priority;
 
 class FileDispatcherImpl extends FileDispatcher {
     static class ResourceProxy implements JDKResource {
@@ -49,8 +50,8 @@ class FileDispatcherImpl extends FileDispatcher {
         }
 
         @Override
-        public int getPriority() {
-            return 0;
+        public Priority getPriority() {
+            return Priority.NORMAL;
         }
     }
 


### PR DESCRIPTION
Added priority enumeration for the JDK resources
It will allow better handling the order of checkpoint notifications for dependent resources

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.java.net/census#akozlov) (@AntonKozlov - **Reviewer**) ⚠️ Review applies to 58f23f6739f050f46bc031843355451bf5d624ef
 * [Dan Heidinga](https://openjdk.java.net/census#heidinga) (@DanHeidinga - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/crac pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.java.net/crac pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/crac/pull/8.diff">https://git.openjdk.java.net/crac/pull/8.diff</a>

</details>
