### PR TITLE
Fix failing CRaC tests

### DIFF
--- a/test/jdk/jdk/crac/DryRunTest.java
+++ b/test/jdk/jdk/crac/DryRunTest.java
@@ -28,7 +28,7 @@ import jdk.crac.*;
 
 /**
  * @test DryRunTest
- * @run main/othervm -XX:CREngine=simengine -XX:CRaCCheckpointTo=./cr -XX:+CRPrintResourcesOnCheckpoint DryRunTest
+ * @run main/othervm -XX:CREngine=simengine -XX:CRaCCheckpointTo=./cr -XX:+UnlockDiagnosticVMOptions -XX:+CRPrintResourcesOnCheckpoint DryRunTest
  */
 public class DryRunTest {
     static class CRResource implements Resource {

--- a/test/jdk/jdk/crac/JarFileFactoryCacheTest/JarFileFactoryCacheTest.java
+++ b/test/jdk/jdk/crac/JarFileFactoryCacheTest/JarFileFactoryCacheTest.java
@@ -30,7 +30,7 @@ import java.nio.file.Path;
 /**
  * @test JarFileFactoryCacheTest
  * @library /test/lib
- * @run main/othervm -XX:CREngine=simengine -XX:CRaCCheckpointTo=./cr -XX:+CRPrintResourcesOnCheckpoint JarFileFactoryCacheTest
+ * @run main/othervm -XX:CREngine=simengine -XX:CRaCCheckpointTo=./cr -XX:+UnlockDiagnosticVMOptions -XX:+CRPrintResourcesOnCheckpoint JarFileFactoryCacheTest
  */
 public class JarFileFactoryCacheTest {
     static public void main(String[] args) throws Exception {

--- a/test/jdk/jdk/crac/RefQueueTest.java
+++ b/test/jdk/jdk/crac/RefQueueTest.java
@@ -28,6 +28,8 @@ import jdk.crac.*;
 
 /**
  * @test
+ * The test will inherit FD with asmtools open and checkpoint would complain; as a workaround we'll add this to classpath
+ * @library ${jtreg.home}/lib/asmtools.jar
  * @run main/othervm -XX:CREngine=simengine -XX:CRaCCheckpointTo=./cr RefQueueTest
  */
 public class RefQueueTest {

--- a/test/jdk/jdk/crac/SecureRandom/Test.sh
+++ b/test/jdk/jdk/crac/SecureRandom/Test.sh
@@ -39,7 +39,7 @@ e=$?
 set -e
 [ $e -eq 137 ]
 
-${TESTJAVA}/bin/java -cp ${TESTCLASSPATH} -XX:CRaCRestoreFrom=cr Test $alg 100
+${TESTJAVA}/bin/java -cp ${TESTCLASSPATH} -XX:CRaCRestoreFrom=cr
 
 echo PASSED
 done

--- a/test/jdk/jdk/crac/SecureRandom/Test1.sh
+++ b/test/jdk/jdk/crac/SecureRandom/Test1.sh
@@ -26,7 +26,7 @@
 ## @summary verify that SHA1PRNG secure random is reseeded after restore if
 ##  initialized with default seed
 ## @compile Test1.java
-## @run shell/timeout=60 Test.sh
+## @run shell/timeout=60 Test1.sh
 ##
 
 set -x
@@ -43,10 +43,10 @@ do
 
     [ $e -eq 137 ]
 
-    ${TESTJAVA}/bin/java -cp ${TESTCLASSPATH} -XX:CRaCRestoreFrom=cr Test1 $test
+    ${TESTJAVA}/bin/java -cp ${TESTCLASSPATH} -XX:CRaCRestoreFrom=cr
     e1=$?
 
-    ${TESTJAVA}/bin/java -cp ${TESTCLASSPATH} -XX:CRaCRestoreFrom=cr Test1 $test
+    ${TESTJAVA}/bin/java -cp ${TESTCLASSPATH} -XX:CRaCRestoreFrom=cr
     e2=$?
 
     if [ $test == "0" ]; then

--- a/test/jdk/jdk/crac/Selector/Test970/Test.sh
+++ b/test/jdk/jdk/crac/Selector/Test970/Test.sh
@@ -43,7 +43,7 @@ do
     set -e
     [ $e -eq 137 ]
 
-    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR Test
+    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR
 
     echo "PASSED $test"
 

--- a/test/jdk/jdk/crac/Selector/interruptedSelection/Test.sh
+++ b/test/jdk/jdk/crac/Selector/interruptedSelection/Test.sh
@@ -42,7 +42,7 @@ do
     set -e
     [ $e -eq 137 ]
 
-    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR Test
+    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR
 
     echo "PASSED $test"
 

--- a/test/jdk/jdk/crac/Selector/keyAfterRestore/Test.sh
+++ b/test/jdk/jdk/crac/Selector/keyAfterRestore/Test.sh
@@ -42,7 +42,7 @@ do
     set -e
     [ $e -eq 137 ]
 
-    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR Test
+    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR
 
     echo "PASSED $test"
 

--- a/test/jdk/jdk/crac/Selector/multipleSelect/Test.sh
+++ b/test/jdk/jdk/crac/Selector/multipleSelect/Test.sh
@@ -42,7 +42,7 @@ do
     set -e
     [ $e -eq 137 ]
 
-    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR Test
+    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR
 
     echo "PASSED $test"
 

--- a/test/jdk/jdk/crac/Selector/multipleSelectNow/Test.sh
+++ b/test/jdk/jdk/crac/Selector/multipleSelectNow/Test.sh
@@ -37,7 +37,7 @@ e=$?
 set -e
 [ $e -eq 137 ]
 
-${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=cr Test
+${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=cr
 echo "PASSED 1"
 
 

--- a/test/jdk/jdk/crac/Selector/multipleSelectSingleClose/Test.sh
+++ b/test/jdk/jdk/crac/Selector/multipleSelectSingleClose/Test.sh
@@ -42,7 +42,7 @@ do
     set -e
     [ $e -eq 137 ]
 
-    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR Test
+    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR
 
     echo "PASSED $test"
 

--- a/test/jdk/jdk/crac/Selector/selectAfterWakeup/Test.sh
+++ b/test/jdk/jdk/crac/Selector/selectAfterWakeup/Test.sh
@@ -44,7 +44,7 @@ do
     set -e
     [ $e -eq 137 ]
 
-    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR Test
+    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR
 
     echo "PASSED $test"
 

--- a/test/jdk/jdk/crac/Selector/selectAndWakeupAfterRestore/Test.sh
+++ b/test/jdk/jdk/crac/Selector/selectAndWakeupAfterRestore/Test.sh
@@ -37,6 +37,6 @@ e=$?
 set -e
 [ $e -eq 137 ]
 
-${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=cr Test
+${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=cr
 
 echo PASSED

--- a/test/jdk/jdk/crac/Selector/wakeupAfterRestore/Test.sh
+++ b/test/jdk/jdk/crac/Selector/wakeupAfterRestore/Test.sh
@@ -42,7 +42,7 @@ do
     set -e
     [ $e -eq 137 ]
 
-    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR Test
+    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR
 
     echo "PASSED $test"
 

--- a/test/jdk/jdk/crac/Selector/wakeupByClose/Test.sh
+++ b/test/jdk/jdk/crac/Selector/wakeupByClose/Test.sh
@@ -43,7 +43,7 @@ do
     set -e
     [ $e -eq 137 ]
 
-    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR Test
+    ${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=$IMGDIR
 
     echo "PASSED $test"
 

--- a/test/jdk/jdk/crac/Selector/wakeupByTimeoutAfterRestore/Test.sh
+++ b/test/jdk/jdk/crac/Selector/wakeupByTimeoutAfterRestore/Test.sh
@@ -38,6 +38,6 @@ e=$?
 set -e
 [ $e -eq 137 ]
 
-${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=cr Test
+${TESTJAVA}/bin/java -XX:CRaCRestoreFrom=cr
 
 echo PASSED

--- a/test/jdk/jdk/crac/java/lang/Thread/JoinSleepWaitOnCRPauseTest.java
+++ b/test/jdk/jdk/crac/java/lang/Thread/JoinSleepWaitOnCRPauseTest.java
@@ -189,8 +189,7 @@ public class JoinSleepWaitOnCRPauseTest {
             // falls within this pause period
             Thread.sleep(CRPAUSE_MS);
 
-            pb = ProcessTools.createJavaProcessBuilder(
-                "-XX:CRaCRestoreFrom=" + crImg, "JoinSleepWaitOnCRPauseTest");
+            pb = ProcessTools.createJavaProcessBuilder("-XX:CRaCRestoreFrom=" + crImg);
             out = new OutputAnalyzer(pb.start());
             out.shouldHaveExitValue(0);
 


### PR DESCRIPTION
Before https://github.com/openjdk/crac/pull/16 the arguments for restored process were ignored; tests were written with this in mind and current behaviour breaks them.

In addition I've added missing `-XX:+UnlockDiagnosticVMOptions` flag and fixed the `recursiveCheckpoint` test runner which got stuck as with `pauseengine` the checkpointed process does not terminate.