### PR TITLE
merge compiler warning fixes from jdk17u-dev

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -459,7 +459,7 @@ else
 
    HARFBUZZ_DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing
    HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
-        maybe-uninitialized class-memaccess unused-result extra
+        maybe-uninitialized class-memaccess unused-result extra use-after-free
    HARFBUZZ_DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
         tautological-constant-out-of-range-compare int-to-pointer-cast \
         undef missing-field-initializers range-loop-analysis \

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -594,7 +594,7 @@ void ErrorContext::stackmap_details(outputStream* ss, const Method* method) cons
 
 ClassVerifier::ClassVerifier(JavaThread* current, InstanceKlass* klass)
     : _thread(current), _previous_symbol(NULL), _symbols(NULL), _exception_type(NULL),
-      _message(NULL), _method_signatures_table(NULL), _klass(klass) {
+      _message(NULL), _klass(klass) {
   _this_type = VerificationType::reference_type(klass->name());
 }
 
@@ -625,16 +625,12 @@ void ClassVerifier::verify_class(TRAPS) {
   // Either verifying both local and remote classes or just remote classes.
   assert(BytecodeVerificationRemote, "Should not be here");
 
-  // Create hash table containing method signatures.
-  method_signatures_table_type method_signatures_table;
-  set_method_signatures_table(&method_signatures_table);
-
   Array<Method*>* methods = _klass->methods();
   int num_methods = methods->length();
 
   for (int index = 0; index < num_methods; index++) {
     // Check for recursive re-verification before each method.
-    if (was_recursively_verified())  return;
+    if (was_recursively_verified()) return;
 
     Method* m = methods->at(index);
     if (m->is_native() || m->is_abstract() || m->is_overpass()) {

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -286,7 +286,7 @@ class ClassVerifier : public StackObj {
   Symbol* _exception_type;
   char* _message;
 
-  method_signatures_table_type* _method_signatures_table;
+  method_signatures_table_type _method_signatures_table;
 
   ErrorContext _error_context;  // contains information about an error
 
@@ -438,12 +438,8 @@ class ClassVerifier : public StackObj {
 
   Klass* load_class(Symbol* name, TRAPS);
 
-  method_signatures_table_type* method_signatures_table() const {
-    return _method_signatures_table;
-  }
-
-  void set_method_signatures_table(method_signatures_table_type* method_signatures_table) {
-    _method_signatures_table = method_signatures_table;
+  method_signatures_table_type* method_signatures_table() {
+    return &_method_signatures_table;
   }
 
   int change_sig_to_verificationType(

--- a/src/hotspot/share/gc/z/zReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/z/zReferenceProcessor.cpp
@@ -59,7 +59,7 @@ static const char* reference_type_name(ReferenceType type) {
 
   default:
     ShouldNotReachHere();
-    return NULL;
+    return "Unknown";
   }
 }
 

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdBits.inline.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdBits.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,7 +132,15 @@ inline void set(jbyte bits, jbyte* dest) {
 template <typename T>
 inline void JfrTraceIdBits::store(jbyte bits, const T* ptr) {
   assert(ptr != NULL, "invariant");
+  // gcc12 warns "writing 1 byte into a region of size 0" when T == Klass.
+  // The warning seems to be a false positive.  And there is no warning for
+  // other types that use the same mechanisms.  The warning also sometimes
+  // goes away with minor code perturbations, such as replacing function calls
+  // with equivalent code directly inlined.
+  PRAGMA_DIAG_PUSH
+  PRAGMA_DISABLE_GCC_WARNING("-Wstringop-overflow")
   set(bits, traceid_tag_byte(ptr));
+  PRAGMA_DIAG_POP
 }
 
 template <typename T>

--- a/src/hotspot/share/oops/array.hpp
+++ b/src/hotspot/share/oops/array.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,7 +91,7 @@ protected:
   Array(int length, T init) : _length(length) {
     assert(length >= 0, "illegal length");
     for (int i = 0; i < length; i++) {
-      _data[i] = init;
+      data()[i] = init;
     }
   }
 
@@ -99,12 +99,22 @@ protected:
 
   // standard operations
   int  length() const                 { return _length; }
-  T* data()                           { return _data; }
+
+  T* data() {
+    return reinterpret_cast<T*>(
+      reinterpret_cast<char*>(this) + base_offset_in_bytes());
+  }
+
+  const T* data() const {
+    return reinterpret_cast<const T*>(
+      reinterpret_cast<const char*>(this) + base_offset_in_bytes());
+  }
+
   bool is_empty() const               { return length() == 0; }
 
   int index_of(const T& x) const {
     int i = length();
-    while (i-- > 0 && _data[i] != x) ;
+    while (i-- > 0 && data()[i] != x) ;
 
     return i;
   }
@@ -112,9 +122,9 @@ protected:
   // sort the array.
   bool contains(const T& x) const      { return index_of(x) >= 0; }
 
-  T    at(int i) const                 { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); return _data[i]; }
-  void at_put(const int i, const T& x) { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); _data[i] = x; }
-  T*   adr_at(const int i)             { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); return &_data[i]; }
+  T    at(int i) const                 { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); return data()[i]; }
+  void at_put(const int i, const T& x) { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); data()[i] = x; }
+  T*   adr_at(const int i)             { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); return &data()[i]; }
   int  find(const T& x)                { return index_of(x); }
 
   T at_acquire(const int i)            { return Atomic::load_acquire(adr_at(i)); }

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -718,9 +718,13 @@ inline bool is_floating_point_type(BasicType t) {
 extern char type2char_tab[T_CONFLICT+1];     // Map a BasicType to a jchar
 inline char type2char(BasicType t) { return (uint)t < T_CONFLICT+1 ? type2char_tab[t] : 0; }
 extern int type2size[T_CONFLICT+1];         // Map BasicType to result stack elements
-extern const char* type2name_tab[T_CONFLICT+1];     // Map a BasicType to a jchar
-inline const char* type2name(BasicType t) { return (uint)t < T_CONFLICT+1 ? type2name_tab[t] : NULL; }
+extern const char* type2name_tab[T_CONFLICT+1];     // Map a BasicType to a char*
 extern BasicType name2type(const char* name);
+
+inline const char* type2name(BasicType t) {
+  assert((uint)t < T_CONFLICT + 1, "invalid type");
+  return type2name_tab[t];
+}
 
 inline jlong max_signed_integer(BasicType bt) {
   if (bt == T_INT) {

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,8 @@
  * the CreateExecutionEnviroment will remove the -d<n> flags.
  */
 
+
+#include <assert.h>
 
 #include "java.h"
 #include "jni.h"
@@ -1708,7 +1710,8 @@ TranslateApplicationArgs(int jargc, const char **jargv, int *pargc, char ***parg
     for (i = 0; i < jargc; i++) {
         const char *arg = jargv[i];
         if (arg[0] == '-' && arg[1] == 'J') {
-            *nargv++ = ((arg + 2) == NULL) ? NULL : JLI_StringDup(arg + 2);
+            assert(arg[2] != '\0' && "Invalid JAVA_ARGS or EXTRA_JAVA_ARGS defined by build");
+            *nargv++ = JLI_StringDup(arg + 2);
         }
     }
 

--- a/src/java.base/share/native/libjli/parse_manifest.c
+++ b/src/java.base/share/native/libjli/parse_manifest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -288,8 +288,8 @@ find_positions(int fd, Byte *eb, jlong* base_offset, jlong* censtart)
     for (cp = &buffer[bytes - ENDHDR]; cp >= &buffer[0]; cp--)
         if (ENDSIG_AT(cp) && (cp + ENDHDR + ENDCOM(cp) == endpos)) {
             (void) memcpy(eb, cp, ENDHDR);
-            free(buffer);
             pos = flen - (endpos - cp);
+            free(buffer);
             return find_positions64(fd, eb, pos, base_offset, censtart);
         }
     free(buffer);

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,10 +119,13 @@ ProgramExists(char *name)
 static char *
 Resolve(char *indir, char *cmd)
 {
-    char name[PATH_MAX + 2], *real;
+    char name[PATH_MAX + 1], *real;
+    int snprintf_result;
 
-    if ((JLI_StrLen(indir) + JLI_StrLen(cmd) + 1)  > PATH_MAX) return 0;
-    JLI_Snprintf(name, sizeof(name), "%s%c%s", indir, FILE_SEPARATOR, cmd);
+    snprintf_result = JLI_Snprintf(name, sizeof(name), "%s%c%s", indir, FILE_SEPARATOR, cmd);
+    if ((snprintf_result < 0) || (snprintf_result >= (int)sizeof(name))) {
+      return NULL;
+    }
     if (!ProgramExists(name)) return 0;
     real = JLI_MemAlloc(PATH_MAX + 2);
     if (!realpath(name, real))

--- a/src/jdk.jpackage/linux/native/applauncher/LinuxPackage.c
+++ b/src/jdk.jpackage/linux/native/applauncher/LinuxPackage.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <linux/limits.h>
@@ -123,6 +124,7 @@ static int popenCommand(const char* cmdlineFormat, const char* arg,
     int callbackMode = POPEN_CALLBACK_USE;
     int exitCode = -1;
     int c;
+    ptrdiff_t char_offset;
 
     cmdline = malloc(cmdlineLenth + 1 /* \0 */);
     if (!cmdline) {
@@ -171,13 +173,14 @@ static int popenCommand(const char* cmdlineFormat, const char* arg,
         if (strBufNextChar == strBufEnd) {
             /* Double buffer size */
             strBufCapacity = strBufCapacity * 2 + 1;
+            char_offset = strBufNextChar - strBufBegin;
             strNewBufBegin = realloc(strBufBegin, strBufCapacity);
             if (!strNewBufBegin) {
                 JP_LOG_ERRNO;
                 goto cleanup;
             }
 
-            strBufNextChar = strNewBufBegin + (strBufNextChar - strBufBegin);
+            strBufNextChar = strNewBufBegin + char_offset;
             strBufEnd = strNewBufBegin + strBufCapacity;
             strBufBegin = strNewBufBegin;
         }


### PR DESCRIPTION
```
../../src/hotspot/share/gc/z/zReferenceProcessor.cpp: In member function 'oopDesc* ZReferenceProcessor::drop(oop, ReferenceType)':
../../src/hotspot/share/gc/z/zReferenceProcessor.cpp:270:22: error: '%s' directive argument is null [-Werror=format-overflow=]
  270 |   log_trace(gc, ref)("Dropped Reference: " PTR_FORMAT " (%s)", p2i(reference), reference_type_name(type));
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
commit 68456bb248378da2ada5ecb6de92302988115b7c
Author: Aleksey Shipilev <shade@openjdk.org>
Date:   Thu Jun 23 15:49:41 2022 +0000
    8288754: GCC 12 fails to build zReferenceProcessor.cpp
    Backport-of: 834d92dd72257ab5d8c6759028098ac0867c5752

../src/java.base/unix/native/libjli/java_md_common.c: In function 'Resolve':
../src/java.base/unix/native/libjli/java_md_common.c:125:43: error: '%s' directive output may be truncated writing up to 4095 bytes into a region of size between 2 and 4097 [-Werror=format-truncation=]
  125 |     JLI_Snprintf(name, sizeof(name), "%s%c%s", indir, FILE_SEPARATOR, cmd);
      |                                           ^~
In file included from ../src/java.base/unix/native/libjli/java_md.h:38,
                 from ../src/java.base/share/native/libjli/java.h:41,
                 from ../src/java.base/unix/native/libjli/java_md_common.c:26:
../src/java.base/share/native/libjli/jli_util.h:103:41: note: 'snprintf' output between 2 and 8192 bytes into a destination of size 4098
  103 | #define JLI_Snprintf                    snprintf
../src/java.base/unix/native/libjli/java_md_common.c:125:5: note: in expansion of macro 'JLI_Snprintf'
  125 |     JLI_Snprintf(name, sizeof(name), "%s%c%s", indir, FILE_SEPARATOR, cmd);
      |     ^~~~~~~~~~~~
cc1: all warnings being treated as errors
commit 46c1434d50f6f0fa371785496c4d37c0e192da16
Author: Yasumasa Suenaga <ysuenaga@openjdk.org>
Date:   Wed Jan 25 17:19:30 2023 +0000
    8286562: GCC 12 reports some compiler warnings
    Backport-of: 410a25d59a11b6a627bbb0a2c405c2c2be19f464

In function 'find_positions',
    inlined from 'find_file' at ../src/java.base/share/native/libjli/parse_manifest.c:364:9:
../src/java.base/share/native/libjli/parse_manifest.c:292:34: error: pointer 'endpos' used after 'free' [-Werror=use-after-free]
  292 |             pos = flen - (endpos - cp);
      |                          ~~~~~~~~^~~~~
../src/java.base/share/native/libjli/parse_manifest.c:291:13: note: call to 'free' here
  291 |             free(buffer);
      |             ^~~~~~~~~~~~
cc1: all warnings being treated as errors
commit 0056a6330bb2e806ea47da0c51af0ab095feb25d
Author: Yasumasa Suenaga <ysuenaga@openjdk.org>
Date:   Mon Jan 23 22:05:43 2023 +0000
    8286705: GCC 12 reports use-after-free potential bugs
    Backport-of: 0e4bece5b5143b8505496ea7430bbfa11e151aff

../src/java.base/share/native/libjli/java.c: In function 'TranslateApplicationArgs':
../src/java.base/share/native/libjli/java.c:1711:35: error: the comparison will always evaluate as 'false' for the pointer operand in 'arg + 2' must not be NULL [-Werror=address]
 1711 |             *nargv++ = ((arg + 2) == NULL) ? NULL : JLI_StringDup(arg + 2);
      |                                   ^~
cc1: all warnings being treated as errors
commit 651ba865c1afe2b29adc5b0ca428117200313912
Author: Dan Lutker <lutkerd@amazon.com>
Date:   Fri Jan 27 16:04:34 2023 +0000
    8286694: Incorrect argument processing in java launcher
    Backport-of: 26c7c92bc93f3eecf7ce69c69f1999ba879d1d60

In file included from /home/azul/azul/crac-git/src/hotspot/share/classfile/stackMapFrame.hpp:29,
                 from /home/azul/azul/crac-git/src/hotspot/share/classfile/stackMapTable.hpp:28,
                 from /home/azul/azul/crac-git/src/hotspot/share/classfile/verifier.cpp:30:
In member function 'void ClassVerifier::set_method_signatures_table(method_signatures_table_type*)',
    inlined from 'void ClassVerifier::verify_class(JavaThread*)' at /home/azul/azul/crac-git/src/hotspot/share/classfile/verifier.cpp:630:30:
/home/azul/azul/crac-git/src/hotspot/share/classfile/verifier.hpp:446:30: error: storing the address of local variable 'method_signatures_table' in '*this.ClassVerifier::_method_signatures_table' [-Werror=dangling-pointer=]
  446 |     _method_signatures_table = method_signatures_table;
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/home/azul/azul/crac-git/src/hotspot/share/classfile/verifier.cpp: In member function 'void ClassVerifier::verify_class(JavaThread*)':
/home/azul/azul/crac-git/src/hotspot/share/classfile/verifier.cpp:629:32: note: 'method_signatures_table' declared here
  629 |   method_signatures_table_type method_signatures_table;
      |                                ^~~~~~~~~~~~~~~~~~~~~~~
/home/azul/azul/crac-git/src/hotspot/share/classfile/verifier.cpp:622:39: note: 'this' declared here
  622 | void ClassVerifier::verify_class(TRAPS) {
      |                                       ^
cc1plus: all warnings being treated as errors
commit 39a6b55847be24e85a9d0e9ddb423808e7d1d57f
Author: Aleksey Shipilev <shade@openjdk.org>
Date:   Tue May 23 11:57:15 2023 +0000
    8287854: Dangling reference in ClassVerifier::verify_class
    Backport-of: 3fa99844a69401f84677e7d512ffd937f7f16898
```

Disabling warnings can lead to bugs like #94.

One could rather do a full merge with `17u-dev` but there were some conflicts so I am not sure if that is wanted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/96/head:pull/96` \
`$ git checkout pull/96`

Update a local copy of the PR: \
`$ git checkout pull/96` \
`$ git pull https://git.openjdk.org/crac.git pull/96/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 96`

View PR using the GUI difftool: \
`$ git pr show -t 96`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/96.diff">https://git.openjdk.org/crac/pull/96.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/96#issuecomment-1656919116)