### PR TITLE
Print peristent JAR assumptions

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/jar/PersistentJarFile.java
+++ b/src/java.base/share/classes/jdk/internal/util/jar/PersistentJarFile.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.util.jar.JarFile;
 
 public class PersistentJarFile extends JarFile implements JDKResource {
+    static final System.Logger logger = System.getLogger("jdk.crac");
 
     public PersistentJarFile(File file, boolean b, int openRead, Runtime.Version runtimeVersion) throws IOException {
         super(file, b, openRead, runtimeVersion);
@@ -44,6 +45,7 @@ public class PersistentJarFile extends JarFile implements JDKResource {
 
     @Override
     public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        logger.log(System.Logger.Level.INFO, "Assuming persistent " + this.getName());
         SharedSecrets.getJavaUtilZipFileAccess().beforeCheckpoint(this);
     }
 

--- a/src/java.base/share/classes/jdk/internal/util/jar/PersistentJarFile.java
+++ b/src/java.base/share/classes/jdk/internal/util/jar/PersistentJarFile.java
@@ -45,7 +45,7 @@ public class PersistentJarFile extends JarFile implements JDKResource {
 
     @Override
     public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
-        logger.log(System.Logger.Level.INFO, "Assuming persistent " + this.getName());
+        logger.log(System.Logger.Level.INFO, this.getName() + " is recorded as always available on restore");
         SharedSecrets.getJavaUtilZipFileAccess().beforeCheckpoint(this);
     }
 


### PR DESCRIPTION
When an application creates URLClassLoader with the JAR, the JAR file will be assumed persistent, that is, it should be available on the restore. To make this more evident, the PR adds reporting for such JARs.

I'm not a big fan of persistent files and the implications, I think it may be done better, but while they are there, better to make them more usable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Dan Heidinga](https://openjdk.org/census#heidinga) (@DanHeidinga - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.org/crac pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/38.diff">https://git.openjdk.org/crac/pull/38.diff</a>

</details>
