### PR TITLE
Linux file system watcher support

### DIFF
--- a/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
@@ -25,9 +25,14 @@
 
 package sun.nio.fs;
 
+import java.nio.channels.IllegalSelectorException;
 import java.nio.file.*;
 import java.util.*;
 import java.io.IOException;
+
+import jdk.crac.Context;
+import jdk.crac.Resource;
+import jdk.internal.crac.JDKResource;
 import jdk.internal.misc.Unsafe;
 
 import static sun.nio.fs.UnixNativeDispatcher.*;
@@ -51,30 +56,7 @@ class LinuxWatchService
     private final Poller poller;
 
     LinuxWatchService(UnixFileSystem fs) throws IOException {
-        // initialize inotify
-        int ifd = - 1;
-        try {
-            ifd = inotifyInit();
-        } catch (UnixException x) {
-            String msg = (x.errno() == EMFILE) ?
-                "User limit of inotify instances reached or too many open files" :
-                x.errorString();
-            throw new IOException(msg);
-        }
-
-        // configure inotify to be non-blocking
-        // create socketpair used in the close mechanism
-        int sp[] = new int[2];
-        try {
-            configureBlocking(ifd, false);
-            socketpair(sp);
-            configureBlocking(sp[0], false);
-        } catch (UnixException x) {
-            UnixNativeDispatcher.close(ifd);
-            throw new IOException(x.errorString());
-        }
-
-        this.poller = new Poller(fs, this, ifd, sp);
+        this.poller = new Poller(fs, this);
         this.poller.start();
     }
 
@@ -141,7 +123,7 @@ class LinuxWatchService
     /**
      * Background thread to read from inotify
      */
