### PR TITLE
Fix recursiveCheckpoint/Test passing extra comma

### DIFF
--- a/test/lib/jdk/test/lib/crac/CracBuilder.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilder.java
@@ -335,8 +335,10 @@ public class CracBuilder {
         }
         cmd.add("-ea");
         if (engine != null) {
-            String engArgs = engineArgs == null ? "" : "," + Arrays.stream(engineArgs)
-                    .map(str -> str.replace(",", "\\,")).collect(Collectors.joining(","));
+            String engArgs = engineArgs == null || engineArgs.length == 0 ? "" :
+                    "," + Arrays.stream(engineArgs)
+                            .map(str -> str.replace(",", "\\,"))
+                            .collect(Collectors.joining(","));
             cmd.add("-XX:CREngine=" + engine.engine + engArgs);
         }
         if (!isRestore) {


### PR DESCRIPTION
Caused by ddf6a0550ddb2d6aa61640bb82317c003e52df3d

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Roman Marchenko](https://openjdk.org/census#rmarchenko) (@wkia - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/83/head:pull/83` \
`$ git checkout pull/83`

Update a local copy of the PR: \
`$ git checkout pull/83` \
`$ git pull https://git.openjdk.org/crac.git pull/83/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 83`

View PR using the GUI difftool: \
`$ git pr show -t 83`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/83.diff">https://git.openjdk.org/crac/pull/83.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/83#issuecomment-1594452788)