### PR TITLE
Let ReseedTest use stdout rather than exit codes

### DIFF
--- a/test/jdk/jdk/crac/SecureRandom/ReseedTest.java
+++ b/test/jdk/jdk/crac/SecureRandom/ReseedTest.java
@@ -44,8 +44,9 @@ public class ReseedTest implements CracTest {
     public void test() throws Exception {
         CracBuilder builder = new CracBuilder();
         builder.doCheckpoint();
-        int e1 = builder.startRestore().waitFor();
-        int e2 = builder.startRestore().waitFor();
+        builder.captureOutput(true);
+        String e1 = builder.doRestore().outputAnalyzer().getStdout();
+        String e2 = builder.doRestore().outputAnalyzer().getStdout();
         if (reseed) {
             assertEquals(e1, e2);
         } else {
@@ -70,7 +71,6 @@ public class ReseedTest implements CracTest {
             throw new RuntimeException("Restore ERROR " + e);
         }
 
-        int r = sr.nextInt(255);
-        System.exit(r);
+        System.out.println(sr.nextInt());
     }
 }


### PR DESCRIPTION
There was a 1:256 chance of test randomly failing because the random generators produced the same number, despite differently seeded.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.org/crac.git pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/55.diff">https://git.openjdk.org/crac/pull/55.diff</a>

</details>
