### PR TITLE
Run native CRaC checks after failed beforeCheckpoint

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -283,10 +283,12 @@ struct CracFailDep {
 };
 
 class VM_Crac: public VM_Operation {
+  const bool _dry_run;
   bool _ok;
   GrowableArray<CracFailDep>* _failures;
  public:
-  VM_Crac() :
+  VM_Crac(bool dry_run) :
+    _dry_run(dry_run),
     _ok(false),
     _failures(new (ResourceObj::C_HEAP, mtInternal) GrowableArray<CracFailDep>(0, mtInternal))
   { }
@@ -5833,7 +5835,7 @@ static int call_crengine() {
   return 0;
 }
 
-static int checkpoint_restore(FdsInfo* fds) {
+static int checkpoint_restore() {
 
   if (CRAllowToSkipCheckpoint) {
     trace_cr("Skip Checkpoint");
@@ -5979,7 +5981,9 @@ void VM_Crac::doit() {
   do_classpaths(mark_all_in, &fds, Arguments::get_ext_dirs());
   mark_persistent(&fds);
 
-  bool ok = true;
+  // dry-run fails checkpoint
+  bool ok = !_dry_run;
+
   for (int i = 0; i < fds.len(); ++i) {
     if (fds.get_state(i) == FdsInfo::CLOSED) {
       continue;
@@ -6058,7 +6062,7 @@ void VM_Crac::doit() {
     return;
   }
 
-  int ret = checkpoint_restore(&fds);
+  int ret = checkpoint_restore();
   if (ret == JVM_CHECKPOINT_ERROR) {
     PerfMemoryLinux::checkpoint_fail();
     return;
@@ -6159,7 +6163,7 @@ static Handle ret_cr(int ret, TRAPS) {
 
 /** Checkpoint main entry.
  */
-Handle os::Linux::checkpoint(TRAPS) {
+Handle os::Linux::checkpoint(bool dry_run, TRAPS) {
   if (!CRaCCheckpointTo) {
     return ret_cr(JVM_CHECKPOINT_NONE, THREAD);
   }
@@ -6173,7 +6177,7 @@ Handle os::Linux::checkpoint(TRAPS) {
   Universe::heap()->collect(GCCause::_full_gc_alot);
   Universe::heap()->set_cleanup_unused(false);
 
-  VM_Crac cr;
+  VM_Crac cr(dry_run);
   {
     MutexLocker ml(Heap_lock);
     VMThread::execute(&cr);

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -173,7 +173,7 @@ class Linux {
 
   static void vm_create_start();
   static bool prepare_checkpoint();
-  static Handle checkpoint(TRAPS);
+  static Handle checkpoint(bool dry_run, TRAPS);
   static void restore();
   static void register_persistent_fd(int fd, int st_dev, int st_ino);
   static void deregister_persistent_fd(int fd, int st_dev, int st_ino);

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1143,7 +1143,7 @@ enum cr_fail_type {
 };
 
 JNIEXPORT jobjectArray JNICALL
-JVM_Checkpoint(JNIEnv *env);
+JVM_Checkpoint(JNIEnv *env, jboolean dry_run);
 
 JNIEXPORT void JNICALL
 JVM_RegisterPersistent(int fd, int st_dev, int st_ino);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3849,8 +3849,8 @@ JVM_ENTRY_NO_ENV(jint, JVM_FindSignal(const char *name))
   return os::get_signal_number(name);
 JVM_END
 
-JVM_ENTRY(jobjectArray, JVM_Checkpoint(JNIEnv *env))
-  Handle ret = os::Linux::checkpoint(CHECK_NULL);
+JVM_ENTRY(jobjectArray, JVM_Checkpoint(JNIEnv *env, jboolean dry_run))
+  Handle ret = os::Linux::checkpoint(dry_run, CHECK_NULL);
   return (jobjectArray) JNIHandles::make_local(THREAD, ret());
 JVM_END
 

--- a/src/java.base/share/classes/jdk/crac/Core.java
+++ b/src/java.base/share/classes/jdk/crac/Core.java
@@ -46,7 +46,7 @@ public class Core {
     private static final int JVM_CR_FAIL_SOCK = 2;
     private static final int JVM_CR_FAIL_PIPE = 3;
 
-    private static native Object[] checkpointRestore0();
+    private static native Object[] checkpointRestore0(boolean dryRun);
 
     private static boolean traceStartupTime;
     private static final Object checkpointRestoreLock = new Object();
@@ -74,24 +74,24 @@ public class Core {
     }
 
     private static void translateJVMExceptions(int[] codes, String[] messages,
-                                               CheckpointException newException) {
+                                               CheckpointException exception) {
         assert codes.length == messages.length;
         final int length = codes.length;
 
         for (int i = 0; i < length; ++i) {
             switch(codes[i]) {
                 case JVM_CR_FAIL_FILE:
-                    newException.addSuppressed(
+                    exception.addSuppressed(
                             new CheckpointOpenFileException(messages[i]));
                     break;
                 case JVM_CR_FAIL_SOCK:
-                    newException.addSuppressed(
+                    exception.addSuppressed(
                             new CheckpointOpenSocketException(messages[i]));
                     break;
                 case JVM_CR_FAIL_PIPE:
                     // FALLTHROUGH
                 default:
-                    newException.addSuppressed(
+                    exception.addSuppressed(
                             new CheckpointOpenResourceException(messages[i]));
                     break;
             }
@@ -110,26 +110,18 @@ public class Core {
     private static void checkpointRestore1() throws
             CheckpointException,
             RestoreException {
+        CheckpointException checkpointException = null;
+
         try {
             globalContext.beforeCheckpoint(null);
         } catch (CheckpointException ce) {
-            // TODO make dry-run
-            try {
-                globalContext.afterRestore(null);
-            } catch (RestoreException re) {
-                CheckpointException newException = new CheckpointException();
-                for (Throwable t : ce.getSuppressed()) {
-                    newException.addSuppressed(t);
-                }
-                for (Throwable t : re.getSuppressed()) {
-                    newException.addSuppressed(t);
-                }
-                throw newException;
+            checkpointException = new CheckpointException();
+            for (Throwable t : ce.getSuppressed()) {
+                checkpointException.addSuppressed(t);
             }
-            throw ce;
         }
 
-        final Object[] bundle = checkpointRestore0();
+        final Object[] bundle = checkpointRestore0(checkpointException != null);
         final int retCode = (Integer)bundle[0];
         final int[] codes = (int[])bundle[1];
         final String[] messages = (String[])bundle[2];
@@ -139,31 +131,36 @@ public class Core {
         }
 
         if (retCode != JVM_CHECKPOINT_OK) {
-            CheckpointException newException = new CheckpointException();
+            if (checkpointException == null) {
+                checkpointException = new CheckpointException();
+            }
             switch (retCode) {
                 case JVM_CHECKPOINT_ERROR:
-                    translateJVMExceptions(codes, messages, newException);
+                    translateJVMExceptions(codes, messages, checkpointException);
                     break;
                 case JVM_CHECKPOINT_NONE:
-                    newException.addSuppressed(
+                    checkpointException.addSuppressed(
                             new RuntimeException("C/R is not configured"));
                     break;
                 default:
-                    newException.addSuppressed(
+                    checkpointException.addSuppressed(
                             new RuntimeException("Unknown C/R result: " + retCode));
             }
-
-            try {
-                globalContext.afterRestore(null);
-            } catch (RestoreException re) {
-                for (Throwable t : re.getSuppressed()) {
-                    newException.addSuppressed(t);
-                }
-            }
-            throw newException;
         }
 
-        globalContext.afterRestore(null);
+        try {
+            globalContext.afterRestore(null);
+        } catch (RestoreException re) {
+            if (checkpointException == null) {
+                throw re;
+            }
+            for (Throwable t : re.getSuppressed()) {
+                checkpointException.addSuppressed(t);
+            }
+        }
+        if (checkpointException != null) {
+            throw checkpointException;
+        }
     }
 
     /**

--- a/src/java.base/share/native/libjava/CracCore.c
+++ b/src/java.base/share/native/libjava/CracCore.c
@@ -32,12 +32,13 @@
 #include "io_util.h"
 #include "io_util_md.h"
 
+#include "jdk_crac_Core.h"
 #include "jdk_internal_crac_Core.h"
 
 JNIEXPORT jobjectArray JNICALL
-Java_jdk_crac_Core_checkpointRestore0(JNIEnv *env, jclass ignore)
+Java_jdk_crac_Core_checkpointRestore0(JNIEnv *env, jclass ignore, jboolean dry_run)
 {
-    return JVM_Checkpoint(env);
+    return JVM_Checkpoint(env, dry_run);
 }
 
 JNIEXPORT void JNICALL Java_jdk_internal_crac_Core_registerPersistent0

--- a/test/jdk/jdk/crac/DryRunTest.java
+++ b/test/jdk/jdk/crac/DryRunTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.io.FileOutputStream;
+
+import jdk.crac.*;
+
+/**
+ * @test DryRunTest
+ * @run main/othervm -XX:CREngine=simengine -XX:CRaCCheckpointTo=./cr -XX:+CRPrintResourcesOnCheckpoint DryRunTest
+ */
+public class DryRunTest {
+    static class CRResource implements Resource {
+        @Override
+        public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+            throw new RuntimeException("should not pass");
+        }
+
+        @Override
+        public void afterRestore(Context<? extends Resource> context) throws Exception {
+        }
+    }
+
+    static public void main(String[] args) throws Exception {
+        Resource resource = new CRResource();
+        Core.getGlobalContext().register(resource);
+
+        File tempFile = File.createTempFile("jtreg-DryRunTest", null);
+        FileOutputStream stream = new FileOutputStream(tempFile);
+        stream.write('j');
+
+        int exceptions = 0;
+
+        try {
+            Core.checkpointRestore();
+        } catch (CheckpointException ce) {
+
+            ce.printStackTrace();
+
+            for (Throwable e : ce.getSuppressed()) {
+                String name = e.getClass().getName();
+                switch (name) {
+                    case "java.lang.RuntimeException":                exceptions |= 0x1; break;
+                    case "jdk.crac.impl.CheckpointOpenFileException": exceptions |= 0x2; break;
+                }
+            }
+        }
+
+        stream.close();
+        tempFile.delete();
+
+        if (exceptions != 0x3) {
+            throw new RuntimeException("fail " + exceptions);
+        }
+    }
+}


### PR DESCRIPTION
After checkpoint failed at the Java level, it's worth to make a "dry-run" checkpoint at the native state: check file descriptors, process -XX:+CRHeapDumpOnCheckpointException, etc.

The patch also removes unused parameter of `checkpoint_restore(FdsInfo* fds)`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ilarion Nakonechnyy](https://openjdk.java.net/census#inakonechnyy) (@Larry-N - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/crac pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.java.net/crac pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/crac/pull/11.diff">https://git.openjdk.java.net/crac/pull/11.diff</a>

</details>
