### PR TITLE
RCU Lock - RW lock with very lightweight read- and heavyweight write-locking

### DIFF
--- a/make/data/hotspot-symbols/symbols-shared
+++ b/make/data/hotspot-symbols/symbols-shared
@@ -35,3 +35,8 @@ JVM_InitAgentProperties
 JVM_Checkpoint
 JVM_RegisterPersistent
 JVM_DeregisterPersistent
+JVM_ThreadListAllocate
+JVM_ThreadListDestroy
+JVM_ThreadListRemoveSelf
+JVM_ThreadListLength
+JVM_RCU_SynchronizeThreads

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1151,6 +1151,21 @@ JVM_RegisterPersistent(int fd, int st_dev, int st_ino);
 JNIEXPORT void JNICALL
 JVM_DeregisterPersistent(int fd, int st_dev, int st_ino);
 
+JNIEXPORT void* JNICALL
+JVM_ThreadListAllocate();
+
+JNIEXPORT void JNICALL
+JVM_ThreadListDestroy(void *addr);
+
+JNIEXPORT void JNICALL
+JVM_ThreadListRemoveSelf(void *addr);
+
+JNIEXPORT jint JNICALL
+JVM_ThreadListLength(const void *addr);
+
+JNIEXPORT void JNICALL
+JVM_RCU_SynchronizeThreads(void *addr, const char **methods);
+
 #ifdef __cplusplus
 } /* extern "C" */
 

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -110,7 +110,8 @@
   template(GTestExecuteAtSafepoint)               \
   template(JFROldObject)                          \
   template(JvmtiPostObjectFree)                   \
-  template(VM_Crac)
+  template(VM_Crac)                               \
+  template(VM_RCU_Synchronize)
 
 class Thread;
 class outputStream;

