### PR TITLE
Don't crash the VM if checkpointing fails

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -6247,7 +6247,7 @@ void VM_Crac::doit() {
   int shmid = 0;
   int ret = checkpoint_restore(&shmid);
   if (ret == JVM_CHECKPOINT_ERROR) {
-    PerfMemoryLinux::checkpoint_fail();
+    PerfMemoryLinux::restore();
     return;
   }
 

--- a/src/hotspot/os/linux/perfMemory_linux.hpp
+++ b/src/hotspot/os/linux/perfMemory_linux.hpp
@@ -35,9 +35,7 @@ public:
   }
 
   static bool checkpoint(const char* checkpoint_path);
-  static bool checkpoint_fail();
   static bool restore();
 };
 
 #endif // OS_LINUX_PERFMEMORY_LINUX_HPP
-

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1373,29 +1373,6 @@ bool PerfMemoryLinux::checkpoint(const char* checkpoint_path) {
   return true;
 }
 
-bool PerfMemoryLinux::checkpoint_fail() {
-  if (checkpoint_fd < 0) {
-    return true;
-  }
-
-  int fd;
-  RESTARTABLE(::open(backing_store_file_name, O_RDWR|O_CREAT|O_NOFOLLOW, S_IRUSR|S_IWUSR), fd);
-  if (fd == OS_ERR) {
-    tty->print_cr("cannot open original perfdata file: %s", os::strerror(errno));
-    return false;
-  }
-
-  void* mmapret = ::mmap(PerfMemory::start(), PerfMemory::capacity(),
-      PROT_READ|PROT_WRITE, MAP_FIXED|MAP_SHARED, fd, 0);
-  if (MAP_FAILED == mmapret) {
-    tty->print_cr("cannot mmap old perfdata file: %s", os::strerror(errno));
-    ::close(fd);
-    return false;
-  }
-
-  return true;
-}
-
 bool PerfMemoryLinux::restore() {
   if (checkpoint_fd < 0) {
     return true;


### PR DESCRIPTION
Currently, if checkpointing is failing (because the `criu` executable can't be find or if `criu dump` returns an error) the JVM will crash with:
```
$ java -XX:+CRPrintResourcesOnCheckpoint -XX:CCheckpointTo=/tmp/crac HelloWait
HelloWorld
JVM: FD fd=0 type=character: details1="/dev/pts/9" OK: inherited from process env
JVM: FD fd=1 type=character: details1="/dev/pts/9" OK: inherited from process env
JVM: FD fd=2 type=character: details1="/dev/pts/9" OK: inherited from process env
JVM: FD fd=3 type=regular: details1="/output/crac-dbg/images/jdk/lib/modules" OK: inherited from process env
CR: Checkpoint ...
/output/crac-dbg/images/jdk/lib/criu: unrecognized option '--shell-job'
Try '/output/crac-dbg/images/jdk/lib/criu --help' for more information.
JVM: invalid info for restore provided (may be failed checkpoint)
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGBUS (0x7) at pc=0x00007ffff55de336, pid=11303, tid=11310
#
# JRE version: OpenJDK Runtime Environment (17.0) (slowdebug build 17-internal+0-adhoc.simonisv.crac)
# Java VM: OpenJDK 64-Bit Server VM (slowdebug 17-internal+0-adhoc.simonisv.crac, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# V  [libjvm.so+0x782336]  PerfLongVariant::inc(long)+0x14
#
...
```

The reason for this crash is that in such situations we call `PerfMemoryLinux::checkpoint_fail()` but this method is just recreating and memory mapping an empty perf map file. Subsequent accesses to the perf map data structure will therefor crash the VM.

The fix is trivial. Instead of calling `PerfMemoryLinux::checkpoint_fail()` we can simply call `PerfMemoryLinux::restore()` which correctly restores the perf map data structures. Because `PerfMemoryLinux::checkpoint_fail()` isn't being used in any other place, I've completely removed it with this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.org/crac pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/25.diff">https://git.openjdk.org/crac/pull/25.diff</a>

</details>
