### PR TITLE
If std descriptor is bound with regular file, redirect it to pseudo terminal before the checkpoint

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -6178,7 +6178,7 @@ void VM_Crac::doit() {
           i, stat2strtype(fds.get_stat(i)->st_mode), details);
     }
 
-    if (i < 3) // close stdin std err if they are "redirected" to file ... 
+    if (i < 3) // close stdin std err if they are "redirected" to file
     {
       if (strcmp("regular", stat2strtype(fds.get_stat(i)->st_mode)) == 0){
         if (CRPrintResourcesOnCheckpoint) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -6182,7 +6182,7 @@ void VM_Crac::doit() {
     {
       if ((strcmp("regular", stat2strtype(fds.get_stat(i)->st_mode))) == 0){
         if (CRPrintResourcesOnCheckpoint) {
-          ostream->print_cr("Closing the redirected std stream ");
+          tty->print_cr("Closing the redirected std stream ");
         }
         close(i);
         continue;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -6180,7 +6180,7 @@ void VM_Crac::doit() {
 
     if (i < 3) // close stdin std err if they are "redirected" to file ... 
     {
-      if ((strcmp("regular", stat2strtype(fds.get_stat(i)->st_mode))) == 0){
+      if (strcmp("regular", stat2strtype(fds.get_stat(i)->st_mode)) == 0){
         if (CRPrintResourcesOnCheckpoint) {
           tty->print_cr("Closing the redirected std stream ");
         }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -6207,14 +6207,14 @@ void VM_Crac::doit() {
     const char* details = 0 < linkret ? detailsbuf : "";
     print_resources("JVM: FD fd=%d type=%s: details1=\"%s\" ",
         i, stat2strtype(fds.get_stat(i)->st_mode), details);
-
-    if (i < 3) // close stdin std err if they are "redirected" to file
+    if (i < 3) // Check if std descriptors binded to file
     {
-      if (strcmp("regular", stat2strtype(fds.get_stat(i)->st_mode)) == 0){
-        if (CRPrintResourcesOnCheckpoint) {
-          tty->print_cr("Closing the redirected std stream ");
-        }
+      if (!S_ISCHR(fds.get_stat(i)->st_mode)){
+        print_resources(" Redirecting std from file to pseudo terminal \n");
+        int fd_tmp=open("/dev/pts/0", O_WRONLY);
         close(i);
+        dup2(fd_tmp, i);
+        close(fd_tmp);
         continue;
       }
     }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -6178,6 +6178,17 @@ void VM_Crac::doit() {
           i, stat2strtype(fds.get_stat(i)->st_mode), details);
     }
 
+    if (i < 3) // close stdin std err if they are "redirected" to file ... 
+    {
+      if ((strcmp("regular", stat2strtype(fds.get_stat(i)->st_mode))) == 0){
+        if (CRPrintResourcesOnCheckpoint) {
+          ostream->print_cr("Closing the redirected std stream ");
+        }
+        close(i);
+        continue;
+      }
+    }
+
     if (_vm_inited_fds.get_state(i, FdsInfo::CLOSED) != FdsInfo::CLOSED) {
       if (CRPrintResourcesOnCheckpoint) {
         tty->print_cr("OK: inherited from process env");


### PR DESCRIPTION
CRIU restore fail after Checkpoint stdout to file.
Redirecting a stdout to the pipeline doesn't break the restore. 

A proposed approach forces the close of stdout, stdin, and stderr file descriptors if they are redirected to the files, on checkpoint resources verification.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.org/crac.git pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/24.diff">https://git.openjdk.org/crac/pull/24.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/24#issuecomment-1158937014)