### PR TITLE
Selectable Global Context implementation

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -249,8 +249,6 @@ public abstract class Reference<T> {
     private static final Object processPendingLock = new Object();
     private static boolean processPendingActive = false;
 
-    private static JDKResource referenceHandlerResource;
-
     private static void processPendingReferences() {
         // Only the singleton reference processing thread calls
         // waitForReferencePendingList() and getAndClearReferencePendingList().
@@ -343,20 +341,6 @@ public abstract class Reference<T> {
                 queue.wakeup();
             }
         });
-
-        referenceHandlerResource = new JDKResource() {
-            @Override
-            public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
-                System.gc();
-                // TODO ensure GC done processing all References
-                while (waitForReferenceProcessing());
-            }
-
-            @Override
-            public void afterRestore(Context<? extends Resource> context) throws Exception {
-            }
-        };
-        Core.Priority.REFERENCE_HANDLER.getContext().register(referenceHandlerResource);
     }
 
     /* -- Referent accessor and setters -- */

--- a/src/java.base/share/classes/javax/crac/Core.java
+++ b/src/java.base/share/classes/javax/crac/Core.java
@@ -38,7 +38,9 @@ public class Core {
     private Core() {
     }
 
-    private static final Context<Resource> globalContext = new ContextWrapper(new BlockingOrderedContext<>());
+    private static final Context<Resource> globalContext = new ContextWrapper(
+        jdk.crac.impl.GlobalContext.createGlobalContextImpl());
+
     static {
         jdk.crac.Core.getGlobalContext().register(new ResourceWrapper(null, globalContext));
     }

--- a/src/java.base/share/classes/jdk/crac/Core.java
+++ b/src/java.base/share/classes/jdk/crac/Core.java
@@ -88,8 +88,15 @@ public class Core {
 
         private static ReferenceHandlerResource resource = new ReferenceHandlerResource();
 
-        public static void register() {
+        static {
             jdk.internal.crac.Core.Priority.REFERENCE_HANDLER.getContext().register(resource);
+        }
+
+        /**
+         * Performs one-time registration of the Reference handling resource
+         */
+        public static void register() {
+            // nothing to do: the resource registered in the static initializer
         }
     }
 

--- a/src/java.base/share/classes/jdk/crac/impl/GlobalContext.java
+++ b/src/java.base/share/classes/jdk/crac/impl/GlobalContext.java
@@ -1,0 +1,22 @@
+package jdk.crac.impl;
+
+import jdk.crac.Context;
+import jdk.crac.Resource;
+import sun.security.action.GetPropertyAction;
+
+public class GlobalContext {
+    private static final String GLOBAL_CONTEXT_IMPL_PROP = "jdk.crac.globalContext.impl";
+    private static final String GLOBAL_CONTEXT_IMPL_NAME =
+        GetPropertyAction.privilegedGetProperty(GLOBAL_CONTEXT_IMPL_PROP, "OrderedContext");
+
+    public static Context<Resource> createGlobalContextImpl() {
+        return switch (GLOBAL_CONTEXT_IMPL_NAME) {
+            case "BlockingOrderedContext" -> new BlockingOrderedContext<>();
+            case "OrderedContext" -> new OrderedContext<>();
+            default -> {
+                System.err.println("Unknown " + GLOBAL_CONTEXT_IMPL_PROP + "=" + GLOBAL_CONTEXT_IMPL_NAME);
+                yield new OrderedContext<>();
+            }
+        };
+    }
+}

--- a/src/java.base/share/classes/jdk/crac/impl/GlobalContext.java
+++ b/src/java.base/share/classes/jdk/crac/impl/GlobalContext.java
@@ -7,16 +7,13 @@ import sun.security.action.GetPropertyAction;
 public class GlobalContext {
     private static final String GLOBAL_CONTEXT_IMPL_PROP = "jdk.crac.globalContext.impl";
     private static final String GLOBAL_CONTEXT_IMPL_NAME =
-        GetPropertyAction.privilegedGetProperty(GLOBAL_CONTEXT_IMPL_PROP, "OrderedContext");
+        GetPropertyAction.privilegedGetProperty(GLOBAL_CONTEXT_IMPL_PROP, "");
 
     public static Context<Resource> createGlobalContextImpl() {
         return switch (GLOBAL_CONTEXT_IMPL_NAME) {
             case "BlockingOrderedContext" -> new BlockingOrderedContext<>();
             case "OrderedContext" -> new OrderedContext<>();
-            default -> {
-                System.err.println("Unknown " + GLOBAL_CONTEXT_IMPL_PROP + "=" + GLOBAL_CONTEXT_IMPL_NAME);
-                yield new OrderedContext<>();
-            }
+            default -> new OrderedContext<>(); // cannot report as System.out/err are not initialized yet
         };
     }
 }


### PR DESCRIPTION
A number of problems were caused by switching to BlockingOrderedContext in the JDK code. To prevent the same in the potential users of EA builds, I temporarily switch the default implementation to the previous OrderedContext. The BlockingContext is still available via a command line option. After an EA build and transition of CRaC development to track newer version openjdk/jdk, the default implementation will be changed.

To make properties available, it was required to delay Reference resource registration. Otherwise, the GlobalContext implementation decision had to be done too early, in the Reference initialization during JDK bootstrapping, before Properties are available.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/87/head:pull/87` \
`$ git checkout pull/87`

Update a local copy of the PR: \
`$ git checkout pull/87` \
`$ git pull https://git.openjdk.org/crac.git pull/87/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 87`

View PR using the GUI difftool: \
`$ git pr show -t 87`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/87.diff">https://git.openjdk.org/crac/pull/87.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/87#issuecomment-1607812672)