### PR TITLE
Update Reference Handling for CRaC

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -25,9 +25,6 @@
 
 package java.lang.ref;
 
-import jdk.crac.Context;
-import jdk.crac.Resource;
-import jdk.internal.crac.JDKResource;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import jdk.internal.access.JavaLangRefAccess;
@@ -248,8 +245,6 @@ public abstract class Reference<T> {
     private static final Object processPendingLock = new Object();
     private static boolean processPendingActive = false;
 
-    private static JDKResource referenceHandlerResource;
-
     private static void processPendingReferences() {
         // Only the singleton reference processing thread calls
         // waitForReferencePendingList() and getAndClearReferencePendingList().
@@ -331,26 +326,16 @@ public abstract class Reference<T> {
             public void runFinalization() {
                 Finalizer.runFinalization();
             }
+
+            @Override
+            public boolean waitForQueueProcessed(ReferenceQueue<?> queue,
+                                                 int nThreads,
+                                                 long timeout)
+                throws InterruptedException
+            {
+                return queue.waitForQueueProcessed(nThreads, timeout);
+            }
         });
-
-        referenceHandlerResource = new JDKResource() {
-            @Override
-            public Priority getPriority() {
-                return Priority.REFERENCE_HANDLER;
-            }
-
-            @Override
-            public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
-                System.gc();
-                // TODO ensure GC done processing all References
-                while (waitForReferenceProcessing());
-            }
-
-            @Override
-            public void afterRestore(Context<? extends Resource> context) throws Exception {
-            }
-        };
-        jdk.internal.crac.Core.getJDKContext().register(referenceHandlerResource);
     }
 
     /* -- Referent accessor and setters -- */

--- a/src/java.base/share/classes/jdk/crac/Misc.java
+++ b/src/java.base/share/classes/jdk/crac/Misc.java
@@ -7,7 +7,7 @@ import java.lang.ref.ReferenceQueue;
 /**
  * Additional utilities.
  */
-public class Misc {
+public final class Misc {
 
     private Misc() {
     }

--- a/src/java.base/share/classes/jdk/crac/Misc.java
+++ b/src/java.base/share/classes/jdk/crac/Misc.java
@@ -1,0 +1,41 @@
+package jdk.crac;
+
+import jdk.internal.access.SharedSecrets;
+
+import java.lang.ref.ReferenceQueue;
+
+/**
+ * Additional utilities.
+ */
+public class Misc {
+
+    private Misc() {
+    }
+
+    /**
+     * Blocks calling thread until there are no references in the queue and
+     * the specified number of threads are blocked without a reference to
+     * process.
+     * <p>
+     * Note that {@code timeout} specifies the timeout for threads to block,
+     * while the total time of this function to complete may be much larger
+     * that the specified timeout.
+     *
+     * @param queue the queue to wait
+     * @param nThreads number of threads to wait
+     * @param timeout milliseconds to wait for threads to block, if positive,
+     *                wait indefinitely, if zero,
+     *                and, otherwise, just check the condition
+     * @throws InterruptedException If the wait is interrupted
+     * @return true if condition was true during the timeout period,
+     *         otherwise false
+     */
+    public static boolean waitForQueueProcessed(ReferenceQueue<?> queue,
+                                                int nThreads,
+                                                long timeout)
+        throws InterruptedException
+    {
+        return SharedSecrets.getJavaLangRefAccess().
+            waitForQueueProcessed(queue, nThreads, timeout);
+    }
+}

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangRefAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangRefAccess.java
@@ -25,6 +25,8 @@
 
 package jdk.internal.access;
 
+import java.lang.ref.ReferenceQueue;
+
 public interface JavaLangRefAccess {
 
     /**
@@ -43,4 +45,12 @@ public interface JavaLangRefAccess {
      * Invoked by Runtime.runFinalization()
      */
     void runFinalization();
+
+    /**
+     * See {@link jdk.crac.Misc#waitForQueueProcessed(ReferenceQueue, int, long)}.
+     */
+    boolean waitForQueueProcessed(ReferenceQueue<?> queue,
+                                  int nThreads,
+                                  long timeout)
+        throws InterruptedException;
 }

--- a/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
@@ -75,11 +75,6 @@ public interface JDKResource extends Resource {
 
         /**
          * Priority of the
-         * java.lan.ref.Reference static resource
-         */
-        REFERENCE_HANDLER,
-        /**
-         * Priority of the
          * jdk.internal.ref.CleanerImpl resources
          */
         CLEANERS,


### PR DESCRIPTION
This change updates Reference Handling after Alan's comments [1].
* The new API is moved to the CRaC-related classes to avoid polluting or changing standard classes. This should make EA builds more attractive.
* The method for waiting threads now accepts timeout, as turns to be needed by CleanerImpl.beforeCheckpoint().
* Now reference handling outside of the JDK code is supported, see the supplied test update. The handing does not depend on the first-level reference processing thread's beforeCheckpoint is called first. After that, it was possible to remove the resource and the corresponding REFERENCE_HANDLER priority.

The methods for waiting threads cannot guarantee that a reference handling is complete for a particular queue and a set of threads, as nothing prevents an another concurrent thread to change the reachability of a random object that will end up in the queue after the method returns. The method is designed to synchronize reference handling and checkpoint. That is, to ensure that objects that are on the way to be enqueued are indeed enqueued and corresponding clean-up is performed, as demonstrated by the test.

[1] https://github.com/openjdk/crac/pull/13#issuecomment-1028024855

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Dan Heidinga](https://openjdk.org/census#heidinga) (@DanHeidinga - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.org/crac pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/22.diff">https://git.openjdk.org/crac/pull/22.diff</a>

</details>
