### PR TITLE
Fix: arguments supplied to restore are split with whitespace

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2257,7 +2257,7 @@ bool Arguments::is_restore_option_set(const JavaVMInitArgs* args) {
   return false;
 }
 
-bool Arguments::parse_options_for_restore(const JavaVMInitArgs* args) {
+bool Arguments::parse_options_for_restore(const JavaVMInitArgs* args, JavaMainArgs** main_args) {
   const char *tail = NULL;
 
   // iterate over arguments
@@ -2283,7 +2283,11 @@ bool Arguments::parse_options_for_restore(const JavaVMInitArgs* args) {
         if (old_java_command != NULL) {
           os::free(old_java_command);
         }
-      } else {
+      }
+      else if (strcmp(key, "CRaCJavaMainArgs") == 0) {
+        *main_args = (JavaMainArgs*)(option->extraInfo);
+      }
+      else {
         add_property(tail);
       }
     } else if (match_option(option, "-XX:", &tail)) { // -XX:xxxx

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2284,7 +2284,7 @@ bool Arguments::parse_options_for_restore(const JavaVMInitArgs* args, JavaMainAr
           os::free(old_java_command);
         }
       }
-      else if (strcmp(key, "CRaCJavaMainArgs") == 0) {
+      else if (strcmp(key, "jdk.internal.crac.mainArgs") == 0) {
         *main_args = (JavaMainArgs*)(option->extraInfo);
       }
       else {

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -148,6 +148,15 @@ class SystemProperty : public PathString {
 // Helper class for controlling the lifetime of JavaVMInitArgs objects.
 class ScopedVMInitArgs;
 
+// Arguments passed from JavaMain via the property CRaCJavaMainArgs
+typedef struct {
+    int    argc;
+    char **argv;
+    int    mode;
+    char  *what;
+    // InvocationFunctions ifn;
+} JavaMainArgs;
+
 class Arguments : AllStatic {
   friend class VMStructs;
   friend class JvmtiExport;
@@ -537,7 +546,7 @@ class Arguments : AllStatic {
 
   static bool is_restore_option_set(const JavaVMInitArgs* args);
 
-  static bool parse_options_for_restore(const JavaVMInitArgs* args);
+  static bool parse_options_for_restore(const JavaVMInitArgs* args, JavaMainArgs** main_args);
 
   DEBUG_ONLY(static bool verify_special_jvm_flags(bool check_globals);)
 };

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -148,7 +148,7 @@ class SystemProperty : public PathString {
 // Helper class for controlling the lifetime of JavaVMInitArgs objects.
 class ScopedVMInitArgs;
 
-// Arguments passed from JavaMain via the property CRaCJavaMainArgs
+// Arguments passed from JavaMain via the property jdk.internal.crac.mainArgs
 typedef struct {
     int    argc;
     char **argv;

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -548,7 +548,7 @@ static bool read_jlong(int fd, jlong* value) {
 
 // Write a GrowableArray to fd.
 // On error, return false.
-static bool write_growable_array(int fd, GrowableArray<const char *>* array) {
+static bool write_growable_array(int fd, const GrowableArray<const char *>* array) {
   const size_t JLONG_SIZE = sizeof(jlong);
   guarantee(array != NULL, "write_growable_array: array is NULL");
 
@@ -609,7 +609,7 @@ CracRestoreParameters::CracRestoreParameters() :
   args(GrowableArray<const char *>(0, mtInternal)),
   envs(GrowableArray<const char *>(0, mtInternal)) {}
 
-bool CracRestoreParameters::serialize(int fd) {
+bool CracRestoreParameters::serialize(int fd) const {
   if (!write_jlong(fd, restore_time)) return false;
   if (!write_jlong(fd, restore_nanos)) return false;
   if (!write_growable_array(fd, &flags)) return false;

--- a/src/hotspot/share/runtime/crac.hpp
+++ b/src/hotspot/share/runtime/crac.hpp
@@ -27,6 +27,7 @@
 #include "memory/allStatic.hpp"
 #include "runtime/handles.hpp"
 #include "utilities/macros.hpp"
+#include "arguments.hpp"
 
 // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 #define UUID_LENGTH 36
@@ -36,7 +37,7 @@ public:
   static void vm_create_start();
   static bool prepare_checkpoint();
   static Handle checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong jcmd_stream, TRAPS);
-  static void restore();
+  static void restore(JavaMainArgs* main_args);
 
   static jlong restore_start_time();
   static jlong uptime_since_restore();

--- a/src/hotspot/share/runtime/crac_structs.hpp
+++ b/src/hotspot/share/runtime/crac_structs.hpp
@@ -98,7 +98,7 @@ public:
 
   GrowableArray<CracFailDep>* failures() { return _failures; }
   bool ok() { return _ok; }
-  const char* new_args() { return _restore_parameters.args.at(0); }
+  GrowableArray<const char *>* new_args() { return &_restore_parameters.args; }
   GrowableArray<const char *>* new_properties() { return &_restore_parameters.properties; }
   virtual bool allow_nested_vm_operations() const  { return true; }
   VMOp_Type type() const { return VMOp_VM_Crac; }

--- a/src/hotspot/share/runtime/crac_structs.hpp
+++ b/src/hotspot/share/runtime/crac_structs.hpp
@@ -61,7 +61,7 @@ struct CracRestoreParameters : public StackObj {
 
   // Write parameters into fd.
   // Return true if successful.
-  bool serialize(int fd);
+  bool serialize(int fd) const;
 
   // Read parameters from fd.
   // Return true if successful.

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -409,10 +409,11 @@ void Threads::initialize_jsr292_core_classes(TRAPS) {
 
 jint Threads::check_for_restore(JavaVMInitArgs* args) {
   if (Arguments::is_restore_option_set(args)) {
-    if (!Arguments::parse_options_for_restore(args)) {
+    JavaMainArgs* main_args;
+    if (!Arguments::parse_options_for_restore(args, &main_args)) {
       return JNI_ERR;
     }
-    crac::restore();
+    crac::restore(main_args);
     if (!CRaCIgnoreRestoreIfUnavailable) {
       // FIXME switch to unified hotspot logging
       warning("cannot restore");

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -410,6 +410,10 @@ JavaMain(void* _args)
 
     RegisterThread();
 
+    // set the -DCRaCJavaMainArgs pseudo property
+    // this is used by CRaC to supply the restored VM with new args
+    AddOption("-DCRaCJavaMainArgs", args);
+
     /* Initialize the virtual machine */
     start = CurrentTimeMicros();
     if (!InitializeJVM(&vm, &env, &ifn)) {

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -410,9 +410,9 @@ JavaMain(void* _args)
 
     RegisterThread();
 
-    // set the -DCRaCJavaMainArgs pseudo property
+    // set the -Djdk.internal.crac.mainArgs pseudo property
     // this is used by CRaC to supply the restored VM with new args
-    AddOption("-DCRaCJavaMainArgs", args);
+    AddOption("-Djdk.internal.crac.mainArgs", args);
 
     /* Initialize the virtual machine */
     start = CurrentTimeMicros();


### PR DESCRIPTION
This PR fixes a bug that causes arguments with whitespaces to be split into multiple arguments during restore.

It contains two commits. The first commit is refactor only. It moves all side effects from `CracRestoreParameters` to the call sites, and changes the type of `CracRestoreParameters::args` from a single string to a `GrowableArray` of strings. Serialization code is also cleaned up a bit.

The second commit fixes the bug by introducing a new pseudo property, `-DCRaCJavaMainArgs`, that is set in `JavaMain`. An instance of `JavaMainArgs` (containing `argc` and `argv`) is stored as extra info of the property, which is later extracted in `Arguments::parse_options_for_restore` and passed to `crac::restore`.

Potential issues:

* We use `putenv` to modify environment variables, which expects `char*`. In this PR, I'm `const_cast`ing from `const char*` to `char*`, since I believe `putenv` doesn't actually modify the string. Is that OK? Maybe rewriting with `setenv` would be better?
* `read_growable_array` is implemented by reading byte-at-a-time from the shared memory. Will it be too slow? I could rewrite it to read everything at once (like the original code did), but the current implementation is cute and I kinda want to keep it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/101/head:pull/101` \
`$ git checkout pull/101`

Update a local copy of the PR: \
`$ git checkout pull/101` \
`$ git pull https://git.openjdk.org/crac.git pull/101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 101`

View PR using the GUI difftool: \
`$ git pr show -t 101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/101.diff">https://git.openjdk.org/crac/pull/101.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/101#issuecomment-1697287254)