### PR TITLE
Secret keys zeroisation

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
@@ -39,6 +39,7 @@ import javax.crypto.*;
 import javax.crypto.spec.ChaCha20ParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+
 import sun.security.util.DerValue;
 
 /**
@@ -1069,9 +1070,13 @@ abstract class ChaCha20Cipher extends CipherSpi {
         // Derive the Poly1305 key from the starting state
         byte[] serializedKey = new byte[KEYSTREAM_SIZE];
         chaCha20Block(startState, 0, serializedKey);
-
-        authenticator.engineInit(new SecretKeySpec(serializedKey, 0, 32,
-                authAlgName), null);
+        SecretKeySpec keySpec = new SecretKeySpec(serializedKey, 0, 32,
+                authAlgName);
+        try {
+            authenticator.engineInit(keySpec, null);
+        } finally {
+            keySpec.destroy();
+        }
         aadLen = 0;
         dataLen = 0;
     }

--- a/src/java.base/share/classes/com/sun/crypto/provider/HmacPKCS12PBECore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/HmacPKCS12PBECore.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import javax.crypto.spec.PBEParameterSpec;
+import javax.security.auth.DestroyFailedException;
 import java.security.*;
 import java.security.spec.*;
 
@@ -183,6 +184,14 @@ abstract class HmacPKCS12PBECore extends HmacCore {
             Arrays.fill(passwdChars, '\0');
         }
         SecretKey cipherKey = new SecretKeySpec(derivedKey, "HmacSHA1");
-        super.engineInit(cipherKey, null);
+        try {
+            super.engineInit(cipherKey, null);
+        } finally {
+            try {
+                cipherKey.destroy();
+            } catch (DestroyFailedException dfEx) {
+                throw new InvalidKeyException("Failed to destroy");
+            }
+        }
     }
 }

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBES1Core.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBES1Core.java
@@ -258,8 +258,12 @@ final class PBES1Core {
         IvParameterSpec ivSpec = new IvParameterSpec(derivedKey,
                                                      derivedKey.length-8,
                                                      8);
-        // initialize the underlying cipher
-        cipher.init(opmode, cipherKey, ivSpec, random);
+        try {
+            // initialize the underlying cipher
+            cipher.init(opmode, cipherKey, ivSpec, random);
+        } finally {
+            cipherKey.destroy();
+        }
     }
 
     private byte[] deriveCipherKey(byte[] passwdBytes) {

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBES2Core.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBES2Core.java
@@ -290,8 +290,12 @@ abstract class PBES2Core extends CipherSpi {
         s.clearPassword();
         SecretKeySpec cipherKey = new SecretKeySpec(derivedKey, cipherAlgo);
 
-        // initialize the underlying cipher
-        cipher.init(opmode, cipherKey, ivSpec, random);
+        try {
+            // initialize the underlying cipher
+            cipher.init(opmode, cipherKey, ivSpec, random);
+        } finally {
+            cipherKey.destroy();
+        }
     }
 
     protected void engineInit(int opmode, Key key, AlgorithmParameters params,

--- a/src/java.base/share/classes/com/sun/security/ntlm/NTLM.java
+++ b/src/java.base/share/classes/com/sun/security/ntlm/NTLM.java
@@ -362,7 +362,11 @@ class NTLM {
         try {
             SecretKeySpec skey =
                     new SecretKeySpec(Arrays.copyOf(key, 16), "HmacMD5");
-            hmac.init(skey);
+            try {
+                hmac.init(skey);
+            } finally {
+                skey.destroy();
+            }
             return hmac.doFinal(text);
         } catch (InvalidKeyException ex) {
             assert false;

--- a/src/java.base/share/classes/javax/crypto/spec/SecretKeySpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/SecretKeySpec.java
@@ -61,7 +61,7 @@ public class SecretKeySpec implements KeySpec, SecretKey {
      *
      * @serial
      */
