### PR TITLE
Harden criuengine cppath reading

### DIFF
--- a/src/java.base/unix/native/criuengine/criuengine.c
+++ b/src/java.base/unix/native/criuengine/criuengine.c
@@ -148,19 +148,28 @@ static int restore(const char *basedir,
         return 1;
     }
 
-    char cppath[PATH_MAX];
-    cppath[0] = '\0';
-    FILE *cppathfile = fopen(cppathpath, "r");
-    if (!cppathfile) {
+    int fd = open(cppathpath, O_RDONLY);
+    if (fd < 0) {
         perror("open cppath");
         return 1;
     }
 
-    if (!fgets(cppath, sizeof(cppath), cppathfile)) {
-        fprintf(stderr, "fgets error\n");
-        return 1;
+    char cppath[PATH_MAX];
+    int cppathlen = 0;
+    int r;
+    while ((r = read(fd, cppath + cppathlen, sizeof(cppath) - cppathlen - 1)) != 0) {
+        if (r < 0 && errno == EINTR) {
+            continue;
+        }
+        if (r < 0) {
+            perror("read cppath");
+            return 1;
+        }
+        cppathlen += r;
     }
-    fclose(cppathfile);
+    cppath[cppathlen] = '\0';
+
+    close(fd);
 
     char *inherit_perfdata = NULL;
     char *perfdatapath;


### PR DESCRIPTION
On some older OSes I see a few `fgets error` coming from criuengine restore function. They are intermittent and hard to debug. After replacing libc fopen/fgets invocations with open/read, the problem went away. I'm still not completely sure why the problem with libc file functions exists but I suspect that EINTR is not correctly handled there, or the fact we store a sequence in characters without `\0` or `\n` in the file we read. So I propose using the lower-level interface to read the file.