### PR TITLE
Do not register MethodHandleNatives

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -90,8 +90,12 @@ class MethodHandleNatives {
             // become unreachable, its Context is retained by the Cleanable instance
             // (which is referenced from Cleaner instance which is referenced from
             // CleanerFactory class) until cleanup is performed.
+            // This PhantomCleanableRef is not registered in any Context as
+            // registration cauesed by the core CRaC code leads to deadlock.
+            // The drawback is native structures may end up in the checkpoint
+            // image and be cleaned shortly after restore, which is neglectable.
             new CleanerImpl.PhantomCleanableRef(cs, CleanerFactory.cleaner(),
-                    newContext, JDKResource.Priority.CALL_SITES);
+                    newContext, null);
             return newContext;
         }
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -94,8 +94,7 @@ class MethodHandleNatives {
             // registration cauesed by the core CRaC code leads to deadlock.
             // The drawback is native structures may end up in the checkpoint
             // image and be cleaned shortly after restore, which is neglectable.
-            new CleanerImpl.PhantomCleanableRef(cs, CleanerFactory.cleaner(),
-                    newContext, null);
+            SharedSecrets.getJavaLangRefAccess().register(CleanerFactory.cleaner(), cs, newContext, null);
             return newContext;
         }
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -91,7 +91,7 @@ class MethodHandleNatives {
             // (which is referenced from Cleaner instance which is referenced from
             // CleanerFactory class) until cleanup is performed.
             // This PhantomCleanableRef is not registered in any Context as
-            // registration cauesed by the core CRaC code leads to deadlock.
+            // registration caused by the core CRaC code leads to deadlock.
             // The drawback is native structures may end up in the checkpoint
             // image and be cleaned shortly after restore, which is neglectable.
             SharedSecrets.getJavaLangRefAccess().register(CleanerFactory.cleaner(), cs, newContext, null);

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -94,7 +94,7 @@ class MethodHandleNatives {
             // registration caused by the core CRaC code leads to deadlock.
             // The drawback is native structures may end up in the checkpoint
             // image and be cleaned shortly after restore, which is neglectable.
-            SharedSecrets.getJavaLangRefAccess().register(CleanerFactory.cleaner(), cs, newContext, null);
+            SharedSecrets.getJavaLangRefAccess().cleanerRegisterWithPriority(CleanerFactory.cleaner(), cs, newContext, null);
             return newContext;
         }
 

--- a/src/java.base/share/classes/java/lang/ref/Cleaner.java
+++ b/src/java.base/share/classes/java/lang/ref/Cleaner.java
@@ -222,6 +222,15 @@ public final class Cleaner {
     }
 
     /**
+     * Register an object and object and also register the underlying Reference with a CRaC priority.
+     */
+    /*non-public*/ Cleanable register(Object obj, Runnable action, JDKResource.Priority priority) {
+        Objects.requireNonNull(obj, "obj");
+        Objects.requireNonNull(action, "action");
+        return new CleanerImpl.PhantomCleanableRef(obj, this, action, priority);
+    }
+
+    /**
      * {@code Cleanable} represents an object and a
      * cleaning action registered in a {@code Cleaner}.
      * @since 9

--- a/src/java.base/share/classes/java/lang/ref/Cleaner.java
+++ b/src/java.base/share/classes/java/lang/ref/Cleaner.java
@@ -222,7 +222,7 @@ public final class Cleaner {
     }
 
     /**
-     * Register an object and object and also register the underlying Reference with a CRaC priority.
+     * Register an object and action and also register the underlying Reference with a CRaC priority.
      */
     /*non-public*/ Cleanable register(Object obj, Runnable action, JDKResource.Priority priority) {
         Objects.requireNonNull(obj, "obj");

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -331,6 +331,11 @@ public abstract class Reference<T> {
             public void runFinalization() {
                 Finalizer.runFinalization();
             }
+
+            @Override
+            public java.lang.ref.Cleaner.Cleanable register(java.lang.ref.Cleaner cleaner, Object obj, Runnable action, JDKResource.Priority priority) {
+                return cleaner.register(obj, action, priority);
+            }
         });
 
         referenceHandlerResource = new JDKResource() {

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -333,7 +333,7 @@ public abstract class Reference<T> {
             }
 
             @Override
-            public java.lang.ref.Cleaner.Cleanable register(java.lang.ref.Cleaner cleaner, Object obj, Runnable action, JDKResource.Priority priority) {
+            public java.lang.ref.Cleaner.Cleanable cleanerRegisterWithPriority(java.lang.ref.Cleaner cleaner, Object obj, Runnable action, JDKResource.Priority priority) {
                 return cleaner.register(obj, action, priority);
             }
         });

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangRefAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangRefAccess.java
@@ -49,7 +49,7 @@ public interface JavaLangRefAccess {
     void runFinalization();
 
     /**
-     * Registers an object and an action in a cleaner, with action synhronized with a CRaC priority.
+     * Calls package-private {@link Cleaner#register(Object, Runnable, JDKResource.Priority)}.
      */
-    Cleaner.Cleanable register(Cleaner cleaner, Object obj, Runnable action, JDKResource.Priority priority);
+    Cleaner.Cleanable cleanerRegisterWithPriority(Cleaner cleaner, Object obj, Runnable action, JDKResource.Priority priority);
 }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangRefAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangRefAccess.java
@@ -25,6 +25,10 @@
 
 package jdk.internal.access;
 
+import jdk.internal.crac.JDKResource;
+
+import java.lang.ref.Cleaner;
+
 public interface JavaLangRefAccess {
 
     /**
@@ -43,4 +47,9 @@ public interface JavaLangRefAccess {
      * Invoked by Runtime.runFinalization()
      */
     void runFinalization();
+
+    /**
+     * Registers an object and an action in a cleaner, with action synhronized with a CRaC priority.
+     */
+    Cleaner.Cleanable register(Cleaner cleaner, Object obj, Runnable action, JDKResource.Priority priority);
 }

--- a/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
@@ -86,14 +86,6 @@ public interface JDKResource extends Resource {
 
         PRE_FILE_DESRIPTORS,
         FILE_DESCRIPTORS,
-
-        /**
-         * Cleaners for CallSites cannot be registered with regular CLEANERS
-         * priority as this would hang/throw exceptions any time a lambda
-         * or method reference is used during or after processing this resource
-         * priority class; therefore we postpone as the last priority.
-         */
-        CALL_SITES,
     };
 
     Priority getPriority();

--- a/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
@@ -170,7 +170,9 @@ public final class CleanerImpl implements Runnable {
             super(obj, cleaner);
             this.action = action;
             this.priority = priority;
-            jdk.internal.crac.Core.getJDKContext().register(this);
+            if (priority != null) {
+                jdk.internal.crac.Core.getJDKContext().register(this);
+            }
         }
 
         /**


### PR DESCRIPTION
A simple solution for the lambda problem in the CRaC Core: do not register CALL_SITES at all.

A second part of the PR introduces an interface for Cleaner.register() with priority parameter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * @rvansa (no known openjdk.org user name / role) ⚠️ Review applies to [dc83f2be](https://git.openjdk.org/crac/pull/76/files/dc83f2be3de189295075fceda75939de0df42cf7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/76/head:pull/76` \
`$ git checkout pull/76`

Update a local copy of the PR: \
`$ git checkout pull/76` \
`$ git pull https://git.openjdk.org/crac.git pull/76/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 76`

View PR using the GUI difftool: \
`$ git pr show -t 76`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/76.diff">https://git.openjdk.org/crac/pull/76.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/76#issuecomment-1562808665)