### PR TITLE
Fix crash after shm_open failure

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -400,14 +400,12 @@ class VM_Crac: public VM_Operation {
     _dry_run(dry_run),
     _ok(false),
     _failures(new (ResourceObj::C_HEAP, mtInternal) GrowableArray<CracFailDep>(0, mtInternal)),
-    _restore_parameters(NULL)
+    _restore_parameters(new CracRestoreParameters(NULL, NULL))
   { }
 
   ~VM_Crac() {
     delete _failures;
-    if (_restore_parameters) {
-      delete _restore_parameters;
-    }
+    delete _restore_parameters;
   }
 
   GrowableArray<CracFailDep>* failures() { return _failures; }
@@ -6144,6 +6142,7 @@ void VM_Crac::read_shm(int shmid) {
 
     shm_unlink(shmpath);
 
+    delete _restore_parameters;
     _restore_parameters = CracRestoreParameters::read_from(shmfd);
 
     close(shmfd);

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -6142,8 +6142,11 @@ void VM_Crac::read_shm(int shmid) {
 
     shm_unlink(shmpath);
 
-    delete _restore_parameters;
-    _restore_parameters = CracRestoreParameters::read_from(shmfd);
+    CracRestoreParameters* new_parameters = CracRestoreParameters::read_from(shmfd);
+    if (new_parameters) {
+      delete _restore_parameters;
+      _restore_parameters = new_parameters;
+    }
 
     close(shmfd);
     return;


### PR DESCRIPTION
When `_restore_parameters` is not set (e.g. after shm_open failure[0]), VM may crash on NULL dereference [1]. The change makes _restore_parameter always valid.

[0] https://github.com/openjdk/crac/blob/b2783c90a8ad81f6a8564e6cacf97a1ea0190ccd/src/hotspot/os/linux/os_linux.cpp#L6142
[1] https://github.com/openjdk/crac/blob/b2783c90a8ad81f6a8564e6cacf97a1ea0190ccd/src/hotspot/os/linux/os_linux.cpp#L415

```
shm_open: Function not implemented
shm_open (ignoring new args): Function not implemented
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f85bce8ad37, pid=131, tid=146
#
# JRE version: OpenJDK Runtime Environment (17.0) (build 17-internal+0-adhoc..crac)
# Java VM: OpenJDK 64-Bit Server VM (17-internal+0-adhoc..crac, mixed mode, tiered, compressed oops, compressed class ptrs, serial gc, linux-amd64)
# Problematic frame:
# V  [libjvm.so+0xc47d37]  os::Linux::checkpoint(bool, JavaThread*)+0x107
#
# Core dump will be written. Default location: /tmp/core.%e.131
#
# An error report file with more information is saved as:
# /tmp/hs_err_pid131.log
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Dan Heidinga](https://openjdk.java.net/census#heidinga) (@DanHeidinga - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/crac pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.java.net/crac pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/crac/pull/23.diff">https://git.openjdk.java.net/crac/pull/23.diff</a>

</details>
