### PR TITLE
Fix failures in testsuite

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/jar/PersistentJarFile.java
+++ b/src/java.base/share/classes/jdk/internal/util/jar/PersistentJarFile.java
@@ -36,7 +36,13 @@ import java.io.IOException;
 import java.util.jar.JarFile;
 
 public class PersistentJarFile extends JarFile implements JDKResource {
-    static final System.Logger logger = System.getLogger("jdk.crac");
+    // PersistentJarFile is <clinit>ed when loading classes on the module path;
+    // when initializing the logger an implementation of logging is looked up through
+    // service-loading and that causes a recursion in opening the module.
+    // Therefore, we isolate the logger into a subclass and initialize only when needed.
+    private static class LoggerContainer {
+        private static final System.Logger logger = System.getLogger("jdk.crac");
+    }
 
     public PersistentJarFile(File file, boolean b, int openRead, Runtime.Version runtimeVersion) throws IOException {
         super(file, b, openRead, runtimeVersion);
@@ -45,7 +51,7 @@ public class PersistentJarFile extends JarFile implements JDKResource {
 
     @Override
     public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
-        logger.log(System.Logger.Level.INFO, this.getName() + " is recorded as always available on restore");
+        LoggerContainer.logger.log(System.Logger.Level.INFO, this.getName() + " is recorded as always available on restore");
         SharedSecrets.getJavaUtilZipFileAccess().beforeCheckpoint(this);
     }
 


### PR DESCRIPTION
This PR fixes some failures I've noticed in the pre-submit checks and could also reproduce locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac pull/44/head:pull/44` \
`$ git checkout pull/44`

Update a local copy of the PR: \
`$ git checkout pull/44` \
`$ git pull https://git.openjdk.org/crac pull/44/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 44`

View PR using the GUI difftool: \
`$ git pr show -t 44`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/44.diff">https://git.openjdk.org/crac/pull/44.diff</a>

</details>
