### PR TITLE
Workaround JDK-8311164: CPU_HT is set randomly on hybrid CPUs like Alder Lake

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -2533,6 +2533,10 @@ void VM_Version::crac_restore() {
 
   uint64_t       features_missing =       features_saved & ~      _features;
   uint64_t glibc_features_missing = glibc_features_saved & ~_glibc_features;
+
+  // Workaround JDK-8311164: CPU_HT is set randomly on hybrid CPUs like Alder Lake.
+  features_missing &= ~CPU_HT;
+
   if (features_missing || glibc_features_missing) {
     static const char part1[] = "You have to specify -XX:CPUFeatures=";
     tty->print_raw(part1, sizeof(part1) - 1);
@@ -2588,6 +2592,10 @@ void VM_Version::initialize() {
   uint64_t   CPUFeatures_x64 = CPUFeatures_parse(GLIBCFeatures_x64);
   uint64_t       features_missing =   CPUFeatures_x64 & ~      _features;
   uint64_t glibc_features_missing = GLIBCFeatures_x64 & ~_glibc_features;
+
+  // Workaround JDK-8311164: CPU_HT is set randomly on hybrid CPUs like Alder Lake.
+  features_missing &= ~CPU_HT;
+
   if (features_missing || glibc_features_missing) {
     static const char part1[] = "Specified -XX:CPUFeatures=";
     tty->print_raw(part1, sizeof(part1) - 1);


### PR DESCRIPTION
SSIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/89/head:pull/89` \
`$ git checkout pull/89`

Update a local copy of the PR: \
`$ git checkout pull/89` \
`$ git pull https://git.openjdk.org/crac.git pull/89/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 89`

View PR using the GUI difftool: \
`$ git pr show -t 89`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/89.diff">https://git.openjdk.org/crac/pull/89.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/89#issuecomment-1614457379)