### PR TITLE
Implement CRaC exit codes

### DIFF
--- a/src/java.base/share/native/launcher/main.c
+++ b/src/java.base/share/native/launcher/main.c
@@ -125,6 +125,17 @@ static int wait_for_children() {
         return WEXITSTATUS(status);
     }
 
+    if (WIFSIGNALED(status)) {
+        // Try to terminate the current process with the same signal
+        // as the child process was terminated
+        const int sig = WTERMSIG(status);
+        signal(sig, SIG_DFL);
+        raise(sig);
+        // Signal was ignored, return 128+n as bash does
+        // see https://linux.die.net/man/1/bash
+        return 128+sig;
+    }
+
     return 1;
 }
 

--- a/src/java.base/unix/native/criuengine/criuengine.c
+++ b/src/java.base/unix/native/criuengine/criuengine.c
@@ -303,6 +303,17 @@ static int restorewait(void) {
         return WEXITSTATUS(status);
     }
 
+    if (WIFSIGNALED(status)) {
+        // Try to terminate the current process with the same signal
+        // as the child process was terminated
+        const int sig = WTERMSIG(status);
+        signal(sig, SIG_DFL);
+        raise(sig);
+        // Signal was ignored, return 128+n as bash does
+        // see https://linux.die.net/man/1/bash
+        return 128+sig;
+    }
+
     return 1;
 }
 


### PR DESCRIPTION
Implement CRaC exit codes in case it catches a signal.

This is a continuation of #46  inspired by [this comment](https://github.com/openjdk/crac/pull/46#discussion_r1122014722)

So, in case the child is terminated by a signal, CRaC should be terminated in similar way too, if possible. Otherwise it returns 128+n exit code as bash does.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/52/head:pull/52` \
`$ git checkout pull/52`

Update a local copy of the PR: \
`$ git checkout pull/52` \
`$ git pull https://git.openjdk.org/crac.git pull/52/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 52`

View PR using the GUI difftool: \
`$ git pr show -t 52`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/52.diff">https://git.openjdk.org/crac/pull/52.diff</a>

</details>
