### PR TITLE
Resize ForkJoinPool and some concurrent data structures

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -593,9 +593,6 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
     static final int RESERVED  = -3; // hash for transient reservations
     static final int HASH_BITS = 0x7fffffff; // usable bits of normal node hash
 
-    /** Number of CPUS, to place bounds on some sizings */
-    static final int NCPU = Runtime.getRuntime().availableProcessors();
-
     /**
      * Serialized pseudo-fields, provided only for jdk7 compatibility.
      * @serialField segments Segment[]
@@ -2423,7 +2420,8 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      */
     private final void transfer(Node<K,V>[] tab, Node<K,V>[] nextTab) {
         int n = tab.length, stride;
-        if ((stride = (NCPU > 1) ? (n >>> 3) / NCPU : n) < MIN_TRANSFER_STRIDE)
+        int ncpu = CpuCount.get();
+        if ((stride = (ncpu > 1) ? (n >>> 3) / ncpu : n) < MIN_TRANSFER_STRIDE)
             stride = MIN_TRANSFER_STRIDE; // subdivide range
         if (nextTab == null) {            // initiating
             try {
@@ -2618,7 +2616,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                     wasUncontended = true;      // Continue after rehash
                 else if (U.compareAndSetLong(c, CELLVALUE, v = c.value, v + x))
                     break;
-                else if (counterCells != cs || n >= NCPU)
+                else if (counterCells != cs || n >= CpuCount.get())
                     collide = false;            // At max size or stale
                 else if (!collide)
                     collide = true;

--- a/src/java.base/share/classes/java/util/concurrent/CpuCount.java
+++ b/src/java.base/share/classes/java/util/concurrent/CpuCount.java
@@ -1,0 +1,42 @@
+package java.util.concurrent;
+
+import jdk.crac.Context;
+import jdk.crac.Resource;
+import jdk.internal.crac.Core;
+import jdk.internal.crac.JDKResource;
+
+final class CpuCount {
+    private static int NCPU = Runtime.getRuntime().availableProcessors();
+    private static final JDKResource RESOURCE = new JDKResource() {
+        @Override
+        public Priority getPriority() {
+            return Priority.NORMAL;
+        }
+
+        @Override
+        public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        }
+
+        @Override
+        public void afterRestore(Context<? extends Resource> context) throws Exception {
+            NCPU = Runtime.getRuntime().availableProcessors();
+        }
+    };
+
+    static {
+        Core.getJDKContext().register(RESOURCE);
+    }
+
+    /**
+     * This method returns the same number as {@link Runtime#availableProcessors()}
+     * but the invocation is cheaper as it does so by accessing a static field caching
+     * the value. Therefore, it is not guaranteed to return the most up-to-date value.
+     *
+     * @return Number of CPUs.
+     */
+    public static int get() {
+        return NCPU;
+    }
+
+    private CpuCount() {}
+}

--- a/test/jdk/jdk/crac/java/util/concurrent/ForkJoinPoolResizeTest.java
+++ b/test/jdk/jdk/crac/java/util/concurrent/ForkJoinPoolResizeTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2022, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.test.lib.containers.docker.Common;
+import jdk.test.lib.containers.docker.DockerTestUtils;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+import jdk.test.lib.process.ProcessTools;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static jdk.test.lib.Asserts.assertEquals;
+
+/**
+ * @test
+ * @library /test/lib
+ * @build ForkJoinPoolResizeTest
+ * @run driver jdk.test.lib.crac.CracTest 1 4
+ * @run driver jdk.test.lib.crac.CracTest 8 16
+ * @run driver jdk.test.lib.crac.CracTest 4 1
+ * @run driver jdk.test.lib.crac.CracTest 16 1
+ * @run driver jdk.test.lib.crac.CracTest 1 1
+ * @run driver jdk.test.lib.crac.CracTest 4 4
+ */
+public class ForkJoinPoolResizeTest implements CracTest {
+    public static final String IMAGE_NAME = Common.imageName("fork-join-pool");
+    public static final long KEEP_ALIVE_TIME = 100; // milliseconds
+    @CracTestArg(0)
+    int initialCpus;
+
+    @CracTestArg(1)
+    int restoreCpus;
+
+    @Override
+    public void test() throws Exception {
+        if (!DockerTestUtils.canTestDocker()) {
+            System.err.println("Docker not available");
+            return;
+        }
+        int cpus = Runtime.getRuntime().availableProcessors();
+        if (initialCpus > cpus || restoreCpus > cpus) {
+            System.err.printf("Ignoring test that requires %d CPUs but we have at most %d%n", Math.max(initialCpus, restoreCpus), cpus);
+            return;
+        }
+        CracBuilder builder = new CracBuilder().inDockerImage(IMAGE_NAME);
+        builder.dockerOptions("--cpus", String.valueOf(initialCpus)).doCheckpoint();
+        builder.recreateContainer(IMAGE_NAME, "--cpus", String.valueOf(restoreCpus));
+        builder.doRestore();
+
+    }
+
+    @Override
+    public void exec() throws Exception {
+        assertEquals(initialCpus, Runtime.getRuntime().availableProcessors());
+        AtomicInteger threadCounter = new AtomicInteger(0);
+        ForkJoinPool fjp = new ForkJoinPool(initialCpus, pool -> {
+            threadCounter.incrementAndGet();
+            return ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
+        }, null, false,
+                initialCpus, 100, 1, null, KEEP_ALIVE_TIME, TimeUnit.MILLISECONDS);
+        assertEquals(0, fjp.getPoolSize());
+        assertEquals(initialCpus, fjp.getParallelism());
+
+        CountDownLatch firstBatchStart = new CountDownLatch(initialCpus);
+        // We use twice as many jobs to make sure not more than expected threads are created
+        CountDownLatch firstBatchEnd = new CountDownLatch(initialCpus * 2);
+        startJobs(fjp, firstBatchStart, firstBatchEnd, initialCpus * 2);
+        firstBatchStart.await();
+        assertEquals(initialCpus, fjp.getActiveThreadCount());
+        firstBatchEnd.await();
+        assertEquals(initialCpus, fjp.getPoolSize());
+
+        // If we wait > initialCpus * keep alive the threads will die
+        Thread.sleep((initialCpus + 1) * KEEP_ALIVE_TIME);
+        assertEquals(0, fjp.getActiveThreadCount());
+        assertEquals(0, fjp.getPoolSize());
+        threadCounter.set(0);
+
+        Core.checkpointRestore();
+        assertEquals(restoreCpus, Runtime.getRuntime().availableProcessors());
+        assertEquals(restoreCpus, fjp.getParallelism());
+
+        CountDownLatch secondBatchStart = new CountDownLatch(restoreCpus);
+        CountDownLatch thirdBatchEnd = new CountDownLatch(restoreCpus);
+        // Scheduling jobs does not immediately start all the threads; we have to wait for them to start
+        startJobs(fjp, secondBatchStart, null, restoreCpus);
+        startJobs(fjp, null, thirdBatchEnd, restoreCpus);
+        secondBatchStart.await();
+
+        assertEquals(restoreCpus, fjp.getPoolSize());
+        // The active thread count is somewhat unreliable
+//        assertEquals(restoreCpus, fjp.getActiveThreadCount());
+        assertEquals(restoreCpus, threadCounter.get());
+
+        thirdBatchEnd.await();
+        // This should let any extra threads die off
+        Thread.sleep((restoreCpus + 1) * KEEP_ALIVE_TIME);
+        assertEquals(0, fjp.getPoolSize());
+        assertEquals(0, fjp.getActiveThreadCount());
+    }
+
+    private static void startJobs(ForkJoinPool fjp, CountDownLatch startLatch, CountDownLatch completeLatch, int count) {
+        for (int i = 0; i < count; ++i) {
+            fjp.execute(() -> {
+                if (startLatch != null) {
+                    startLatch.countDown();
+                }
+                System.out.println(Thread.currentThread().getName() + " " + System.currentTimeMillis() + " START");
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                if (completeLatch != null) {
+                    completeLatch.countDown();
+                }
+                System.out.println(Thread.currentThread().getName() + " " + System.currentTimeMillis() + " COMPLETE ");
+            });
+        }
+    }
+}


### PR DESCRIPTION
Some parts of JDK expect that #cpus is constant; update those places after restore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.org/crac.git pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/54.diff">https://git.openjdk.org/crac/pull/54.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/54#issuecomment-1481491986)