### PR TITLE
Disable non-buildable platforms in GHA

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -19,12 +19,12 @@ jobs:
     outputs:
       should_run: ${{ steps.check_submit.outputs.should_run }}
       bundle_id: ${{ steps.check_bundle_id.outputs.bundle_id }}
-      platform_linux_additional: ${{ steps.check_platforms.outputs.platform_linux_additional }}
+      platform_linux_additional: ${{ false && steps.check_platforms.outputs.platform_linux_additional }}
       platform_linux_x64: ${{ steps.check_platforms.outputs.platform_linux_x64 }}
-      platform_linux_x86: ${{ steps.check_platforms.outputs.platform_linux_x86 }}
-      platform_windows_x64: ${{ steps.check_platforms.outputs.platform_windows_x64 }}
-      platform_macos_x64: ${{ steps.check_platforms.outputs.platform_macos_x64 }}
-      platform_macos_aarch64: ${{ steps.check_platforms.outputs.platform_macos_aarch64 }}
+      platform_linux_x86: ${{ false && steps.check_platforms.outputs.platform_linux_x86 }}
+      platform_windows_x64: ${{ false && steps.check_platforms.outputs.platform_windows_x64 }}
+      platform_macos_x64: ${{ false && steps.check_platforms.outputs.platform_macos_x64 }}
+      platform_macos_aarch64: ${{ false && steps.check_platforms.outputs.platform_macos_aarch64 }}
       dependencies: ${{ steps.check_deps.outputs.dependencies }}
 
     steps:


### PR DESCRIPTION
Disable builds on GitHub Actions for platforms that is not expected to build successfully. The change removes GHA failures noise in forks of the project repo. https://github.com/AntonKozlov/crac/actions/runs/2109490740

I've also requested GHA to be enabled to the project repo, so tests report should appear for this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Dan Heidinga](https://openjdk.java.net/census#heidinga) (@DanHeidinga - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/crac pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.java.net/crac pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/crac/pull/20.diff">https://git.openjdk.java.net/crac/pull/20.diff</a>

</details>
