### PR TITLE
Fix JVMCI after #41

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1158,9 +1158,9 @@ void VM_Version::glibc_not_using(uint64_t excessive_CPU, uint64_t excessive_GLIB
   GLIBC_UNSUPPORTED(GLIBC, F16C             );
 #undef GLIBC_UNSUPPORTED
 #define CHECK_KIND(kind) do {                                                                                                                 \
-    if (PASTE_TOKENS(excessive_handled_, kind) != PASTE_TOKENS(kind, _MAX) - 1)                                                               \
+    if (PASTE_TOKENS(excessive_handled_, kind) != PASTE_TOKENS(MAX_, kind) - 1)                                                               \
       vm_exit_during_initialization(err_msg("internal error: Unsupported disabling of some " STR(kind) "_* 0x%" PRIx64 " != full 0x%" PRIx64, \
-                                            PASTE_TOKENS(excessive_handled_, kind), CPU_MAX - 1));                                            \
+                                            PASTE_TOKENS(excessive_handled_, kind), PASTE_TOKENS(MAX_, kind) - 1));                           \
   } while (0)
   CHECK_KIND(CPU  );
   CHECK_KIND(GLIBC);
@@ -2493,11 +2493,11 @@ void VM_Version::fatal_missing_features(uint64_t features_missing, uint64_t glib
   tty->print_raw(part2, sizeof(part2) - 1);
   char buf[512] = "";
   // insert_features_names() does crash for undefined too high-numbered features.
-  insert_features_names(buf, sizeof(buf)          ,       features_missing & (  CPU_MAX - 1));
+  insert_features_names(buf, sizeof(buf)          ,       features_missing & (  MAX_CPU - 1));
   char *s = buf;
   while (*s)
     ++s;
-  insert_features_names(s  , buf + sizeof(buf) - s, glibc_features_missing & (GLIBC_MAX - 1));
+  insert_features_names(s  , buf + sizeof(buf) - s, glibc_features_missing & (MAX_GLIBC - 1));
   while (*s)
     ++s;
   /* +1 to skip the first ','. */
@@ -2608,8 +2608,8 @@ void VM_Version::initialize() {
     print_using_features_cr();
 
   if (!ignore_glibc_not_using) {
-    uint64_t       features_expected =   CPU_MAX - 1;
-    uint64_t glibc_features_expected = GLIBC_MAX - 1;
+    uint64_t       features_expected =   MAX_CPU - 1;
+    uint64_t glibc_features_expected = MAX_GLIBC - 1;
 #if !INCLUDE_CPU_FEATURE_ACTIVE && !INCLUDE_LD_SO_LIST_DIAGNOSTICS
           features_expected =       features_saved;
     glibc_features_expected = glibc_features_saved;

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -370,12 +370,11 @@ protected:
     decl(AVX512_VBMI2,      "avx512_vbmi2",      44) /* VBMI2 shift left double instructions */ \
     decl(AVX512_VBMI,       "avx512_vbmi",       45) /* Vector BMI instructions */ \
     decl(HV,                "hv",                46) /* Hypervisor instructions */ \
-                                                     \
-    decl(MAX,               "max",               47) /* Maximum - this feature must never be used */
 
 #define DECLARE_CPU_FEATURE_FLAG(id, name, bit) CPU_##id = (1ULL << bit),
     CPU_FEATURE_FLAGS(DECLARE_CPU_FEATURE_FLAG)
 #undef DECLARE_CPU_FEATURE_FLAG
+    MAX_CPU = CPU_HV << 1
   };
 
   /* Tracking of a CPU feature for glibc */ \
@@ -391,11 +390,11 @@ protected:
     decl(LAHFSAHF,          "lahfsahf",           7) /* Also known in cpuinfo as lahf_lm and in glibc as lahf64_sahf64 */ \
     decl(F16C,              "f16c",               8) \
     decl(HTT,               "htt",                9) /* hotspot calls it 'ht' but it is affected by threads_per_core() */ \
-                                                     \
-    decl(MAX,               "max",               10) /* Maximum - this feature must never be used */
+
 #define DECLARE_GLIBC_FEATURE_FLAG(id, name, bit) GLIBC_##id = (1ULL << bit),
     GLIBC_FEATURE_FLAGS(DECLARE_GLIBC_FEATURE_FLAG)
 #undef DECLARE_GLIBC_FEATURE_FLAG
+    MAX_GLIBC = GLIBC_HTT << 1
   };
 
   // glibc feature flags.


### PR DESCRIPTION
The recently added CPU_MAX feature went out of sync with JVMCI code [1].  Since this is not a real feature, but auxilary value, a distinct name for the maximum value solves the issue. 

[1] jtreg_test_hotspot_jtreg_tier1_compiler/compiler/jvmci/JVM_GetJVMCIRuntimeTest.jtr:
```
jdk.vm.ci.common.JVMCIError: Missing CPU feature constants: [MAX]
        at jdk.internal.vm.ci/jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory.convertFeatures(HotSpotJVMCIBackendFactory.java:79)
        at jdk.internal.vm.ci/jdk.vm.ci.hotspot.amd64.AMD64HotSpotJVMCIBackendFactory.computeFeatures(AMD64HotSpotJVMCIBackendFactory.java:53)
        at jdk.internal.vm.ci/jdk.vm.ci.hotspot.amd64.AMD64HotSpotJVMCIBackendFactory.createTarget(AMD64HotSpotJVMCIBackendFactory.java:74)
        at jdk.internal.vm.ci/jdk.vm.ci.hotspot.amd64.AMD64HotSpotJVMCIBackendFactory.createJVMCIBackend(AMD64HotSpotJVMCIBackendFactory.java:109)
        at jdk.internal.vm.ci/jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.<init>(HotSpotJVMCIRuntime.java:549)
        at jdk.internal.vm.ci/jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.runtime(HotSpotJVMCIRuntime.java:176)
        at jdk.internal.vm.ci/jdk.vm.ci.runtime.JVMCI.initializeRuntime(Native Method)
        at jdk.internal.vm.ci/jdk.vm.ci.runtime.JVMCI.getRuntime(JVMCI.java:65)
        at compiler.jvmci.JVM_GetJVMCIRuntimeTest.run(JVM_GetJVMCIRuntimeTest.java:77)
        at compiler.jvmci.JVM_GetJVMCIRuntimeTest.main(JVM_GetJVMCIRuntimeTest.java:70)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Roman Marchenko](https://openjdk.org/census#rmarchenko) (@wkia - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/88/head:pull/88` \
`$ git checkout pull/88`

Update a local copy of the PR: \
`$ git checkout pull/88` \
`$ git pull https://git.openjdk.org/crac.git pull/88/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 88`

View PR using the GUI difftool: \
`$ git pr show -t 88`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/88.diff">https://git.openjdk.org/crac/pull/88.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/88#issuecomment-1611300488)