### PR TITLE
Fix test/lib/crac/CracBuilder compilation

### DIFF
--- a/test/lib/jdk/test/lib/crac/CracBuilder.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilder.java
@@ -32,7 +32,7 @@ public class CracBuilder {
     final List<String> classpathEntries = new ArrayList<>();
     final Map<String, String> env = new HashMap<>();
     final List<String> vmOptions = new ArrayList<>();
-    final Map<String, String> javaOptions = new HashMap<>();
+    Map<String, String> javaOptions = new HashMap<>();
     String imageDir = DEFAULT_IMAGE_DIR;
     CracEngine engine;
     boolean printResources;


### PR DESCRIPTION
Fixes test compilation failure from e.g. https://github.com/openjdk/crac/pull/74/checks?check_run_id=13554598897. 
```
----------direct:(16/1096)----------
/home/runner/work/crac/crac/test/lib/jdk/test/lib/crac/CracBuilder.java:71: error: cannot assign a value to final variable javaOptions
        other.javaOptions = new HashMap<>(javaOptions);
             ^
```

Reproduces locally after clearing JTreg cache.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.org/crac.git pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/77.diff">https://git.openjdk.org/crac/pull/77.diff</a>

</details>
