### PR TITLE
macOS build fixes

### DIFF
--- a/src/hotspot/share/services/writeableFlags.cpp
+++ b/src/hotspot/share/services/writeableFlags.cpp
@@ -236,7 +236,7 @@ JVMFlag::Error WriteableFlags::set_flag(const char* name, const void* value, JVM
   JVMFlag* f = JVMFlag::find_flag(name);
   if (f) {
     // only writeable or restore_settable flags are allowed to be set
-    if (f->is_writeable() || f->is_restore_settable() && origin == JVMFlagOrigin::CRAC_RESTORE) {
+    if (f->is_writeable() || (f->is_restore_settable() && origin == JVMFlagOrigin::CRAC_RESTORE)) {
       return setter(f, value, origin, err_msg);
     } else {
       err_msg.print("only 'writeable' flags can be set");

--- a/src/java.base/unix/native/libjava/FileDescriptor_md.c
+++ b/src/java.base/unix/native/libjava/FileDescriptor_md.c
@@ -144,6 +144,9 @@ static char* fmtaddr(char *buf, const char *end, unsigned char* addr, int len) {
     return buf;
 }
 
+#ifdef __APPLE__
+__attribute__((__format__ (__printf__, 3, 0)))
+#endif
 static jstring format_string(JNIEnv *env, struct stat *st, const char *fmt, ...) {
     char details[PATH_MAX];
     va_list va;
@@ -179,12 +182,13 @@ Java_java_io_FileDescriptor_nativeDescription0(JNIEnv *env, jobject this) {
         return format_string(env, &st, "%s: %s", stat2strtype(st.st_mode), link);
     }
 
-    int family;
-    socklen_t famlen = sizeof(int);
-    if (getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &family, &famlen) != 0) {
+    struct sockaddr sa;
+    socklen_t slen = sizeof(sa);
+    if (getsockname(fd, &sa, &slen) != 0) {
         return format_string(env, &st, "socket: %s", link);
     }
 
+    const int family = sa.sa_family;
     int socktype;
     socklen_t typelen = sizeof(int);
     if (getsockopt(fd, SOL_SOCKET, SO_TYPE, &socktype, &typelen) != 0) {

--- a/src/java.base/unix/native/libjava/FileDescriptor_md.c
+++ b/src/java.base/unix/native/libjava/FileDescriptor_md.c
@@ -144,9 +144,7 @@ static char* fmtaddr(char *buf, const char *end, unsigned char* addr, int len) {
     return buf;
 }
 
-#ifdef __APPLE__
 __attribute__((__format__ (__printf__, 3, 0)))
-#endif
 static jstring format_string(JNIEnv *env, struct stat *st, const char *fmt, ...) {
     char details[PATH_MAX];
     va_list va;


### PR DESCRIPTION
This changeset fixes build warnings and errors occured on macOS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/92/head:pull/92` \
`$ git checkout pull/92`

Update a local copy of the PR: \
`$ git checkout pull/92` \
`$ git pull https://git.openjdk.org/crac.git pull/92/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 92`

View PR using the GUI difftool: \
`$ git pr show -t 92`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/92.diff">https://git.openjdk.org/crac/pull/92.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/92#issuecomment-1647820421)