### PR TITLE
Assume module jars persistent

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -78,6 +78,7 @@ import jdk.internal.crac.Core;
 import jdk.internal.crac.JDKResource;
 import jdk.internal.crac.JDKResource.Priority;
 import jdk.internal.util.jar.InvalidJarIndexError;
+import jdk.internal.util.jar.JarFileCRaCSupport;
 import jdk.internal.util.jar.JarIndex;
 import sun.net.util.URLUtil;
 import sun.net.www.ParseUtil;
@@ -827,15 +828,8 @@ public class URLClassPath {
             @Override
             public void beforeCheckpoint(Context<? extends jdk.crac.Resource> context) {
                 try {
-                    Method zipBeforeCheckpoint = ZipFile.class.getDeclaredMethod("beforeCheckpoint");
-                    @SuppressWarnings("removal")
-                    Void v = AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                        public Void run() {
-                            zipBeforeCheckpoint.setAccessible(true);
-                            return null;
-                        }});
-                    zipBeforeCheckpoint.invoke(this);
-                } catch (Throwable e) {
+                    JarFileCRaCSupport.beforeCheckpoint(this);
+                } catch (ReflectiveOperationException e) {
                     e.printStackTrace();
                 }
             }

--- a/src/java.base/share/classes/jdk/internal/util/jar/JarFileCRaCSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/jar/JarFileCRaCSupport.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.util.jar;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.jar.JarFile;
+import java.util.zip.ZipFile;
+
+public class JarFileCRaCSupport {
+    public static void beforeCheckpoint(JarFile jarFile) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method zipBeforeCheckpoint = ZipFile.class.getDeclaredMethod("beforeCheckpoint");
+        @SuppressWarnings("removal")
+        Void v = AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            public Void run() {
+                zipBeforeCheckpoint.setAccessible(true);
+                return null;
+            }});
+        zipBeforeCheckpoint.invoke(jarFile);
+    }
+}


### PR DESCRIPTION
Jar files opened by URLClassLoaders are assumed persistent. We need to handle module Jars the same way to prevent CheckpointException as reported by [1] 

[1] https://mail.openjdk.org/pipermail/crac-dev/2022-November/000380.html