-    private byte[] key;
+    private final byte[] key;
 
     /**
      * The name of the algorithm associated with this key.
@@ -256,4 +256,13 @@ public class SecretKeySpec implements KeySpec, SecretKey {
     void clear() {
         Arrays.fill(key, (byte)0);
     }
-}
+
+    /**
+     * Destroy this {@code Object}.
+     */
+    @Override
+    public void destroy() {
+        clear();
+    }
+
+ }

--- a/src/java.base/share/classes/sun/security/provider/CtrDrbg.java
+++ b/src/java.base/share/classes/sun/security/provider/CtrDrbg.java
@@ -207,7 +207,12 @@ public class CtrDrbg extends AbstractDrbg {
                 // Step 2.1. Increment
                 addOne(v, ctrLen);
                 // Step 2.2. Block_Encrypt
-                cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(k, keyAlg));
+                SecretKeySpec keySpec = new SecretKeySpec(k, keyAlg);
+                try {
+                    cipher.init(Cipher.ENCRYPT_MODE, keySpec);
+                } finally {
+                    keySpec.destroy();
+                }
                 // Step 2.3. Encrypt into right position, no need to cat
                 cipher.doFinal(v, 0, blockLen, temp, i * blockLen);
             }
@@ -326,7 +331,12 @@ public class CtrDrbg extends AbstractDrbg {
 
         for (int i = 0; i * blockLen < seedLen; i++) {
             try {
-                cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(k, keyAlg));
+                SecretKeySpec keySpec = new SecretKeySpec(k, keyAlg);
+                try {
+                    cipher.init(Cipher.ENCRYPT_MODE, keySpec);
+                } finally {
+                    keySpec.destroy();
+                }
                 int tailLen = temp.length - blockLen*i;
                 // 14. requested_bits = leftmost(temp, nuumber_of_bits_to_return)
                 if (tailLen > blockLen) {
@@ -375,7 +385,12 @@ public class CtrDrbg extends AbstractDrbg {
                 break;
             }
             try {
-                cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(k, keyAlg));
+                SecretKeySpec keySpec = new SecretKeySpec(k, keyAlg);
+                try {
+                    cipher.init(Cipher.ENCRYPT_MODE, keySpec);
+                } finally {
+                    keySpec.destroy();
+                }
                 chain = cipher.doFinal(chain);
             } catch (GeneralSecurityException e) {
                 throw new InternalError(e);
@@ -495,7 +510,12 @@ public class CtrDrbg extends AbstractDrbg {
             // Step 4.1. Increment
             addOne(v, ctrLen);
             try {
-                cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(k, keyAlg));
+                SecretKeySpec keySpec = new SecretKeySpec(k, keyAlg);
+                try {
+                    cipher.init(Cipher.ENCRYPT_MODE, keySpec);
+                } finally {
+                    keySpec.destroy();
+                }
                 // Step 4.2. Encrypt
                 // Step 4.3 and 5. Cat bytes and leftmost
                 if (len > blockLen) {


### PR DESCRIPTION
The main idea is to destroy secrets as soon as possible after use. Otherwise, the secret could be checkpointed and restored multiple times on restore. It causes predictable secrets after restore.
* SecretKey implements Destroyable, so destroy() method should be called just after secret is used (it could affect performance)
* In the most cases the jdk.internal.ref.CleanerFactory.java handles secrets end of life and cleans memory. However, it happens on GC only, so it does not guaranty the keys cleaned on checkpoint 

Another alternative/additional solution is to make SecretKey is checkpoint resource and verify it on checkpoint. In case of secret initialized and not yet destroyed - throw CheckpointException or log a warning

Additionaly, TLS SessionCache should be cleaned on checkpoint -> SSLSessionContextImpl should implement Checkpoint Resource and clean sessionCache/sessionHostPortCache on beforeCheckpoint()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.org/crac.git pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/28.diff">https://git.openjdk.org/crac/pull/28.diff</a>

</details>
