### PR TITLE
Log restore finish time

### DIFF
--- a/make/data/hotspot-symbols/symbols-shared
+++ b/make/data/hotspot-symbols/symbols-shared
@@ -33,3 +33,4 @@ JNI_GetDefaultJavaVMInitArgs
 JVM_FindClassFromBootLoader
 JVM_InitAgentProperties
 JVM_Checkpoint
+JVM_RestoreStartTime

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1145,6 +1145,9 @@ enum cr_fail_type {
 JNIEXPORT jobjectArray JNICALL
 JVM_Checkpoint(JNIEnv *env, jarray fd_arr, jobjectArray obj_arr, jboolean dry_run, jlong jcmd_stream);
 
+JNIEXPORT jlong JNICALL
+JVM_RestoreStartTime();
+
 #ifdef __cplusplus
 } /* extern "C" */
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3853,3 +3853,7 @@ JVM_ENTRY(jobjectArray, JVM_Checkpoint(JNIEnv *env, jarray fd_arr, jobjectArray 
   Handle ret = os::Linux::checkpoint(fd_arr, obj_arr, dry_run, jcmd_stream, CHECK_NULL);
   return (jobjectArray) JNIHandles::make_local(THREAD, ret());
 JVM_END
+
+JVM_LEAF(jlong, JVM_RestoreStartTime())
+  return os::Linux::restore_start_time();
+JVM_END

--- a/src/java.base/share/classes/jdk/crac/Core.java
+++ b/src/java.base/share/classes/jdk/crac/Core.java
@@ -254,11 +254,17 @@ public class Core {
                 checkpointInProgress = true;
                 try {
                     checkpointRestore1(jcmdStream);
-                } finally {
-                    LoggerContainer.debug("Java part of restore took {0} ms",
+                    // Don't print anything on unsuccessful checkpoint
+                    long restoreStartTime = restoreStartTime();
+                    if (restoreStartTime >= 0) {
+                        LoggerContainer.debug("Java part of restore took {0} ms",
                                 TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - javaRestoreStartNanos));
-                    LoggerContainer.debug("Complete restore took {0} ms",
-                                System.currentTimeMillis() - restoreStartTime());
+                        LoggerContainer.debug("Complete restore took {0} ms",
+                                System.currentTimeMillis() - restoreStartTime);
+                    } else {
+                        LoggerContainer.error("Restore start time was not recorded!");
+                    }
+                } finally {
                     checkpointInProgress = false;
                 }
             } else {

--- a/src/java.base/share/native/libjava/CracCore.c
+++ b/src/java.base/share/native/libjava/CracCore.c
@@ -38,3 +38,9 @@ JNIEXPORT jobjectArray JNICALL
 Java_jdk_crac_Core_checkpointRestore0(JNIEnv *env, jclass ignore, jarray fdArr, jobjectArray objArr, jboolean dry_run, jlong jcmd_stream) {
     return JVM_Checkpoint(env, fdArr, objArr, dry_run, jcmd_stream);
 }
+
+JNIEXPORT jlong JNICALL
+Java_jdk_crac_Core_restoreStartTime(JNIEnv *env, jclass ignore)
+{
+    return JVM_RestoreStartTime();
+}


### PR DESCRIPTION
Prints duration of both the Java part (Resource notifications) and total time needed for restore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/crac.git pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/68.diff">https://git.openjdk.org/crac/pull/68.diff</a>

</details>
