### PR TITLE
Ensure empty Reference Handler and Cleaners queues

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -25,6 +25,9 @@
 
 package java.lang.ref;
 
+import jdk.crac.Context;
+import jdk.crac.Resource;
+import jdk.internal.crac.JDKResource;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import jdk.internal.access.JavaLangRefAccess;
@@ -245,6 +248,8 @@ public abstract class Reference<T> {
     private static final Object processPendingLock = new Object();
     private static boolean processPendingActive = false;
 
+    private static JDKResource referenceHandlerResource;
+
     private static void processPendingReferences() {
         // Only the singleton reference processing thread calls
         // waitForReferencePendingList() and getAndClearReferencePendingList().
@@ -327,6 +332,25 @@ public abstract class Reference<T> {
                 Finalizer.runFinalization();
             }
         });
+
+        referenceHandlerResource = new JDKResource() {
+            @Override
+            public Priority getPriority() {
+                return Priority.REFERENCE_HANDLER;
+            }
+
+            @Override
+            public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+                System.gc();
+                // TODO ensure GC done processing all References
+                while (waitForReferenceProcessing());
+            }
+
+            @Override
+            public void afterRestore(Context<? extends Resource> context) throws Exception {
+            }
+        };
+        jdk.internal.crac.Core.getJDKContext().register(referenceHandlerResource);
     }
 
     /* -- Referent accessor and setters -- */

--- a/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
@@ -68,7 +68,21 @@ public interface JDKResource extends Resource {
          * Priority of the
          * sun.security.provider.SecureRandom.SeederHolder resource
          */
-        SEEDER_HOLDER
+        SEEDER_HOLDER,
+
+        /* Keep next priorities last to ensure handling of pending References
+         * appeared on earlier priorities. */
+
+        /**
+         * Priority of the
+         * java.lan.ref.Reference static resource
+         */
+        REFERENCE_HANDLER,
+        /**
+         * Priority of the
+         * jdk.internal.ref.CleanerImpl resources
+         */
+        CLEANERS,
     };
 
     Priority getPriority();

--- a/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
@@ -34,13 +34,16 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+import jdk.crac.Context;
+import jdk.crac.Resource;
+import jdk.internal.crac.JDKResource;
 import jdk.internal.misc.InnocuousThread;
 
 /**
  * CleanerImpl manages a set of object references and corresponding cleaning actions.
  * CleanerImpl provides the functionality of {@link java.lang.ref.Cleaner}.
  */
-public final class CleanerImpl implements Runnable {
+public final class CleanerImpl implements Runnable, JDKResource {
 
     /**
      * An object to access the CleanerImpl from a Cleaner; set by Cleaner init.
@@ -83,6 +86,7 @@ public final class CleanerImpl implements Runnable {
     public CleanerImpl() {
         queue = new ReferenceQueue<>();
         phantomCleanableList = new PhantomCleanableRef();
+        jdk.internal.crac.Core.getJDKContext().register(this);
     }
 
     /**
@@ -146,6 +150,20 @@ public final class CleanerImpl implements Runnable {
                 // (including interruption of cleanup thread)
             }
         }
+    }
+
+    @Override
+    public Priority getPriority() {
+        return Priority.CLEANERS;
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        queue.waitForWaiters(1);
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) throws Exception {
     }
 
     /**

--- a/test/jdk/jdk/crac/RefQueueTest.java
+++ b/test/jdk/jdk/crac/RefQueueTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.*;
+import java.lang.ref.Cleaner;
+
+import jdk.crac.*;
+
+/**
+ * @test
+ * @run main/othervm -XX:CREngine=simengine -XX:CRaCCheckpointTo=./cr RefQueueTest
+ */
+public class RefQueueTest {
+    private static final Cleaner cleaner = Cleaner.create();
+
+    static public void main(String[] args) throws Exception {
+
+        File badFile = File.createTempFile("jtreg-RefQueueTest", null);
+        OutputStream badStream = new FileOutputStream(badFile);
+        badStream.write('j');
+        badFile.delete();
+
+        // the cleaner would be able to run right away
+        cleaner.register(new Object(), () -> {
+            try {
+                badStream.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // should close the file and only then go to the native checkpoint
+        Core.checkpointRestore();
+    }
+}


### PR DESCRIPTION
At the time of checkpoint, a set of References may need handling. This change ensures no References pending in ReferenceHandler and in Cleaners.

System.gc() is a best effort attempt to make GC to look for References. Default VM flags (-DisableExplicitGC, -ExplicitGCInvokesConcurrent) should not block the call, but additional investigation is needed to make sure GC found all references.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Dan Heidinga](https://openjdk.java.net/census#heidinga) (@DanHeidinga - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/crac pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.java.net/crac pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/crac/pull/13.diff">https://git.openjdk.java.net/crac/pull/13.diff</a>

</details>
