### PR TITLE
C++ize criuengine

### DIFF
--- a/make/modules/java.base/Launcher.gmk
+++ b/make/modules/java.base/Launcher.gmk
@@ -93,10 +93,11 @@ ifeq ($(OPENJDK_TARGET_OS), linux)
   $(eval $(call SetupJdkExecutable, BUILD_CRIUENGINE, \
       NAME := criuengine, \
       SRC := $(TOPDIR)/src/$(MODULE)/unix/native/criuengine, \
-      INCLUDE_FILES := criuengine.c, \
+      INCLUDE_FILES := criuengine.cpp, \
       OPTIMIZATION := HIGH, \
-      CFLAGS := $(CFLAGS_JDKEXE), \
+      CXXFLAGS := $(CXXFLAGS_JDKEXE), \
       LDFLAGS := $(LDFLAGS_JDKEXE), \
+      LD := $(LDCXX), \
       OUTPUT_DIR := $(SUPPORT_OUTPUTDIR)/modules_libs/$(MODULE), \
   ))
   TARGETS += $(BUILD_CRIUENGINE)

--- a/src/java.base/unix/native/criuengine/criuengine.cpp
+++ b/src/java.base/unix/native/criuengine/criuengine.cpp
@@ -38,6 +38,8 @@
 #include <signal.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
+#include <string>
+#include <vector>
 
 #define RESTORE_SIGNAL   (SIGRTMIN + 2)
 
