### PR TITLE
Synchronize concurrent clean() in PhantomCleanableRef

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -128,6 +128,11 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
     private boolean readEOF;
     private boolean connectionReset;
 
+    static {
+        // trigger eager initialization
+        new FileDispatcherImpl();
+    }
+
     /**
      * Creates an instance of this SocketImpl.
      * @param server true if this is a SocketImpl for a ServerSocket

--- a/test/jdk/jdk/crac/RefQueueTest.java
+++ b/test/jdk/jdk/crac/RefQueueTest.java
@@ -53,10 +53,6 @@ public class RefQueueTest implements CracTest {
 
         // the cleaner would be able to run right away
         cleaner.register(new Object(), () -> {
-            // FIXME: This test can still spuriously fail when this starts running
-            // before C/R, voiding the PhantomCleanableRef.beforeCheckpoint, but
-            // does not finish the close before FileDescriptor finds itself not closed
-            // and rightfully throws CheckpointOpenFileException.
             try {
                 badStream.close();
             } catch (IOException e) {


### PR DESCRIPTION
Fixes failures in RefQueueTest and JarFileFactoryCacheTest.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.org/crac.git pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/70.diff">https://git.openjdk.org/crac/pull/70.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/70#issuecomment-1545791516)