### PR TITLE
Block RESTORE_SIGNAL in all threads

### DIFF
--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -1491,6 +1491,11 @@ static sigset_t* unblocked_signals() {
   return &unblocked_sigs;
 }
 
+static sigset_t* blocked_signals() {
+  assert(signal_sets_initialized, "Not initialized");
+  return &blocked_sigs;
+}
+
 // These are the signals that are blocked while a (non-VM) thread is
 // running Java. Only the VM thread handles these signals.
 static sigset_t* vm_signals() {
@@ -1508,6 +1513,7 @@ void PosixSignals::hotspot_sigmask(Thread* thread) {
   osthread->set_caller_sigmask(caller_sigmask);
 
   pthread_sigmask(SIG_UNBLOCK, unblocked_signals(), NULL);
+  pthread_sigmask(SIG_BLOCK, blocked_signals(), NULL);
 
   if (!ReduceSignalUsage) {
     if (thread->is_VM_thread()) {


### PR DESCRIPTION
The 'crac' branch already introduced a signal set for blocked signals which contains `RESTORE_SIGNAL` (i.e. `SIGRTMIN+2`) but the signalset is currently not used. This PR uses that signalset to block `RESTORE_SIGNAL` in all threads as recommended when using [`sigwaitinfo()`](https://man7.org/linux/man-pages/man2/sigwaitinfo.2.html) to wait for `RESTORE_SIGNAL`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.org/crac pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/27.diff">https://git.openjdk.org/crac/pull/27.diff</a>

</details>
