### PR TITLE
Fixing VMOptionsTest.java

### DIFF
--- a/test/jdk/jdk/crac/VMOptionsTest.java
+++ b/test/jdk/jdk/crac/VMOptionsTest.java
@@ -41,36 +41,42 @@ public class VMOptionsTest implements CracTest {
     @Override
     public void test() throws Exception {
         CracBuilder builder = new CracBuilder();
+        builder.vmOption("-XX:NativeMemoryTracking=off");
         builder.doCheckpoint();
+        builder.clearVmOptions();
         builder.vmOption("-XX:CRaCCheckpointTo=another"); // manageable
         builder.vmOption("-XX:CRaCIgnoredFileDescriptors=42,43"); // restore_settable
         builder.doRestore();
         // Setting non-manageable option
-        HotSpotDiagnosticMXBean bean = ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class);
-        final VMOption nmt = bean.getVMOption("NativeMemoryTracking");
-        builder.vmOption("-XX:NativeMemoryTracking=" + (nmt.getValue().equals("off") ? "summary" : "off"));
+        builder.vmOption("-XX:NativeMemoryTracking=summary");
         assertEquals(1, builder.startRestore().waitFor());
     }
 
     @Override
     public void exec() throws RestoreException, CheckpointException {
-        HotSpotDiagnosticMXBean bean = ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class);
-        VMOption checkpointTo1 = bean.getVMOption("CRaCCheckpointTo");
-        assertEquals("cr", checkpointTo1.getValue());
-        assertEquals(VMOption.Origin.VM_CREATION, checkpointTo1.getOrigin());
-        VMOption nmt1 = bean.getVMOption("NativeMemoryTracking");
-        assertEquals(VMOption.Origin.DEFAULT, nmt1.getOrigin());
+        {
+            HotSpotDiagnosticMXBean bean = ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class);
+            VMOption checkpointTo1 = bean.getVMOption("CRaCCheckpointTo");
+            assertEquals("cr", checkpointTo1.getValue());
+            assertEquals(VMOption.Origin.VM_CREATION, checkpointTo1.getOrigin());
+            VMOption nmt1 = bean.getVMOption("NativeMemoryTracking");
+            assertEquals("off", nmt1.getValue());
+            assertEquals(VMOption.Origin.VM_CREATION, nmt1.getOrigin());
+        }
 
         Core.checkpointRestore();
 
-        VMOption checkpointTo2 = bean.getVMOption("CRaCCheckpointTo");
-        assertEquals("another", checkpointTo2.getValue());
-        assertEquals(VMOption.Origin.OTHER, checkpointTo2.getOrigin());
-        VMOption ignoredFileDescriptors = bean.getVMOption("CRaCIgnoredFileDescriptors");
-        assertEquals("42,43", ignoredFileDescriptors.getValue());
-        assertEquals(VMOption.Origin.OTHER, ignoredFileDescriptors.getOrigin());
-        VMOption nmt = bean.getVMOption("NativeMemoryTracking");
-        assertEquals(nmt1.getValue(), nmt.getValue());
-        assertEquals(VMOption.Origin.DEFAULT, nmt.getOrigin());
+        {
+            HotSpotDiagnosticMXBean bean = ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class);
+            VMOption checkpointTo2 = bean.getVMOption("CRaCCheckpointTo");
+            assertEquals("another", checkpointTo2.getValue());
+            assertEquals(VMOption.Origin.OTHER, checkpointTo2.getOrigin());
+            VMOption ignoredFileDescriptors = bean.getVMOption("CRaCIgnoredFileDescriptors");
+            assertEquals("42,43", ignoredFileDescriptors.getValue());
+            assertEquals(VMOption.Origin.OTHER, ignoredFileDescriptors.getOrigin());
+            VMOption nmt = bean.getVMOption("NativeMemoryTracking");
+            assertEquals("off", nmt.getValue());
+            assertEquals(VMOption.Origin.VM_CREATION, nmt.getOrigin());
+        }
     }
 }

--- a/test/jdk/jdk/crac/VMOptionsTest.java
+++ b/test/jdk/jdk/crac/VMOptionsTest.java
@@ -46,7 +46,9 @@ public class VMOptionsTest implements CracTest {
         builder.vmOption("-XX:CRaCIgnoredFileDescriptors=42,43"); // restore_settable
         builder.doRestore();
         // Setting non-manageable option
-        builder.vmOption("-XX:NativeMemoryTracking=summary");
+        HotSpotDiagnosticMXBean bean = ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class);
+        final VMOption nmt = bean.getVMOption("NativeMemoryTracking");
+        builder.vmOption("-XX:NativeMemoryTracking=" + (nmt.getValue().equals("off") ? "summary" : "off"));
         assertEquals(1, builder.startRestore().waitFor());
     }
 
@@ -57,7 +59,6 @@ public class VMOptionsTest implements CracTest {
         assertEquals("cr", checkpointTo1.getValue());
         assertEquals(VMOption.Origin.VM_CREATION, checkpointTo1.getOrigin());
         VMOption nmt1 = bean.getVMOption("NativeMemoryTracking");
-        assertEquals("off", nmt1.getValue());
         assertEquals(VMOption.Origin.DEFAULT, nmt1.getOrigin());
 
         Core.checkpointRestore();
@@ -69,7 +70,7 @@ public class VMOptionsTest implements CracTest {
         assertEquals("42,43", ignoredFileDescriptors.getValue());
         assertEquals(VMOption.Origin.OTHER, ignoredFileDescriptors.getOrigin());
         VMOption nmt = bean.getVMOption("NativeMemoryTracking");
-        assertEquals("off", nmt.getValue());
+        assertEquals(nmt1.getValue(), nmt.getValue());
         assertEquals(VMOption.Origin.DEFAULT, nmt.getOrigin());
     }
 }

--- a/test/lib/jdk/test/lib/crac/CracBuilder.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilder.java
@@ -116,6 +116,10 @@ public class CracBuilder {
         return this;
     }
 
+    public void clearVmOptions() {
+        vmOptions.clear();
+    }
+
     public CracBuilder printResources(boolean print) {
         this.printResources = print;
         return this;


### PR DESCRIPTION
test/jdk/jdk/crac/VMOptionsTest.java fails in debug build because it expects that NativeMemoryTracking equals to"off", that is not true in debug build.

```
Exception in thread "main" java.lang.RuntimeException: assertEquals: expected off to equal summary
    at jdk.test.lib.Asserts.fail(Asserts.java:594)
    at jdk.test.lib.Asserts.assertEquals(Asserts.java:205)
    at jdk.test.lib.Asserts.assertEquals(Asserts.java:189)
    at VMOptionsTest.exec(VMOptionsTest.java:60)
    at jdk.test.lib.crac.CracTest.run(CracTest.java:155)
    at jdk.test.lib.crac.CracTest.main(CracTest.java:87)
```

This change fixes the issue by retrieving NMT value before checkpoint, and comparing later.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/81/head:pull/81` \
`$ git checkout pull/81`

Update a local copy of the PR: \
`$ git checkout pull/81` \
`$ git pull https://git.openjdk.org/crac.git pull/81/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 81`

View PR using the GUI difftool: \
`$ git pr show -t 81`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/81.diff">https://git.openjdk.org/crac/pull/81.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/81#issuecomment-1589308428)