### PR TITLE
Support repeated checkpoint and restore operations

### DIFF
--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1209,5 +1209,16 @@ template<typename K> bool primitive_equals(const K& k0, const K& k1) {
   return k0 == k1;
 }
 
+template<ccstr> unsigned primitive_hash(const ccstr& k) {
+  unsigned h = 0;
+  for (ccstr c = k; *c != 0; ++c) {
+    h = 31 * h + (*c & 0xff);
+  }
+  return h;
+}
+
+template<ccstr> bool primitive_equals(const ccstr& k0, const ccstr& k1) {
+  return strcmp(k0, k1) == 0;
+}
 
 #endif // SHARE_UTILITIES_GLOBALDEFINITIONS_HPP

--- a/src/hotspot/share/utilities/hashtable.hpp
+++ b/src/hotspot/share/utilities/hashtable.hpp
@@ -228,6 +228,7 @@ template<
     bool     (*EQUALS)(K const&, K const&) = primitive_equals<K>
     >
 class KVHashtable : public BasicHashtable<F> {
+public:
   class KVHashtableEntry : public BasicHashtableEntry<F> {
   public:
     K _key;
@@ -265,6 +266,17 @@ public:
     for (KVHashtableEntry* e = bucket(index); e != NULL; e = e->next()) {
       if (e->hash() == hash && EQUALS(e->_key, key)) {
         return &(e->_value);
+      }
+    }
+    return NULL;
+  }
+
+  KVHashtableEntry* lookup_entry(K key) const {
+    unsigned int hash = HASH(key);
+    int index = BasicHashtable<F>::hash_to_index(hash);
+    for (KVHashtableEntry* e = bucket(index); e != NULL; e = e->next()) {
+      if (e->hash() == hash && EQUALS(e->_key, key)) {
+        return e;
       }
     }
     return NULL;

--- a/src/java.base/share/classes/jdk/crac/Core.java
+++ b/src/java.base/share/classes/jdk/crac/Core.java
@@ -60,6 +60,7 @@ public class Core {
     private static native Object[] checkpointRestore0(boolean dryRun, long jcmdStream);
     private static final Object checkpointRestoreLock = new Object();
     private static boolean checkpointInProgress = false;
+    private static boolean jsigLoaded;
 
     private static class FlagsHolder {
         public static final boolean TRACE_STARTUP_TIME =
@@ -237,6 +238,12 @@ public class Core {
         // checkpointRestoreLock protects against the simultaneous
         // call of checkpointRestore from different threads.
         synchronized (checkpointRestoreLock) {
+            if (!jsigLoaded) {
+                // Signal handlers chaining is necessary for remapping memory
+                // with repeated checkpoint-restores
+                System.loadLibrary("jsig");
+                jsigLoaded = true;
+            }
             // checkpointInProgress protects against recursive
             // checkpointRestore from resource's
             // beforeCheckpoint/afterRestore methods

--- a/src/java.base/unix/native/criuengine/criuengine.c
+++ b/src/java.base/unix/native/criuengine/criuengine.c
@@ -301,6 +301,10 @@ static int restorewait(void) {
 
     if (WIFEXITED(status)) {
         return WEXITSTATUS(status);
+    } else if (WIFSIGNALED(status)) {
+        return 128 + WTERMSIG(status);
+    } else if (WIFSTOPPED(status)) {
+        return 128 + WSTOPSIG(status);
     }
 
     if (WIFSIGNALED(status)) {

--- a/test/jdk/jdk/crac/RepeatedCheckpointRestoreTest.java
+++ b/test/jdk/jdk/crac/RepeatedCheckpointRestoreTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+
+/**
+ * @test
+ * @library /test/lib
+ * @build RepeatedCheckpointRestoreTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class RepeatedCheckpointRestoreTest implements CracTest {
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder();
+        builder.doCheckpoint();
+        builder.captureOutput(true)
+                .startRestore().waitForCheckpointed()
+                .outputAnalyzer().stdoutShouldContain("First");
+        builder
+                .startRestoreAndCheckpointTo("cr2").waitForCheckpointed()
+                .outputAnalyzer().stdoutShouldContain("Second");
+        builder.imageDir("cr2").doRestore()
+                .outputAnalyzer().stdoutShouldContain("Third");
+        // Let's try to run again last one
+        builder.doRestore().outputAnalyzer().stdoutShouldContain("Third");
+        // Now test in the old directory
+        new CracBuilder().captureOutput(true)
+                .startRestore().waitForCheckpointed()
+                .outputAnalyzer().stdoutShouldContain("Second");
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Core.checkpointRestore();
+        System.out.println("First");
+        Core.checkpointRestore();
+        System.out.println("Second");
+        Core.checkpointRestore();
+        System.out.println("Third");
+    }
+}

--- a/test/lib/jdk/test/lib/crac/CracProcess.java
+++ b/test/lib/jdk/test/lib/crac/CracProcess.java
@@ -18,6 +18,7 @@ public class CracProcess {
     private final Process process;
 
     public CracProcess(CracBuilder builder, List<String> cmd) throws IOException {
+        builder.log(String.join(" ", cmd));
         this.builder = builder;
         ProcessBuilder pb = new ProcessBuilder().inheritIO();
         if (builder.captureOutput) {
@@ -32,13 +33,14 @@ public class CracProcess {
         return process.waitFor();
     }
 
-    public void waitForCheckpointed() throws InterruptedException {
+    public CracProcess waitForCheckpointed() throws InterruptedException {
         if (builder.engine == null || builder.engine == CracEngine.CRIU) {
             assertEquals(137, process.waitFor(), "Checkpointed process was not killed as expected.");
             // TODO: we could check that "CR: Checkpoint" was written out
         } else {
             fail("With engine " + builder.engine.engine + " use the async version.");
         }
+        return this;
     }
 
     public void waitForPausePid() throws IOException, InterruptedException {


### PR DESCRIPTION
* VM option CRaCCheckpointTo is recognized when restoring the application (destination can be changed)
* The main problem for checkpoint after restore was old checkpoint image mmapped to files (CRaC-specific CRIU optimization for faster boot). Before performing checkpoint we transparently swap this with memory using anonymous mapping.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.org/crac.git pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/57.diff">https://git.openjdk.org/crac/pull/57.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/57#issuecomment-1498962564)