### PR TITLE
Add CRAC_CRIU_LEAVE_RUNNING option

### DIFF
--- a/src/java.base/unix/native/criuengine/criuengine.c
+++ b/src/java.base/unix/native/criuengine/criuengine.c
@@ -89,6 +89,7 @@ static int checkpoint(pid_t jvm,
         exit(0);
     }
 
+    char* leave_running = getenv("CRAC_CRIU_LEAVE_RUNNING");
 
     char jvmpidchar[32];
     snprintf(jvmpidchar, sizeof(jvmpidchar), "%d", jvm);
@@ -115,6 +116,9 @@ static int checkpoint(pid_t jvm,
                 fprintf(stderr, "Warning: too many arguments in CRAC_CRIU_OPTS (dropped from '%s')\n", criuopt);
             }
         }
+        if (leave_running) {
+            *arg++ = "-R";
+        }
         *arg++ = NULL;
 
         execv(criu, (char**)args);
@@ -125,6 +129,8 @@ static int checkpoint(pid_t jvm,
     int status;
     if (child != wait(&status) || !WIFEXITED(status) || WEXITSTATUS(status)) {
         kickjvm(jvm, -1);
+    } else if (leave_running) {
+        kickjvm(jvm, 0);
     }
 
     create_cppath(imagedir);

--- a/src/java.base/unix/native/criuengine/criuengine.c
+++ b/src/java.base/unix/native/criuengine/criuengine.c
@@ -105,6 +105,11 @@ static int checkpoint(pid_t jvm,
             "-v4", "-o", "dump4.log", // -D without -W makes criu cd to image dir for logs
         };
         const char** arg = args + 10;
+
+        if (leave_running) {
+            *arg++ = "-R";
+        }
+
         char *criuopts = getenv("CRAC_CRIU_OPTS");
         if (criuopts) {
             char* criuopt = strtok(criuopts, " ");
@@ -115,9 +120,6 @@ static int checkpoint(pid_t jvm,
             if (criuopt) {
                 fprintf(stderr, "Warning: too many arguments in CRAC_CRIU_OPTS (dropped from '%s')\n", criuopt);
             }
-        }
-        if (leave_running) {
-            *arg++ = "-R";
         }
         *arg++ = NULL;
 

--- a/test/jdk/jdk/crac/LeaveRunning.java
+++ b/test/jdk/jdk/crac/LeaveRunning.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.*;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+/**
+ * @test
+ * @library /test/lib
+ * @run main LeaveRunning
+ */
+public class LeaveRunning {
+    private static final String RESTORED_MESSAGE = "Restored";
+
+    static class Test {
+        public static void main(String[] args) throws CheckpointException, RestoreException {
+            Core.checkpointRestore();
+            System.out.println(RESTORED_MESSAGE);
+        }
+    }
+
+    public static void main(String[] args) {
+        OutputAnalyzer output;
+        try {
+            ProcessBuilder pb = ProcessTools.createTestJvm(
+                "-XX:CRaCCheckpointTo=./cr",
+                "LeaveRunning$Test");
+            pb.environment().put("CRAC_CRIU_LEAVE_RUNNING", "");
+            output = ProcessTools.executeProcess(pb);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        output.shouldHaveExitValue(0);
+        output.shouldContain(RESTORED_MESSAGE);
+
+        try {
+            output = ProcessTools.executeTestJvm(
+                "-XX:CRaCRestoreFrom=./cr");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        output.shouldHaveExitValue(0);
+        output.shouldContain(RESTORED_MESSAGE);
+    }
+}


### PR DESCRIPTION
The patch adds an option to the CRaC-CRIU glue code to continue running the original instance after the checkpoint. The central part is adding the right option to the CRIU command line. But after the checkpoint is done by CRIU, it's also necessary to communicate to the JVM that it can continue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac pull/32/head:pull/32` \
`$ git checkout pull/32`

Update a local copy of the PR: \
`$ git checkout pull/32` \
`$ git pull https://git.openjdk.org/crac pull/32/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32`

View PR using the GUI difftool: \
`$ git pr show -t 32`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/32.diff">https://git.openjdk.org/crac/pull/32.diff</a>

</details>
