### PR TITLE
Print better diagnostics for spawning CRIU

### DIFF
--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -200,7 +200,10 @@ static int call_crengine() {
   }
   _crengine_args[1] = "checkpoint";
   add_crengine_arg(CRaCCheckpointTo);
-  return os::exec_child_process_and_wait(_crengine, _crengine_args);
+  if (os::exec_child_process_and_wait(_crengine, _crengine_args) == 0)
+    return 0;
+  fprintf(stderr, "CRaC error executing: %s\n", _crengine);
+  return -1;
 }
 
 static int checkpoint_restore(int *shmid) {


### PR DESCRIPTION
It was always a mystery why it does not work this time as there are no error messages printed.
Still may system call errors are currently not reported but those errors at least do not happen commonly.
In fact `os::exec_child_process_and_wait` should be more verbose but that is already a part of OpenJDK so I did not modify it.
It would be much easier if `criuengine.c` was in C++. I was considering to switch it but then I wrote it already in C.
I understand this code will become obsolete after planned integration of CRIU into JVM but it may not yet be soon enough.
