### PR TITLE
Improve modules handling in initial FD bookkeeping

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -25,6 +25,7 @@
 
 // no precompiled headers
 #include "jvm.h"
+#include "classfile/classLoader.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "code/icBuffer.hpp"
 #include "code/vtableStubs.hpp"
@@ -6460,12 +6461,6 @@ void os::Linux::restore() {
 static char modules_path[JVM_MAXPATHLEN] = { '\0' };
 
 static bool is_fd_ignored(int fd, const char *path) {
-  if (!strcmp(modules_path, path)) {
-    // Path to the modules directory is opened early when JVM is booted up and won't be closed.
-    // We can ignore this for purposes of CRaC.
-    return true;
-  }
-
   const char *list = CRaCIgnoredFileDescriptors;
   while (list && *list) {
     const char *end = strchr(list, ',');
@@ -6492,6 +6487,13 @@ static bool is_fd_ignored(int fd, const char *path) {
       break;
     }
   }
+
+  if (os::same_files(modules_path, path)) {
+    // Path to the modules directory is opened early when JVM is booted up and won't be closed.
+    // We can ignore this for purposes of CRaC.
+    return true;
+  }
+
   return false;
 }
 
@@ -6500,7 +6502,7 @@ void os::Linux::close_extra_descriptors() {
   // We can ignore this for purposes of CRaC.
   if (modules_path[0] == '\0') {
     const char* fileSep = os::file_separator();
-    jio_snprintf(modules_path, JVM_MAXPATHLEN, "%s%slib%smodules", Arguments::get_java_home(), fileSep, fileSep);
+    jio_snprintf(modules_path, JVM_MAXPATHLEN, "%s%slib%s" MODULES_IMAGE_NAME, Arguments::get_java_home(), fileSep, fileSep);
   }
 
   char path[PATH_MAX];
@@ -6512,7 +6514,7 @@ void os::Linux::close_extra_descriptors() {
     if (fd > 2 && fd != dirfd(dir)) {
       int r = readfdlink(fd, path, sizeof(path));
       if (!is_fd_ignored(fd, r != -1 ? path : nullptr)) {
-        log_warning(os)("CRaC closing file descriptor %d: %s\n", fd, path);
+        log_warning(os)("CRaC closing file descriptor %d: %s", fd, path);
         close(fd);
       }
     }


### PR DESCRIPTION
Replace paths comparision with `os::same_file` which compares paths first, then compares st_{ino,dev}. This makes the check a bit more robust and fixes CRaC example-lambda [1]

Also, an annoying empty line is fixed in the warning, now that looks like:
```
anton@mercury:~/proj/crac$ ./jdk/bin/java -XX:CRaCCheckpointTo=./cr -version
[0.001s][warning][os] CRaC closing file descriptor 31: /dev/ptmx
openjdk version "17-internal" 2021-09-14
OpenJDK Runtime Environment (build 17-internal+0-adhoc..crac)
OpenJDK 64-Bit Server VM (build 17-internal+0-adhoc..crac, mixed mode)
```

[1] https://github.com/CRaC/example-lambda

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * @rvansa (no known openjdk.org user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/59/head:pull/59` \
`$ git checkout pull/59`

Update a local copy of the PR: \
`$ git checkout pull/59` \
`$ git pull https://git.openjdk.org/crac.git pull/59/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 59`

View PR using the GUI difftool: \
`$ git pr show -t 59`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/59.diff">https://git.openjdk.org/crac/pull/59.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/59#issuecomment-1516593078)