### PR TITLE
Get tracing properties lazily

### DIFF
--- a/src/java.base/share/classes/jdk/crac/impl/AbstractContextImpl.java
+++ b/src/java.base/share/classes/jdk/crac/impl/AbstractContextImpl.java
@@ -26,20 +26,17 @@ import jdk.crac.CheckpointException;
 import jdk.crac.Context;
 import jdk.crac.Resource;
 import jdk.crac.RestoreException;
+import sun.security.action.GetBooleanAction;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.*;
 import java.util.stream.Collectors;
 
 public abstract class AbstractContextImpl<R extends Resource, P> extends Context<R> {
-    @SuppressWarnings("removal")
-    private static final boolean DEBUG = AccessController.doPrivileged(
-            new PrivilegedAction<Boolean>() {
-                public Boolean run() {
-                    return Boolean.parseBoolean(
-                            System.getProperty("jdk.crac.debug"));
-                }});
+
+    private static class FlagsHolder {
+        public static final boolean DEBUG =
+            GetBooleanAction.privilegedGetProperty("jdk.crac.debug");
+    }
 
     private WeakHashMap<R, P> checkpointQ = new WeakHashMap<>();
     private List<R> restoreQ = null;
@@ -62,7 +59,7 @@ public abstract class AbstractContextImpl<R extends Resource, P> extends Context
 
         CheckpointException exception = new CheckpointException();
         for (Resource r : resources) {
-            if (DEBUG) {
+            if (FlagsHolder.DEBUG) {
                 System.err.println("jdk.crac beforeCheckpoint " + r.toString());
             }
             try {
@@ -88,7 +85,7 @@ public abstract class AbstractContextImpl<R extends Resource, P> extends Context
     public synchronized void afterRestore(Context<? extends Resource> context) throws RestoreException {
         RestoreException exception = new RestoreException();
         for (Resource r : restoreQ) {
-            if (DEBUG) {
+            if (FlagsHolder.DEBUG) {
                 System.err.println("jdk.crac afterRestore " + r.toString());
             }
             try {

--- a/test/jdk/jdk/crac/LazyProps.java
+++ b/test/jdk/jdk/crac/LazyProps.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.*;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+/**
+ * @test
+ * @library /test/lib
+ * @run main LazyProps
+ */
+public class LazyProps {
+    static public void main(String[] args) throws Exception {
+        if (args.length == 0) {
+            OutputAnalyzer output = ProcessTools.executeTestJvm(
+                    "-XX:CREngine=simengine", "-XX:CRaCCheckpointTo=./cr",
+                    "LazyProps",
+                    "-runTest");
+            output.shouldHaveExitValue(0);
+            output.shouldContain("jdk.crac beforeCheckpoint");
+        } else {
+            Resource resource = new Resource() {
+                @Override
+                public void beforeCheckpoint(Context<? extends Resource> context) throws Exception { }
+                @Override
+                public void afterRestore(Context<? extends Resource> context) throws Exception { }
+            };
+            Core.getGlobalContext().register(resource);
+
+            System.setProperty("jdk.crac.debug", "true");
+            Core.checkpointRestore();
+        }
+    }
+}


### PR DESCRIPTION
A minor change to make tracing flags lazily initialized.

Without this, reading j.l.System's properties during jdk.crac.Core initialization could lead to NPE if happens too early, i.e. before j.l.System's properties are initialized.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Dan Heidinga](https://openjdk.java.net/census#heidinga) (@DanHeidinga - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/crac pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.java.net/crac pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/crac/pull/12.diff">https://git.openjdk.java.net/crac/pull/12.diff</a>

</details>