--- a/src/java.base/share/classes/jdk/crac/RCULock.java
+++ b/src/java.base/share/classes/jdk/crac/RCULock.java
@@ -1,0 +1,255 @@
+package jdk.crac;
+
+import jdk.internal.ref.CleanerFactory;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.invoke.*;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * This class represents a RW-lock with extremely lightweight read-locking
+ * and heavyweight write locking.
+ * <p>
+ * Readers should use the {@link #readLock()} and {@link #readUnlock()}; when
+ * the writer lock is not locked these are similar to calling no-op methods.
+ * The lock needs a declaration of all read-critical (top-level) methods;
+ * contrary to the regular synchronization pattern we need to
+ * <strong>acquire</strong> the read-lock <strong>inside</strong> the critical
+ * section (at the beginning) and <strong>release</strong> it <strong>outside</strong>,
+ * preferrably in the <code>finally</code> block.
+ * Therefore, the code should be normally separated into wrapper and implementation method:
+ * <hr><blockquote><pre>
+ *   public void wrapper() {
+ *       try {
+ *           implementation();
+ *       } finally {
+ *           lock.readUnlock();
+ *       }
+ *   }
+ *
+ *   &#64;RCULock.Critical
+ *   public void implementation() {
+ *       lock.readLock();
+ *       // critical code ...
+ *   }
+ * </pre></blockquote><hr>
+ * In the example above the {@link RCULock.Critical} annotation would be used
+ * in the {@link #forClasses(Class[])} factory method; alternatively you can
+ * declare the methods (or their signatures) using one of the constructors.
+ * <p>
+ * There should be at most one writer invoking the {@link #synchronizeBegin()}
+ * and {@link #synchronizeEnd()} pair. This operation requires all Java threads
+ * to block in safepoint to inspect their stack; if the stack contains one of
+ * the read-critical methods the thread acquires read-ownership even if
+ * the actual <code>readLock()</code> invocation was a no-op.
+ */
+public class RCULock {
+    private final ReentrantLock lock = new ReentrantLock(true);
+    private final Condition beginCondition = lock.newCondition();
+    private final Condition endCondition = lock.newCondition();
+    private boolean synchronize;
+    @SuppressWarnings("unused") // used in native code
+    private long readerThreadsList;
+    @SuppressWarnings("unused") // used in native code
+    private long readCriticalMethods;
+    private SwitchPoint lockSwitchPoint = new SwitchPoint();
+    private SwitchPoint unlockSwitchPoint = new SwitchPoint();
+    private volatile MethodHandle lockImpl;
+    private volatile MethodHandle unlockImpl;
+
+    static {
+        initFieldOffsets();
+    }
+
+    private static native void initFieldOffsets();
+
+    /**
+     * Inspect the classes for all methods (including private ones) marked with
+     * the {@link RCULock.Critical} annotation and create a lock that can protect
+     * these methods with read lock.
+     *
+     * @param classes List of classes to be inspected.
+     * @return New lock instance.
+     */
+    public static RCULock forClasses(Class<?>... classes) {
+        ArrayList<Method> methods = new ArrayList<>();
+        for (Class<?> cls : classes) {
+            while (cls != null && cls != Object.class) {
+                for (Method m : cls.getDeclaredMethods()) {
+                    if (m.isAnnotationPresent(Critical.class)) {
+                        methods.add(m);
+                    }
+                }
+                cls = cls.getSuperclass();
+            }
+        }
+        return new RCULock(methods);
+    }
+
+    /**
+     * Create a lock that can protect selected methods with read-locking.
+     *
+     * @param readCriticalMethods List of methods with the read-critical section.
+     */
+    public RCULock(Iterable<Method> readCriticalMethods) {
+        this(StreamSupport.stream(readCriticalMethods.spliterator(), false)
+                .map(m -> m.getDeclaringClass().getName() + "." + m.getName() + "(" +
+                Arrays.stream(m.getParameterTypes())
+                        .map(Class::descriptorString).collect(Collectors.joining())
+                + ")" + m.getReturnType().descriptorString()).toArray(String[]::new));
+    }
+
+    /**
+     * Create a lock that can protect selected methods with read-locking.
+     * <p>
+     * The signatures follow the form
+     * <pre>my.package.MyClass.foobar(another/package/SomeClass;Z)V</pre>
+     *
+     * @param readCriticalMethods List of signatures for methods invoked in the read-critical section.
+     */
+    public RCULock(String[] readCriticalMethods) {
+        initSwitchPoints();
+        //noinspection CapturingCleaner
+        CleanerFactory.cleaner().register(this, this::destroy);
+        Arrays.sort(readCriticalMethods);
+        init(readCriticalMethods);
+    }
+
+    private native void init(String[] readCriticalMethods);
+
+    private native void destroy();
+
+    private void initSwitchPoints() {
+        try {
+            MethodType voidType = MethodType.methodType(void.class);
+            MethodHandle noop = MethodHandles.lookup().findSpecial(RCULock.class, "noop", voidType, RCULock.class);
+            MethodHandle readLockImpl = MethodHandles.lookup().findSpecial(RCULock.class, "readLockImpl", voidType, RCULock.class);
+            MethodHandle readUnlockImpl = MethodHandles.lookup().findSpecial(RCULock.class, "readUnlockImpl", voidType, RCULock.class);
+            lockSwitchPoint = new SwitchPoint();
+            lockImpl = lockSwitchPoint.guardWithTest(noop, readLockImpl);
+            unlockSwitchPoint = new SwitchPoint();
+            unlockImpl = lockSwitchPoint.guardWithTest(noop, readUnlockImpl);
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void noop() {
+    }
+
+    /**
+     * Acquire the read-lock. This method <strong>must</strong> be called from
+     * within the read-critical method declared when this lock is created.
+     *
+     * @implNote It is not possible to guarantee that the thread would jump into
+     * the critical section right after <code>readLock()</code> without being spotted
+     * in-between; therefore the implementation works even if <code>readLock()</code>
+     * is called after the synchronizer thread finds it in the critical section.
+     */
+    public void readLock() {
+        try {
+            lockImpl.invokeExact(this);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void readLockImpl() {
+        lock.lock();
+        try {
+            // In case that we have been caught in the critical section
+            // before calling readLock() this thread was added to the list
+            // but won't be removed as we will block.
+            // After continuing in the critical section any subsequent
+            // synchronizeBegin will catch us in again, so we don't need to
+            // do anything.
+            removeThread();
+            // The lock is released as we are waiting for beginCondition
+            while (synchronize) {
+                endCondition.awaitUninterruptibly();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Release the read-lock. This method must be called <strong>outside</strong>
+     * the critical section, preferably in a <code>finally</code> block.
+     */
+    public void readUnlock() {
+        try {
+            unlockImpl.invokeExact(this);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void readUnlockImpl() {
+        lock.lock();
+        try {
+            removeThread();
+            beginCondition.signal();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private native void removeThread();
+
+    /**
+     * Acquire write-lock. It is illegal to call this method concurrently,
+     * if you require to arbitrate the synchronizer thread use an external lock.
+     * The lock should be later released using {@link #synchronizeEnd()}.
+     */
+    public void synchronizeBegin() {
+        lock.lock();
+        if (synchronize) {
+            lock.unlock();
+            throw new IllegalMonitorStateException("Concurrent synchronization or bug?");
+        }
+        synchronize = true;
+        SwitchPoint.invalidateAll(new SwitchPoint[]{ lockSwitchPoint, unlockSwitchPoint });
+        synchronizeThreads();
+        while (hasReaderThreads()) {
+            beginCondition.awaitUninterruptibly();
+        }
+        // No unlocking here
+    }
+
+    public native boolean hasReaderThreads();
+
+    public native void synchronizeThreads();
+
+    /**
+     * Release write-lock. This method can be called only by the thread that previously
+     * successfully called {@link #synchronizeBegin()}.
+     */
+    public void synchronizeEnd() {
+        if (!lock.isHeldByCurrentThread()) {
+            throw new IllegalMonitorStateException("The lock is not held by ");
+        }
+        initSwitchPoints();
+        synchronize = false;
+        endCondition.signalAll();
+        lock.unlock();
+    }
+
+    /**
+     * Marks read-critical methods. This is used in combination with
+     * the {@link #forClasses(Class[])} factory method.
+     */
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Critical {
+    }
+}

--- a/src/java.base/share/classes/jdk/crac/RCULock.java
+++ b/src/java.base/share/classes/jdk/crac/RCULock.java
@@ -242,6 +242,7 @@ public class RCULock {
             // synchronizeBegin will catch us in again, so we don't need to
             // do anything.
             removeThread();
+            beginCondition.signal();
             // The lock is released as we are waiting for beginCondition
             while (synchronize) {
                 endCondition.awaitUninterruptibly();

--- a/src/java.base/share/classes/jdk/crac/RCULock.java
+++ b/src/java.base/share/classes/jdk/crac/RCULock.java
@@ -132,7 +132,7 @@ public class RCULock {
      * <p>
      * The signatures follow the form
      * <pre>my.package.MyClass.foobar(another/package/SomeClass;Z)V</pre>
-     * 
+     *
      * @apiNote This constructor does not use var-args argument to prevent
      * accidentally creating a RCULock without declaring any critical methods.
      *
@@ -164,9 +164,9 @@ public class RCULock {
 
     /**
      * Add read-critical methods.
-     * 
+     *
      * @param methods List of read-critical methods.
-     *                
+     *
      * @see RCULock#RCULock(Iterable)
      */
     public void amendCriticalMethods(Iterable<Method> methods) {
@@ -176,9 +176,9 @@ public class RCULock {
 
     /**
      * Add read-critical methods using signatures.
-     * 
+     *
      * @param methods List of method signatures.
-     *                
+     *
      * @see RCULock#RCULock(String[])
      */
     public void amendCriticalMethods(String... methods) {

--- a/src/java.base/share/classes/jdk/crac/RCULock.java
+++ b/src/java.base/share/classes/jdk/crac/RCULock.java
@@ -6,7 +6,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.invoke.*;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -15,12 +14,11 @@ import java.util.List;
 import java.util.TreeSet;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 /**
- * This class represents a RW-lock with extremely lightweight read-locking
+ * This class represents a non-reentrant RW-lock with extremely lightweight read-locking
  * and heavyweight write locking.
  * <p>
  * Readers should use the {@link #readLock()} and {@link #readUnlock()}; when
@@ -60,16 +58,12 @@ public class RCULock {
     private final ReentrantLock lock = new ReentrantLock(true);
     private final Condition beginCondition = lock.newCondition();
     private final Condition endCondition = lock.newCondition();
-    private boolean synchronize;
+    private volatile boolean synchronize;
     @SuppressWarnings("unused") // used in native code
     private long readerThreadsList;
     @SuppressWarnings("unused") // used in native code
     private long readCriticalMethods;
     private final TreeSet<String> methodsCopy;
-    private SwitchPoint lockSwitchPoint = new SwitchPoint();
-    private SwitchPoint unlockSwitchPoint = new SwitchPoint();
-    private volatile MethodHandle lockImpl;
-    private volatile MethodHandle unlockImpl;
 
     static {
         try {
@@ -139,7 +133,6 @@ public class RCULock {
      * @param readCriticalMethods List of signatures for methods invoked in the read-critical section.
      */
     public RCULock(String[] readCriticalMethods) {
-        initSwitchPoints();
         methodsCopy = new TreeSet<>(Arrays.asList(readCriticalMethods));
         //noinspection CapturingCleaner
         CleanerFactory.cleaner().register(this, this::destroy);
@@ -196,25 +189,6 @@ public class RCULock {
 
     private native void updateMethods(String[] methods);
 
-    private void initSwitchPoints() {
-        try {
-            MethodType voidType = MethodType.methodType(void.class);
-            MethodHandles.Lookup lookup = MethodHandles.lookup();
-            MethodHandle noop = lookup.findSpecial(RCULock.class, "noop", voidType, RCULock.class);
-            MethodHandle readLockImpl = lookup.findSpecial(RCULock.class, "readLockImpl", voidType, RCULock.class);
-            MethodHandle readUnlockImpl = lookup.findSpecial(RCULock.class, "readUnlockImpl", voidType, RCULock.class);
-            lockSwitchPoint = new SwitchPoint();
-            lockImpl = lockSwitchPoint.guardWithTest(noop, readLockImpl);
-            unlockSwitchPoint = new SwitchPoint();
-            unlockImpl = lockSwitchPoint.guardWithTest(noop, readUnlockImpl);
-        } catch (NoSuchMethodException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private void noop() {
-    }
-
     /**
      * Acquire the read-lock. This method <strong>must</strong> be called from
      * within the read-critical method declared when this lock is created.
@@ -226,29 +200,27 @@ public class RCULock {
      */
     public void readLock() {
         try {
-            lockImpl.invokeExact(this);
+            if (synchronize) {
+                lock.lock();
+                try {
+                    // In case that we have been caught in the critical section
+                    // before calling readLock() this thread was added to the list
+                    // but won't be removed as we will block.
+                    // After continuing in the critical section any subsequent
+                    // synchronizeBegin will catch us in again, so we don't need to
+                    // do anything.
+                    removeThread();
+                    beginCondition.signal();
+                    // The lock is released as we are waiting for beginCondition
+                    while (synchronize) {
+                        endCondition.awaitUninterruptibly();
+                    }
+                } finally {
+                    lock.unlock();
+                }
+            }
         } catch (Throwable e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    private void readLockImpl() {
-        lock.lock();
-        try {
-            // In case that we have been caught in the critical section
-            // before calling readLock() this thread was added to the list
-            // but won't be removed as we will block.
-            // After continuing in the critical section any subsequent
-            // synchronizeBegin will catch us in again, so we don't need to
-            // do anything.
-            removeThread();
-            beginCondition.signal();
-            // The lock is released as we are waiting for beginCondition
-            while (synchronize) {
-                endCondition.awaitUninterruptibly();
-            }
-        } finally {
-            lock.unlock();
         }
     }
 
@@ -258,19 +230,17 @@ public class RCULock {
      */
     public void readUnlock() {
         try {
-            unlockImpl.invokeExact(this);
+            if (synchronize) {
+                lock.lock();
+                try {
+                    removeThread();
+                    beginCondition.signal();
+                } finally {
+                    lock.unlock();
+                }
+            }
         } catch (Throwable e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    private void readUnlockImpl() {
-        lock.lock();
-        try {
-            removeThread();
-            beginCondition.signal();
-        } finally {
-            lock.unlock();
         }
     }
 
@@ -288,7 +258,6 @@ public class RCULock {
             throw new IllegalMonitorStateException("Concurrent synchronization or bug?");
         }
         synchronize = true;
-        SwitchPoint.invalidateAll(new SwitchPoint[]{ lockSwitchPoint, unlockSwitchPoint });
         synchronizeThreads();
         while (hasReaderThreads()) {
             beginCondition.awaitUninterruptibly();
@@ -308,7 +277,6 @@ public class RCULock {
         if (!lock.isHeldByCurrentThread()) {
             throw new IllegalMonitorStateException("The lock is not held by ");
         }
-        initSwitchPoints();
         synchronize = false;
         endCondition.signalAll();
         lock.unlock();

--- a/src/java.base/share/classes/jdk/crac/RCULock.java
+++ b/src/java.base/share/classes/jdk/crac/RCULock.java
@@ -131,9 +131,10 @@ public class RCULock {
     private void initSwitchPoints() {
         try {
             MethodType voidType = MethodType.methodType(void.class);
-            MethodHandle noop = MethodHandles.lookup().findSpecial(RCULock.class, "noop", voidType, RCULock.class);
-            MethodHandle readLockImpl = MethodHandles.lookup().findSpecial(RCULock.class, "readLockImpl", voidType, RCULock.class);
-            MethodHandle readUnlockImpl = MethodHandles.lookup().findSpecial(RCULock.class, "readUnlockImpl", voidType, RCULock.class);
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            MethodHandle noop = lookup.findSpecial(RCULock.class, "noop", voidType, RCULock.class);
+            MethodHandle readLockImpl = lookup.findSpecial(RCULock.class, "readLockImpl", voidType, RCULock.class);
+            MethodHandle readUnlockImpl = lookup.findSpecial(RCULock.class, "readUnlockImpl", voidType, RCULock.class);
             lockSwitchPoint = new SwitchPoint();
             lockImpl = lockSwitchPoint.guardWithTest(noop, readLockImpl);
             unlockSwitchPoint = new SwitchPoint();

--- a/src/java.base/share/native/libjava/RCULock.c
+++ b/src/java.base/share/native/libjava/RCULock.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/** \file */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "jni.h"
+#include "jvm.h"
+#include "jni_util.h"
+#include "jdk_crac_RCULock.h"
+
+static jfieldID readerThreadsListField = NULL;
+static jfieldID readCriticalMethodsField = NULL;
+
+JNIEXPORT void JNICALL
+Java_jdk_crac_RCULock_initFieldOffsets(JNIEnv *env, jclass cls)
+{
+    readerThreadsListField = (*env)->GetFieldID(env, cls, "readerThreadsList", "J");
+    readCriticalMethodsField = (*env)->GetFieldID(env, cls, "readCriticalMethods", "J");
+}
+
+static void free_up_to(char **mem, uint limit) {
+    for (uint i = 0; i < limit; ++i) {
+        free(*(mem + i));
+    }
+    free(mem);
+}
+
+JNIEXPORT void JNICALL
+Java_jdk_crac_RCULock_init(JNIEnv *env, jobject rcuLock, jobjectArray methods)
+{
+    void *threads = JVM_ThreadListAllocate();
+    if (threads == NULL) {
+        JNU_ThrowOutOfMemoryError(env, NULL);
+        return;
+    }
+    (*env)->SetLongField(env, rcuLock, readerThreadsListField, (jlong) threads);
+
+    jsize num = (*env)->GetArrayLength(env, methods);
+    char **c_methods = malloc(sizeof(char *) * (num + 1));
+    if (c_methods == NULL) {
+        JNU_ThrowOutOfMemoryError(env, NULL);
+        return;
+    }
+    for (int i = 0; i < num; ++i) {
+        jobject el = (*env)->GetObjectArrayElement(env, methods, i);
+        if (el == NULL) {
+            free_up_to(c_methods, i);
+            JNU_ThrowNullPointerException(env, "null signature");
+            return;
+        }
+        jsize len = (*env)->GetStringLength(env, el);
+        const char *sig = (*env)->GetStringUTFChars(env, el, NULL);
+        if (sig == NULL) {
+            free_up_to(c_methods, i);
+            JNU_ThrowNullPointerException(env, "null signature");
+            return;
+        }
+        char *copy = malloc((len + 1) * sizeof(char));
+        if (copy == NULL) {
+            (*env)->ReleaseStringUTFChars(env, el, sig);
+            free_up_to(c_methods, i);
+            JNU_ThrowOutOfMemoryError(env, NULL);
+            return;
+        }
+        strncpy(copy, sig, len + 1);
+        (*env)->ReleaseStringUTFChars(env, el, sig);
+        c_methods[i] = copy;
+    }
+    c_methods[num] = NULL;
+#ifndef PROD
+    // TODO: assert methods are sorted - note that we should mind UTF-8 format
+#endif // !PROD
+    (*env)->SetLongField(env, rcuLock, readCriticalMethodsField, (jlong) (void *) c_methods);
+}
+
+JNIEXPORT void JNICALL
+Java_jdk_crac_RCULock_destroy(JNIEnv *env, jobject rcuLock)
+{
+    jlong threads = (*env)->GetLongField(env, rcuLock, readerThreadsListField);
+    if (threads != 0) {
+        JVM_ThreadListDestroy((void *) threads);
+        (*env)->SetLongField(env, rcuLock, readerThreadsListField, 0);
+    }
+
+    jlong methods = (*env)->GetLongField(env, rcuLock, readCriticalMethodsField);
+    if (methods != 0) {
+        char **m = (char **) (void *) methods;
+        while (*m != NULL) {
+            free(*m);
+            ++m;
+        }
+        free(m);
+        (*env)->SetLongField(env, rcuLock, readCriticalMethodsField, 0);
+    }
+}
+
+JNIEXPORT void JNICALL
+Java_jdk_crac_RCULock_removeThread(JNIEnv *env, jobject rcuLock)
+{
+    jlong addr = (*env)->GetLongField(env, rcuLock, readerThreadsListField);
+    if (addr != 0) {
+        JVM_ThreadListRemoveSelf((void *) addr);
+    }
+}
+
+JNIEXPORT jboolean JNICALL
+Java_jdk_crac_RCULock_hasReaderThreads(JNIEnv *env, jobject rcuLock)
+{
+    jlong addr = (*env)->GetLongField(env, rcuLock, readerThreadsListField);
+    if (addr != 0) {
+        return JVM_ThreadListLength((void *) addr) != 0;
+    } else {
+        return 0;
+    }
+}
+
+JNIEXPORT void JNICALL
+Java_jdk_crac_RCULock_synchronizeThreads(JNIEnv *env, jobject rcuLock)
+{
+    jlong threads = (*env)->GetLongField(env, rcuLock, readerThreadsListField);
+    jlong methods = (*env)->GetLongField(env, rcuLock, readCriticalMethodsField);
+    JVM_RCU_SynchronizeThreads((void *) threads, (const char **) (void *) methods);
+}

--- a/test/jdk/jdk/crac/RCULockTest.java
+++ b/test/jdk/jdk/crac/RCULockTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.RCULock;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static jdk.test.lib.Asserts.*;
+
+/**
+ * @test
+ * @library /test/lib
+ * @run main/timeout=20 RCULockTest
+ */
+public class RCULockTest {
+    public static final int NUM_READERS = 50;
+    private final RCULock lock = RCULock.forClasses(RCULockTest.class);
+    private final AtomicBoolean stop = new AtomicBoolean();
+    private final AtomicInteger readersIn = new AtomicInteger();
+    private final AtomicReference<Throwable> exception = new AtomicReference<>();
+    private final CountDownLatch exLatch = new CountDownLatch(1);
+    private final CyclicBarrier completion = new CyclicBarrier(2 + NUM_READERS);
+
+    public static void main(String[] args) throws Exception {
+        new RCULockTest().run();
+    }
+
+    private void run() throws Exception {
+        new Thread(this::synchronizer, "synchronizer").start();
+        for (int i = 0; i < NUM_READERS; ++i) {
+            new Thread(this::reader, "reader-" + i).start();
+        }
+        exLatch.await(10, TimeUnit.SECONDS);
+        Throwable ex = exception.get();
+        if (ex != null) {
+            throw new AssertionError(ex);
+        }
+        stop.set(true);
+        completion.await(10, TimeUnit.SECONDS);
+    }
+
+    private void reader() {
+        try {
+            while (!stop.get()) {
+                try {
+                    readerCritical();
+                } finally {
+                    lock.readUnlock();
+                }
+                Thread.sleep(1);
+            }
+            completion.await();
+        } catch (Throwable t) {
+            t.printStackTrace();
+            exception.set(t);
+            exLatch.countDown();
+        }
+    }
+
+    @RCULock.Critical
+    private void readerCritical() throws InterruptedException {
+        lock.readLock();
+        readersIn.incrementAndGet();
+        Thread.sleep(ThreadLocalRandom.current().nextInt(10));
+        readersIn.decrementAndGet();
+    }
+
+    private void synchronizer() {
+        try {
+            while (!stop.get()) {
+                lock.synchronizeBegin();
+                try {
+                    assertEquals(0, readersIn.get());
+                    Thread.sleep(ThreadLocalRandom.current().nextInt(10));
+                    assertEquals(0, readersIn.get());
+                } finally {
+                    lock.synchronizeEnd();
+                }
+                Thread.sleep(ThreadLocalRandom.current().nextInt(10));
+            }
+            completion.await();
+        } catch (Throwable t) {
+            t.printStackTrace();
+            exception.set(t);
+            exLatch.countDown();
+        }
+    }
+}

--- a/test/jdk/jdk/crac/RCULockTest.java
+++ b/test/jdk/jdk/crac/RCULockTest.java
@@ -51,6 +51,8 @@ public class RCULockTest {
     }
 
     private void run() throws Exception {
+        // just add some other methods to test that code path
+        lock.amendCriticalMethods("foo.Bar(I)I");
         new Thread(this::synchronizer, "synchronizer").start();
         for (int i = 0; i < NUM_READERS; ++i) {
             new Thread(this::reader, "reader-" + i).start();


### PR DESCRIPTION
This implementation is suitable for uses where the write-locking happens very rarely (if at all), as in the case of CRaC checkpoint, and we don't want to slow down regular access to the protected resource.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.org/crac.git pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/58.diff">https://git.openjdk.org/crac/pull/58.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/58#issuecomment-1504938895)