### PR TITLE
Linux file system watcher support

### DIFF
--- a/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
@@ -502,6 +502,8 @@ class LinuxWatchService
                     try {
                         this.wait();
                     } catch (InterruptedException e) {
+                        checkpointState = CheckpointRestoreState.CHECKPOINT_ERROR;
+                        throw e;
                     }
                 }
                 if (checkpointState == CheckpointRestoreState.CHECKPOINT_ERROR) {
@@ -522,6 +524,8 @@ class LinuxWatchService
                     try {
                         this.wait();
                     } catch (InterruptedException e) {
+                        checkpointState = CheckpointRestoreState.CHECKPOINT_ERROR;
+                        throw e;
                     }
                 }
                 if (checkpointState != CheckpointRestoreState.NORMAL_OPERATION) {

--- a/test/jdk/jdk/crac/fileDescriptors/FileWatcherAfterRestoreTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/FileWatcherAfterRestoreTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+
+import java.net.ServerSocket;
+import java.nio.file.*;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @test
+ * @library /test/lib
+ * @build FileWatcherAfterRestoreTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class FileWatcherAfterRestoreTest implements CracTest {
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder();
+        builder.doCheckpointAndRestore();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        WatchService watchService = FileSystems.getDefault().newWatchService();
+
+        Core.checkpointRestore();
+
+        Path directory = Paths.get(System.getProperty("user.dir"));
+        WatchKey key = directory.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
+        Path tempFilePath = Files.createTempFile(directory, "temp", ".txt");
+
+        // other file events might happen, so iterate all to make test stable
+        boolean matchFound = false;
+        while ((key = watchService.poll(1, TimeUnit.SECONDS)) != null) {
+            for (WatchEvent<?> event : key.pollEvents()) {
+                if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                    Object context = event.context();
+                    if (context instanceof Path filePath) {
+                        String fileName = filePath.getFileName().toString();
+                        if (fileName.matches("^temp\\d*\\.txt$")) {
+                            matchFound = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            key.reset();
+            if (matchFound) {
+                break;
+            }
+        }
+
+        Asserts.assertTrue(matchFound);
+        watchService.close();
+    }
+}

--- a/test/jdk/jdk/crac/fileDescriptors/FileWatcherAfterRestoreTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/FileWatcherAfterRestoreTest.java
@@ -59,7 +59,6 @@ public class FileWatcherAfterRestoreTest implements CracTest {
 
         directory = Paths.get(System.getProperty("user.dir"), "workdir");
         directory.toFile().mkdir();
-        Files.createTempFile(directory, "temp", ".txt");
         Asserts.assertTrue(isMatchFound(watchService, directory));
 
         Core.checkpointRestore();

--- a/test/jdk/jdk/crac/fileDescriptors/FileWatcherAfterRestoreTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/FileWatcherAfterRestoreTest.java
@@ -59,10 +59,8 @@ public class FileWatcherAfterRestoreTest implements CracTest {
 
         directory = Paths.get(System.getProperty("user.dir"), "workdir");
         directory.toFile().mkdir();
-        key = directory.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
         Files.createTempFile(directory, "temp", ".txt");
         Asserts.assertTrue(isMatchFound(watchService, directory));
-        key.cancel();
 
         Core.checkpointRestore();
 
@@ -79,7 +77,7 @@ public class FileWatcherAfterRestoreTest implements CracTest {
     private boolean isMatchFound(WatchService watchService, Path directory) throws IOException, InterruptedException {
         WatchKey key;
         boolean matchFound;
-        directory.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
+        WatchKey watchKey = directory.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
         Files.createTempFile(directory, "temp", ".txt");
         matchFound = false;
         while ((key = watchService.poll(1, TimeUnit.SECONDS)) != null) {
@@ -100,6 +98,7 @@ public class FileWatcherAfterRestoreTest implements CracTest {
                 break;
             }
         }
+        watchKey.cancel();
         return matchFound;
     }
 }

--- a/test/jdk/jdk/crac/fileDescriptors/FileWatcherWithOpenKeysTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/FileWatcherWithOpenKeysTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracProcess;
+import jdk.test.lib.crac.CracTest;
+
+import java.nio.file.*;
+
+/**
+ * @test
+ * @library /test/lib
+ * @build FileWatcherWithOpenKeysTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class FileWatcherWithOpenKeysTest implements CracTest {
+
+    @Override
+    public void test() throws Exception {
+        CracProcess cp = new CracBuilder().captureOutput(true)
+                .startCheckpoint();
+        cp.outputAnalyzer()
+                .shouldHaveExitValue(1)
+                .shouldContain("CheckpointOpenSocketException");
+    }
+
+    @Override
+    public void exec() throws Exception {
+        WatchService watchService = FileSystems.getDefault().newWatchService();
+        Path directory = Paths.get(System.getProperty("user.dir"));
+        directory.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);
+        Core.checkpointRestore();
+    }
+}


### PR DESCRIPTION
inotify monitors changes on filesystem, this support automatic restore for LinuxFileWatcher.

FileWatcherAfterRestoreTest verifies watcher service works after restore.
FileWatcherTest verifies automatic closing inotiify fd

The watcher keys are still managed by user, so exception will be thrown if no watcher keys are leaked, as in FileWatcherWithOpenKeysTest

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/72/head:pull/72` \
`$ git checkout pull/72`

Update a local copy of the PR: \
`$ git checkout pull/72` \
`$ git pull https://git.openjdk.org/crac.git pull/72/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 72`

View PR using the GUI difftool: \
`$ git pr show -t 72`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/72.diff">https://git.openjdk.org/crac/pull/72.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/72#issuecomment-1546861808)