### PR TITLE
Register CallSite cleaners with higher priority

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -27,10 +27,13 @@ package java.lang.invoke;
 
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.crac.JDKResource;
 import jdk.internal.ref.CleanerFactory;
+import jdk.internal.ref.CleanerImpl;
 import sun.invoke.util.Wrapper;
 
 import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.ref.Cleaner;
 import java.lang.reflect.Field;
 
 import static java.lang.invoke.MethodHandleNatives.Constants.*;
@@ -87,7 +90,8 @@ class MethodHandleNatives {
             // become unreachable, its Context is retained by the Cleanable instance
             // (which is referenced from Cleaner instance which is referenced from
             // CleanerFactory class) until cleanup is performed.
-            CleanerFactory.cleaner().register(cs, newContext);
+            new CleanerImpl.PhantomCleanableRef(cs, CleanerFactory.cleaner(),
+                    newContext, JDKResource.Priority.CALL_SITES);
             return newContext;
         }
 

--- a/src/java.base/share/classes/java/lang/ref/Cleaner.java
+++ b/src/java.base/share/classes/java/lang/ref/Cleaner.java
@@ -25,6 +25,7 @@
 
 package java.lang.ref;
 
+import jdk.internal.crac.JDKResource;
 import jdk.internal.ref.CleanerImpl;
 
 import java.util.Objects;
@@ -217,7 +218,7 @@ public final class Cleaner {
     public Cleanable register(Object obj, Runnable action) {
         Objects.requireNonNull(obj, "obj");
         Objects.requireNonNull(action, "action");
-        return new CleanerImpl.PhantomCleanableRef(obj, this, action);
+        return new CleanerImpl.PhantomCleanableRef(obj, this, action, JDKResource.Priority.CLEANERS);
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
@@ -86,6 +86,14 @@ public interface JDKResource extends Resource {
 
         PRE_FILE_DESRIPTORS,
         FILE_DESCRIPTORS,
+
+        /**
+         * Cleaners for CallSites cannot be registered with regular CLEANERS
+         * priority as this would hang/throw exceptions any time a lambda
+         * or method reference is used during or after processing this resource
+         * priority class; therefore we postpone as the last priority.
+         */
+        CALL_SITES,
     };
 
     Priority getPriority();

--- a/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
@@ -157,16 +157,19 @@ public final class CleanerImpl implements Runnable {
      */
     public static final class PhantomCleanableRef extends PhantomCleanable<Object> implements JDKResource {
         private final Runnable action;
+        private final JDKResource.Priority priority;
 
         /**
          * Constructor for a phantom cleanable reference.
          * @param obj the object to monitor
          * @param cleaner the cleaner
          * @param action the action Runnable
+         * @param priority priority for checkpoint handling
          */
-        public PhantomCleanableRef(Object obj, Cleaner cleaner, Runnable action) {
+        public PhantomCleanableRef(Object obj, Cleaner cleaner, Runnable action, JDKResource.Priority priority) {
             super(obj, cleaner);
             this.action = action;
+            this.priority = priority;
             jdk.internal.crac.Core.getJDKContext().register(this);
         }
 
@@ -176,6 +179,7 @@ public final class CleanerImpl implements Runnable {
         PhantomCleanableRef() {
             super();
             this.action = null;
+            this.priority = Priority.CLEANERS;
         }
 
         @Override
@@ -205,7 +209,7 @@ public final class CleanerImpl implements Runnable {
 
         @Override
         public Priority getPriority() {
-            return Priority.CLEANERS;
+            return priority;
         }
 
         @Override


### PR DESCRIPTION
Cleaners for CallSites cannot be registered with regular CLEANERS priority as this would hang/throw exceptions any time a lambda or method reference is used during or after processing this resource priority class; therefore we postpone as the last priority.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.org/crac.git pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/66.diff">https://git.openjdk.org/crac/pull/66.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/66#issuecomment-1545561779)