@@ -99,40 +101,36 @@ static int checkpoint(pid_t jvm,
     char jvmpidchar[32];
     snprintf(jvmpidchar, sizeof(jvmpidchar), "%d", jvm);
 
+    std::vector<const char *> args = {
+        criu,
+        "dump",
+        "-t", jvmpidchar,
+        "-D", imagedir,
+        "--shell-job",
+    };
+
+    args.push_back(verbosity != NULL ? verbosity : "-v4");
+    args.push_back("-o");
+    // -D without -W makes criu cd to image dir for logs
+    args.push_back(log_file != NULL ? log_file : "dump4.log");
+
+    if (leave_running) {
+        args.push_back("-R");
+    }
+
+    char *criuopts = getenv("CRAC_CRIU_OPTS");
+    if (criuopts) {
+        char* criuopt = strtok(criuopts, " ");
+        while (criuopt) {
+            args.push_back(criuopt);
+            criuopt = strtok(NULL, " ");
+        }
+    }
+    args.push_back(NULL);
+
     pid_t child = fork();
     if (!child) {
-        const char* args[32] = {
-            criu,
-            "dump",
-            "-t", jvmpidchar,
-            "-D", imagedir,
-            "--shell-job",
-        };
-        const char** arg = args + 7;
-
-        *arg++ = verbosity != NULL ? verbosity : "-v4";
-        *arg++ = "-o";
-        // -D without -W makes criu cd to image dir for logs
-        *arg++ = log_file != NULL ? log_file : "dump4.log";
-
-        if (leave_running) {
-            *arg++ = "-R";
-        }
-
-        char *criuopts = getenv("CRAC_CRIU_OPTS");
-        if (criuopts) {
-            char* criuopt = strtok(criuopts, " ");
-            while (criuopt && ARRAY_SIZE(args) >= (size_t)(arg - args) + 1/* account for trailing NULL */) {
-                *arg++ = criuopt;
-                criuopt = strtok(NULL, " ");
-            }
-            if (criuopt) {
-                fprintf(stderr, "Warning: too many arguments in CRAC_CRIU_OPTS (dropped from '%s')\n", criuopt);
-            }
-        }
-        *arg++ = NULL;
-
-        execv(criu, (char**)args);
+        execv(criu, const_cast<char **>(args.data()));
         perror("criu dump");
         exit(1);
     }
@@ -152,12 +150,9 @@ static int restore(const char *basedir,
         const char *self,
         const char *criu,
         const char *imagedir) {
-    char *cppathpath;
-    if (-1 == asprintf(&cppathpath, "%s/cppath", imagedir)) {
-        return 1;
-    }
+    std::string cppathpath = std::string(imagedir) + "/cppath";
 
-    int fd = open(cppathpath, O_RDONLY);
+    int fd = open(cppathpath.c_str(), O_RDONLY);
     if (fd < 0) {
         perror("open cppath");
         return 1;
@@ -180,21 +175,14 @@ static int restore(const char *basedir,
 
     close(fd);
 
-    char *inherit_perfdata = NULL;
-    char *perfdatapath;
-    if (-1 == asprintf(&perfdatapath, "%s/" PERFDATA_NAME, imagedir)) {
-        return 1;
-    }
-    int perfdatafd = open(perfdatapath, O_RDWR);
+    std::string inherit_perfdata;
+    std::string perfdatapath = std::string(imagedir) + "/" PERFDATA_NAME;
+    int perfdatafd = open(perfdatapath.c_str(), O_RDWR);
     if (0 < perfdatafd) {
-        if (-1 == asprintf(&inherit_perfdata, "fd[%d]:%s/" PERFDATA_NAME,
-                    perfdatafd,
-                    cppath[0] == '/' ? cppath + 1 : cppath)) {
-            return 1;
-        }
+        inherit_perfdata = "fd[" + std::to_string(perfdatafd) + "]:" + std::string(cppath[0] == '/' ? cppath + 1 : cppath) + "/" PERFDATA_NAME;
     }
 
-    const char* args[32] = {
+    std::vector<const char *> args = {
         criu,
         "restore",
         "-W", ".",
@@ -202,39 +190,34 @@ static int restore(const char *basedir,
         "--action-script", self,
         "-D", imagedir,
     };
-    const char** arg = args + 9;
 
-    *arg++ = verbosity != NULL ? verbosity : "-v1";
+    args.push_back(verbosity != NULL ? verbosity : "-v1");
     if (log_file != NULL) {
-        *arg++ = "-o";
-        *arg++ = log_file;
+        args.push_back("-o");
+        args.push_back(log_file);
     }
 
-    if (inherit_perfdata) {
-        *arg++ = "--inherit-fd";
-        *arg++ = inherit_perfdata;
+    if (!inherit_perfdata.empty()) {
+        args.push_back("--inherit-fd");
+        args.push_back(inherit_perfdata.c_str());
     }
-    const char* tail[] = {
-        "--exec-cmd", "--", self, "restorewait",
-        NULL
-    };
     char *criuopts = getenv("CRAC_CRIU_OPTS");
     if (criuopts) {
         char* criuopt = strtok(criuopts, " ");
-        while (criuopt && ARRAY_SIZE(args) >= (size_t)(arg - args + ARRAY_SIZE(tail))) {
-            *arg++ = criuopt;
+        while (criuopt) {
+            args.push_back(criuopt);
             criuopt = strtok(NULL, " ");
-        }
-        if (criuopt) {
-            fprintf(stderr, "Warning: too many arguments in CRAC_CRIU_OPTS (dropped from '%s')\n", criuopt);
         }
     }
 
-    memcpy(arg, tail, sizeof(tail));
+    const std::vector<const char *> tail = {
+        "--exec-cmd", "--", self, "restorewait", NULL,
+    };
+    args.insert(args.end(), tail.begin(), tail.end());
 
     fflush(stderr);
 
-    execv(criu, (char**)args);
+    execv(criu, const_cast<char **>(args.data()));
     perror("exec criu");
     return 1;
 }
@@ -386,16 +369,17 @@ int main(int argc, char *argv[]) {
 
         char *basedir = dirname(strdup(argv[0]));
 
-        char *criu = getenv("CRAC_CRIU_PATH");
-        if (!criu) {
-            if (-1 == asprintf(&criu, "%s/criu", basedir)) {
-                return 1;
-            }
+        std::string criu;
+        const char *criu_s = getenv("CRAC_CRIU_PATH");
+        if (criu_s) {
+          criu = criu_s;
+        } else {
+            criu = std::string(basedir) + "/criu";
             struct stat st;
-            if (stat(criu, &st)) {
+            if (stat(criu.c_str(), &st)) {
                 /* some problem with the bundled criu */
                 criu = "/usr/sbin/criu";
-                if (stat(criu, &st)) {
+                if (stat(criu.c_str(), &st)) {
                     fprintf(stderr, "cannot find CRIU to use\n");
                     return 1;
                 }
@@ -405,9 +389,9 @@ int main(int argc, char *argv[]) {
 
         if (!strcmp(action, "checkpoint")) {
             pid_t jvm = getppid();
-            return checkpoint(jvm, basedir, argv[0], criu, imagedir);
+            return checkpoint(jvm, basedir, argv[0], criu.c_str(), imagedir);
         } else if (!strcmp(action, "restore")) {
-            return restore(basedir, argv[0], criu, imagedir);
+            return restore(basedir, argv[0], criu.c_str(), imagedir);
         } else if (!strcmp(action, "restorewait")) { // called by CRIU --exec-cmd
             return restorewait();
         } else {


### PR DESCRIPTION
As the #97 review has no good solution I have C++ized the `criuengine` first.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.org/crac.git pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/98.diff">https://git.openjdk.org/crac/pull/98.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/98#issuecomment-1663659040)