### PR TITLE
Fix NPE on ZipFile$Source access

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -801,8 +801,12 @@ public class ZipFile implements ZipConstants, Closeable {
             }
         }
 
-        public Source getSource() {
-            return zsrc;
+        public void beforeCheckpoint() {
+            if (zsrc != null) {
+                synchronized (zsrc) {
+                    zsrc.beforeCheckpoint();
+                }
+            }
         }
     }
 
@@ -1085,17 +1089,7 @@ public class ZipFile implements ZipConstants, Closeable {
     }
 
     private synchronized void beforeCheckpoint() {
-        RandomAccessFile f = res.getSource().getFile();
-        synchronized (f) {
-            FileDescriptor fd = null;
-            try {
-                fd = f.getFD();
-            } catch (IOException e) {
-            }
-            if (fd != null) {
-                Core.registerPersistent(fd);
-            }
-        }
+        res.beforeCheckpoint();
     }
 
     private static boolean isWindows;
@@ -1796,8 +1790,17 @@ public class ZipFile implements ZipConstants, Closeable {
             return count;
         }
 
-        public RandomAccessFile getFile() {
-            return zfile;
+        public void beforeCheckpoint() {
+            synchronized (zfile) {
+                FileDescriptor fd = null;
+                try {
+                    fd = zfile.getFD();
+                } catch (IOException e) {
+                }
+                if (fd != null) {
+                    Core.registerPersistent(fd);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
A race between ZipFile$CleanableResource.run() and ZipFile$Resource.beforeCheckpoint() can lead to NullPointerException when zsrc == null. This is observed on some runs of JavaCompilerCRaC.java from #16. The change aligns beforeCheckpoint() with the run(), providing the zsrc check and the proper locking.

The exception looks like below:
```
java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/jdk.internal.loader.URLClassPath$JarLoader$ClassLoaderJarFile.beforeCheckpoint(URLClassPath.java:837)
	at java.base/jdk.crac.impl.AbstractContextImpl.beforeCheckpoint(AbstractContextImpl.java:66)
	at java.base/jdk.crac.impl.AbstractContextImpl.beforeCheckpoint(AbstractContextImpl.java:66)
	at java.base/jdk.crac.Core.checkpointRestore1(Core.java:108)
	at java.base/jdk.crac.Core.checkpointRestore(Core.java:182)
	at JavaCompilerCRaC.main(JavaCompilerCRaC.java:27)
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.zip.ZipFile$Source.getFile()" because the return value of "java.util.zip.ZipFile$CleanableResource.getSource()" is null
	at java.base/java.util.zip.ZipFile.beforeCheckpoint(ZipFile.java:1088)
	... 10 more
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Dan Heidinga](https://openjdk.java.net/census#heidinga) (@DanHeidinga - Committer) ⚠️ Review applies to d1a74be66f638b59963946a40873343a83845a6a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/crac pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.java.net/crac pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/crac/pull/17.diff">https://git.openjdk.java.net/crac/pull/17.diff</a>

</details>
