### PR TITLE
Remove code trigger register during checkpointRestore

### DIFF
--- a/src/java.base/share/classes/jdk/crac/Core.java
+++ b/src/java.base/share/classes/jdk/crac/Core.java
@@ -175,6 +175,8 @@ public class Core {
         }
 
         if (newProperties != null && newProperties.length > 0) {
+            // Do not use lambda here since lambda will introduce registration
+            // during checkpoint, which may cause dead loop.
             Arrays.stream(newProperties).map(new Function<String, String[]>() {
                 @Override
                 public String[] apply(String propStr) {

--- a/src/java.base/share/classes/jdk/crac/Core.java
+++ b/src/java.base/share/classes/jdk/crac/Core.java
@@ -46,6 +46,8 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * The coordination service.
@@ -173,10 +175,22 @@ public class Core {
         }
 
         if (newProperties != null && newProperties.length > 0) {
-            Arrays.stream(newProperties).map(propStr -> propStr.split("=", 2)).forEach(pair -> {
-                AccessController.doPrivileged(
-                    (PrivilegedAction<String>)() ->
-                        System.setProperty(pair[0], pair.length == 2 ? pair[1] : ""));
+            Arrays.stream(newProperties).map(new Function<String, String[]>() {
+                @Override
+                public String[] apply(String propStr) {
+                    return propStr.split("=", 2);
+                }
+            }).forEach(new Consumer<String[]>() {
+                @Override
+                public void accept(String[] pair) {
+                    AccessController.doPrivileged(
+                            new PrivilegedAction<String>() {
+                                @Override
+                                public String run() {
+                                    return System.setProperty(pair[0], pair.length == 2 ? pair[1] : "");
+                                }
+                            });
+                }
             });
         }
 

--- a/test/jdk/jdk/crac/CracOptionTest.java
+++ b/test/jdk/jdk/crac/CracOptionTest.java
@@ -35,7 +35,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
- * @test DryRunTest
+ * @test CracOptionTest
  * @library /test/lib
  * @build CracOptionTest
  * @run driver jdk.test.lib.crac.CracTest
@@ -51,11 +51,6 @@ public class CracOptionTest implements CracTest {
 
     @Override
     public void exec() throws Exception {
-        Path directory;
-        directory = Paths.get(System.getProperty("user.dir"), "workdir");
-        directory.toFile().mkdir();
-        Files.createTempFile(directory, "temp", ".txt");
-
         Core.checkpointRestore();
     }
 }

--- a/test/jdk/jdk/crac/CracOptionTest.java
+++ b/test/jdk/jdk/crac/CracOptionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import jdk.crac.*;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.Pipe;
+import java.nio.file.*;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @test DryRunTest
+ * @library /test/lib
+ * @build CracOptionTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+
+public class CracOptionTest implements CracTest {
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder();
+        builder.javaOption("k","v");
+        builder.doCheckpointAndRestore();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Path directory;
+        directory = Paths.get(System.getProperty("user.dir"), "workdir");
+        directory.toFile().mkdir();
+        Files.createTempFile(directory, "temp", ".txt");
+
+        Core.checkpointRestore();
+    }
+}


### PR DESCRIPTION
Register higher priority context during checkpoint could lead to dead lock, this patch removes the code that triggers register during checkpoint call. 

Thread dump for `CracOptionTest`  without this patch
```
2023-05-23 18:10:39
Full thread dump OpenJDK 64-Bit Server VM (17-internal+0-adhoc.ubuntu.jdk mixed mode, sharing):

Threads class SMR info:
_java_thread_list=0x00007f30a8002610, length=13, elements={
0x00007f30ec025690, 0x00007f30ec0b3d30, 0x00007f30ec0b5ae0, 0x00007f30ec0baa40,
0x00007f30ec0bbdf0, 0x00007f30ec0bd200, 0x00007f30ec0bebb0, 0x00007f30ec0c00e0,
0x00007f30ec0c1550, 0x00007f30ec0c9350, 0x00007f30ec0cc3d0, 0x00007f30ec0e5c20,
0x00007f30a8001650
}

"main" #1 prio=5 os_prio=0 cpu=2.19ms elapsed=12.30s tid=0x00007f30ec025690 nid=0x69b0 in Object.wait()  [0x00007f30f392f000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(java.base@17-internal/Native Method)
	- waiting on <0x00000000ca413e78> (a jdk.internal.crac.JDKContext)
	at java.lang.Object.wait(java.base@17-internal/Object.java:338)
	at jdk.crac.impl.AbstractContextImpl.waitWhileCheckpointIsInProgress(java.base@17-internal/AbstractContextImpl.java:102)
	at jdk.crac.impl.PriorityContext.register(java.base@17-internal/PriorityContext.java:44)
	- locked <0x00000000ca413e78> (a jdk.internal.crac.JDKContext)
	at jdk.internal.crac.JDKContext.register(java.base@17-internal/JDKContext.java:108)
	at jdk.internal.ref.CleanerImpl$PhantomCleanableRef.<init>(java.base@17-internal/CleanerImpl.java:173)
	at java.lang.invoke.MethodHandleNatives$CallSiteContext.make(java.base@17-internal/MethodHandleNatives.java:93)
	at java.lang.invoke.CallSite.<init>(java.base@17-internal/CallSite.java:144)
	at java.lang.invoke.ConstantCallSite.<init>(java.base@17-internal/ConstantCallSite.java:50)
	at java.lang.invoke.InnerClassLambdaMetafactory.buildCallSite(java.base@17-internal/InnerClassLambdaMetafactory.java:262)
	at java.lang.invoke.LambdaMetafactory.metafactory(java.base@17-internal/LambdaMetafactory.java:341)
	at java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(java.base@17-internal/DirectMethodHandle$Holder)
	at java.lang.invoke.Invokers$Holder.invokeExact_MT(java.base@17-internal/Invokers$Holder)
	at java.lang.invoke.BootstrapMethodInvoker.invoke(java.base@17-internal/BootstrapMethodInvoker.java:134)
	at java.lang.invoke.CallSite.makeSite(java.base@17-internal/CallSite.java:315)
	at java.lang.invoke.MethodHandleNatives.linkCallSiteImpl(java.base@17-internal/MethodHandleNatives.java:285)
	at java.lang.invoke.MethodHandleNatives.linkCallSite(java.base@17-internal/MethodHandleNatives.java:275)
	at jdk.crac.Core.checkpointRestore1(java.base@17-internal/Core.java:176)
	at jdk.crac.Core.checkpointRestore(java.base@17-internal/Core.java:264)
	- locked <0x00000000ca413f00> (a java.lang.Object)
	at jdk.crac.Core.checkpointRestore(java.base@17-internal/Core.java:249)
	at FileWatcherAfterRestoreTest.exec(FileWatcherAfterRestoreTest.java:89)
	at jdk.test.lib.crac.CracTest.run(CracTest.java:157)
	at jdk.test.lib.crac.CracTest.main(CracTest.java:89)

"Reference Handler" #2 daemon prio=10 os_prio=0 cpu=0.07ms elapsed=12.28s tid=0x00007f30ec0b3d30 nid=0x69b8 waiting on condition  [0x00007f30deefc000]
   java.lang.Thread.State: RUNNABLE
	at java.lang.ref.Reference.waitForReferencePendingList(java.base@17-internal/Native Method)
	at java.lang.ref.Reference.processPendingReferences(java.base@17-internal/Reference.java:258)
	at java.lang.ref.Reference$ReferenceHandler.run(java.base@17-internal/Reference.java:218)

"Finalizer" #3 daemon prio=8 os_prio=0 cpu=0.09ms elapsed=12.28s tid=0x00007f30ec0b5ae0 nid=0x69b9 in Object.wait()  [0x00007f30dedfb000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(java.base@17-internal/Native Method)
	- waiting on <0x00000000ca4143f8> (a java.lang.ref.ReferenceQueue$Lock)
	at java.lang.ref.ReferenceQueue.remove(java.base@17-internal/ReferenceQueue.java:155)
	- locked <0x00000000ca4143f8> (a java.lang.ref.ReferenceQueue$Lock)
	at java.lang.ref.ReferenceQueue.remove(java.base@17-internal/ReferenceQueue.java:176)
	at java.lang.ref.Finalizer$FinalizerThread.run(java.base@17-internal/Finalizer.java:172)

"Signal Dispatcher" #4 daemon prio=9 os_prio=0 cpu=0.37ms elapsed=12.28s tid=0x00007f30ec0baa40 nid=0x69ba waiting on condition  [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"Service Thread" #5 daemon prio=9 os_prio=0 cpu=0.06ms elapsed=12.28s tid=0x00007f30ec0bbdf0 nid=0x69bb runnable  [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"Monitor Deflation Thread" #6 daemon prio=9 os_prio=0 cpu=0.26ms elapsed=12.28s tid=0x00007f30ec0bd200 nid=0x69bc runnable  [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"C2 CompilerThread0" #7 daemon prio=9 os_prio=0 cpu=0.12ms elapsed=12.28s tid=0x00007f30ec0bebb0 nid=0x69bd waiting on condition  [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE
   No compile task

"C1 CompilerThread0" #8 daemon prio=9 os_prio=0 cpu=2.12ms elapsed=12.28s tid=0x00007f30ec0c00e0 nid=0x69be waiting on condition  [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE
   No compile task

"Sweeper thread" #9 daemon prio=9 os_prio=0 cpu=0.07ms elapsed=12.28s tid=0x00007f30ec0c1550 nid=0x69bf runnable  [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"Notification Thread" #10 daemon prio=9 os_prio=0 cpu=0.06ms elapsed=12.27s tid=0x00007f30ec0c9350 nid=0x69c0 runnable  [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"Common-Cleaner" #11 daemon prio=8 os_prio=0 cpu=0.08ms elapsed=12.27s tid=0x00007f30ec0cc3d0 nid=0x69c2 in Object.wait()  [0x00007f30de2b7000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
	at java.lang.Object.wait(java.base@17-internal/Native Method)
	- waiting on <0x00000000ca428060> (a java.lang.ref.ReferenceQueue$Lock)
	at java.lang.ref.ReferenceQueue.remove(java.base@17-internal/ReferenceQueue.java:155)
	- locked <0x00000000ca428060> (a java.lang.ref.ReferenceQueue$Lock)
	at jdk.internal.ref.CleanerImpl.run(java.base@17-internal/CleanerImpl.java:144)
	at java.lang.Thread.run(java.base@17-internal/Thread.java:833)
	at jdk.internal.misc.InnocuousThread.run(java.base@17-internal/InnocuousThread.java:162)

"FileSystemWatchService" #12 daemon prio=5 os_prio=0 cpu=0.06ms elapsed=12.25s tid=0x00007f30ec0e5c20 nid=0x69c3 in Object.wait()  [0x00007f30ddd8d000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(java.base@17-internal/Native Method)
	- waiting on <0x00000000ca43abb8> (a sun.nio.fs.LinuxWatchService$Poller)
	at java.lang.Object.wait(java.base@17-internal/Object.java:338)
	at sun.nio.fs.LinuxWatchService$Poller.processCheckpointRestore(java.base@17-internal/LinuxWatchService.java:233)
	- locked <0x00000000ca43abb8> (a sun.nio.fs.LinuxWatchService$Poller)
	at sun.nio.fs.LinuxWatchService$Poller.run(java.base@17-internal/LinuxWatchService.java:369)
	at java.lang.Thread.run(java.base@17-internal/Thread.java:833)

"Attach Listener" #13 daemon prio=9 os_prio=0 cpu=0.21ms elapsed=0.10s tid=0x00007f30a8001650 nid=0x6a13 waiting on condition  [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"VM Thread" os_prio=0 cpu=1.99ms elapsed=12.28s tid=0x00007f30ec0afe10 nid=0x69b7 runnable

"GC Thread#0" os_prio=0 cpu=1.21ms elapsed=12.29s tid=0x00007f30ec050f80 nid=0x69b2 runnable

"GC Thread#1" os_prio=0 cpu=0.41ms elapsed=12.21s tid=0x00007f30ac000f70 nid=0x69c4 runnable

"G1 Main Marker" os_prio=0 cpu=0.27ms elapsed=12.29s tid=0x00007f30ec0590d0 nid=0x69b3 runnable

"G1 Conc#0" os_prio=0 cpu=6.10ms elapsed=12.29s tid=0x00007f30ec05a030 nid=0x69b4 runnable

"G1 Refine#0" os_prio=0 cpu=0.08ms elapsed=12.29s tid=0x00007f30ec0874e0 nid=0x69b5 runnable

"G1 Service" os_prio=0 cpu=1.24ms elapsed=12.29s tid=0x00007f30ec0883d0 nid=0x69b6 runnable

"VM Periodic Task Thread" os_prio=0 cpu=4.56ms elapsed=12.27s tid=0x00007f30ec0cac90 nid=0x69c1 waiting on condition

JNI global refs: 7, weak refs: 0
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)
 * @rvansa (no known openjdk.org user name / role) ⚠️ Review applies to [ac5410f7](https://git.openjdk.org/crac/pull/75/files/ac5410f7467756dc45a3d92ede5e41ac40dda1b2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/75/head:pull/75` \
`$ git checkout pull/75`

Update a local copy of the PR: \
`$ git checkout pull/75` \
`$ git pull https://git.openjdk.org/crac.git pull/75/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 75`

View PR using the GUI difftool: \
`$ git pr show -t 75`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/75.diff">https://git.openjdk.org/crac/pull/75.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/75#issuecomment-1562429429)