-    private static class Poller extends AbstractPoller {
+    private static class Poller extends AbstractPoller implements JDKResource {
         /**
          * struct inotify_event {
          *     int          wd;
@@ -171,25 +153,95 @@ class LinuxWatchService
         // sizeof buffer for when polling inotify
         private static final int BUFFER_SIZE = 8192;
 
+        private enum CheckpointRestoreState {
+            NORMAL_OPERATION,
+            CHECKPOINT_TRANSITION,
+            CHECKPOINTED,
+            CHECKPOINT_ERROR,
+            RESTORE_TRANSITION,
+        }
+
         private final UnixFileSystem fs;
         private final LinuxWatchService watcher;
 
         // inotify file descriptor
-        private final int ifd;
+        private int ifd;
         // socketpair used to shutdown polling thread
-        private final int socketpair[];
+        private int socketpair[];
         // maps watch descriptor to Key
         private final Map<Integer,LinuxWatchKey> wdToKey;
         // address of read buffer
         private final long address;
+        private volatile CheckpointRestoreState checkpointState = CheckpointRestoreState.NORMAL_OPERATION;
+        private final Object checkpointLock = new Object();
 
-        Poller(UnixFileSystem fs, LinuxWatchService watcher, int ifd, int[] sp) {
+
+        Poller(UnixFileSystem fs, LinuxWatchService watcher) throws IOException {
             this.fs = fs;
             this.watcher = watcher;
-            this.ifd = ifd;
-            this.socketpair = sp;
             this.wdToKey = new HashMap<>();
             this.address = unsafe.allocateMemory(BUFFER_SIZE);
+            this.socketpair = new int[2];
+            initFDs();
+            jdk.internal.crac.Core.getJDKContext().register(this);
+        }
+
+        private void initFDs() throws IOException {
+            // initialize inotify
+            try {
+                this.ifd = inotifyInit();
+            } catch (UnixException x) {
+                String msg = (x.errno() == EMFILE) ?
+                        "User limit of inotify instances reached or too many open files" :
+                        x.errorString();
+                throw new IOException(msg);
+            }
+
+            // configure inotify to be non-blocking
+            // create socketpair used in the close mechanism
+            try {
+                configureBlocking(ifd, false);
+                socketpair(this.socketpair);
+                configureBlocking(this.socketpair[0], false);
+            } catch (UnixException x) {
+                UnixNativeDispatcher.close(ifd);
+                throw new IOException(x.errorString());
+            }
+        }
+
+        private boolean processCheckpointRestore() throws IOException {
+            if (checkpointState != CheckpointRestoreState.CHECKPOINT_TRANSITION) {
+                return false;
+            }
+
+            synchronized (checkpointLock) {
+                CheckpointRestoreState thisState;
+                if (wdToKey.size() == 0) {
+                    unsafe.freeMemory(address);
+                    UnixNativeDispatcher.close(socketpair[0]);
+                    UnixNativeDispatcher.close(socketpair[1]);
+                    UnixNativeDispatcher.close(ifd);
+                    thisState = CheckpointRestoreState.CHECKPOINTED;
+                } else {
+                    thisState = CheckpointRestoreState.CHECKPOINT_ERROR;
+                }
+
+                checkpointState = thisState;
+                checkpointLock.notifyAll();
+                while (checkpointState == thisState) {
+                    try {
+                        checkpointLock.wait();
+                    } catch (InterruptedException e) {
+                    }
+                }
+                assert checkpointState == CheckpointRestoreState.RESTORE_TRANSITION;
+                if (thisState == CheckpointRestoreState.CHECKPOINTED) {
+                    initFDs();
+                }
+                checkpointState = CheckpointRestoreState.NORMAL_OPERATION;
+                checkpointLock.notifyAll();
+            }
+            return true;
         }
 
         @Override
@@ -311,7 +363,13 @@ class LinuxWatchService
                     int nReady, bytesRead;
 
                     // wait for close or inotify event
-                    nReady = poll(ifd, socketpair[0]);
+                    try {
+                        do {
+                            nReady = poll(ifd, socketpair[0]);
+                        } while (processCheckpointRestore());
+                    } catch (IOException e) {
+                        throw new Error("IOException in inotify processCheckpointRestore", e);
+                    }
 
                     // read from inotify
                     try {
@@ -430,6 +488,49 @@ class LinuxWatchService
             if (kind != null) {
                 key.signalEvent(kind, name);
             }
+        }
+
+        @Override
+        public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+            if (!watcher.isOpen()) {
+                return;
+            }
+
+            synchronized (checkpointLock) {
+                checkpointState = CheckpointRestoreState.CHECKPOINT_TRANSITION;
+                write(socketpair[1], address, 1);
+                while (checkpointState == CheckpointRestoreState.CHECKPOINT_TRANSITION) {
+                    try {
+                        checkpointLock.wait();
+                    } catch (InterruptedException e) {
+                    }
+                }
+                if (checkpointState == CheckpointRestoreState.CHECKPOINT_ERROR) {
+                    throw new IllegalSelectorException();
+                }
+            }
+        }
+
+        @Override
+        public void afterRestore(Context<? extends Resource> context) throws Exception {
+            if (!watcher.isOpen()) {
+                return;
+            }
+            synchronized (checkpointLock) {
+                checkpointState = CheckpointRestoreState.RESTORE_TRANSITION;
+                checkpointLock.notifyAll();
+                while (checkpointState == CheckpointRestoreState.RESTORE_TRANSITION) {
+                    try {
+                        checkpointLock.wait();
+                    } catch (InterruptedException e) {
+                    }
+                }
+            }
+        }
+
+        @Override
+        public Priority getPriority() {
+            return Priority.NORMAL;
         }
     }
 

--- a/test/jdk/jdk/crac/fileDescriptors/FileWatcherAfterRestoreTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/FileWatcherAfterRestoreTest.java
@@ -1,0 +1,83 @@
+package crac.fileDescriptors;/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+
+import java.nio.file.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @test
+ * @library /test/lib
+ * @build FileWatcherAfterRestoreTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class FileWatcherAfterRestoreTest implements CracTest {
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder();
+        builder.doCheckpointAndRestore();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        WatchService watchService = FileSystems.getDefault().newWatchService();
+
+        Core.checkpointRestore();
+
+        Path directory = Paths.get(System.getProperty("user.dir"));
+        WatchKey key = directory.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
+        Thread.sleep(1000);
+        Path tempFilePath = Files.createTempFile(directory, "temp", ".txt");
+
+        // other file events might happen, so iterate all to make test stable
+        boolean matchFound = false;
+        while ((key = watchService.poll(1, TimeUnit.SECONDS)) != null) {
+            System.out.println(key);
+            for (WatchEvent<?> event : key.pollEvents()) {
+                System.out.println(event.kind().toString());
+                if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                    Object context = event.context();
+                    if (context instanceof Path filePath) {
+                        String fileName = filePath.getFileName().toString();
+                        System.out.println(fileName);
+                        if (fileName.matches("^temp\\d*\\.txt$")) {
+                            matchFound = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            key.reset();
+            if (matchFound) {
+                break;
+            }
+        }
+
+        Asserts.assertTrue(matchFound);
+    }
+}

--- a/test/jdk/jdk/crac/fileDescriptors/FileWatcherTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/FileWatcherTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.crac.CracTest;
+
+import java.nio.file.*;
+import jdk.crac.Core;
+import jdk.test.lib.crac.CracBuilder;
+
+/**
+ * @test
+ * @library /test/lib
+ * @build FileWatcherTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class FileWatcherTest implements CracTest {
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder();
+        builder.doCheckpointAndRestore();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        WatchService watchService = FileSystems.getDefault().newWatchService();
+        Core.checkpointRestore();
+    }
+}

--- a/test/jdk/jdk/crac/fileDescriptors/FileWatcherWithOpenKeysTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/FileWatcherWithOpenKeysTest.java
@@ -1,0 +1,57 @@
+package crac.fileDescriptors;/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracProcess;
+import jdk.test.lib.crac.CracTest;
+
+import java.nio.file.*;
+
+/**
+ * @test
+ * @library /test/lib
+ * @build FileWatcherWithOpenKeysTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class FileWatcherWithOpenKeysTest implements CracTest {
+
+    @Override
+    public void test() throws Exception {
+        CracProcess cp = new CracBuilder().captureOutput(true)
+                .startCheckpoint();
+        cp.outputAnalyzer()
+                .shouldHaveExitValue(1)
+                .shouldContain("CheckpointOpenSocketException");
+    }
+
+    @Override
+    public void exec() throws Exception {
+        WatchService watchService = FileSystems.getDefault().newWatchService();
+        Path directory = Paths.get(System.getProperty("user.dir"));
+        directory.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);
+
+        Core.checkpointRestore();
+    }
+}


### PR DESCRIPTION
`inotify` monitors changes on filesystem, this support automatic restore for LinuxFileWatcher.

FileWatcherAfterRestoreTest verifies watcher service works after restore.
FileWatcherTest verifies automatic closing inotiify fd

The watcher keys are still managed by user, so exception will be thrown if no watcher keys are leaked, as in FileWatcherWithOpenKeysTest

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/71/head:pull/71` \
`$ git checkout pull/71`

Update a local copy of the PR: \
`$ git checkout pull/71` \
`$ git pull https://git.openjdk.org/crac.git pull/71/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 71`

View PR using the GUI difftool: \
`$ git pr show -t 71`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/71.diff">https://git.openjdk.org/crac/pull/71.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/71#issuecomment-1546801613)