### PR TITLE
Do not add generic native checkpoint error in dry runs

### DIFF
--- a/test/jdk/jdk/crac/FailedResourceTest.java
+++ b/test/jdk/jdk/crac/FailedResourceTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import jdk.crac.*;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static jdk.test.lib.Asserts.*;
+
+/**
+ * @test FailedResourceTest
+ * @library /test/lib
+ * @build FailedResourceTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+
+public class FailedResourceTest implements CracTest {
+    public static final String EXCEPTION_MESSAGE = "Resource failed";
+
+    @Override
+    public void test() throws Exception {
+        new CracBuilder().startCheckpoint().waitForSuccess();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        AtomicBoolean ranAfter = new AtomicBoolean();
+        Resource resource = new Resource() {
+            @Override
+            public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+                throw new Exception(EXCEPTION_MESSAGE);
+            }
+
+            @Override
+            public void afterRestore(Context<? extends Resource> context) throws Exception {
+                ranAfter.set(true);
+            }
+        };
+        Core.getGlobalContext().register(resource);
+        try {
+            Core.checkpointRestore();
+            fail("Was supposed to throw");
+        } catch (CheckpointException e) {
+            assertEquals(1, e.getSuppressed().length, Arrays.toString(e.getSuppressed()));
+            assertEquals(EXCEPTION_MESSAGE, e.getSuppressed()[0].getMessage());
+        } catch (RestoreException e) {
+            fail("Shouldn't error in restore", e);
+        }
+        assertTrue(ranAfter.get());
+    }
+}


### PR DESCRIPTION
When a Resource throws an exception we still enter the checks in native code. In such cases the native code should return successful status if there are no further errors found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/80/head:pull/80` \
`$ git checkout pull/80`

Update a local copy of the PR: \
`$ git checkout pull/80` \
`$ git pull https://git.openjdk.org/crac.git pull/80/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 80`

View PR using the GUI difftool: \
`$ git pr show -t 80`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/80.diff">https://git.openjdk.org/crac/pull/80.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/80#issuecomment-1586969205)