### PR TITLE
Fix missing include file.

### DIFF
--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -59,6 +59,7 @@
 #include "prims/jvmtiAgentList.hpp"
 #include "prims/jvm_misc.hpp"
 #include "runtime/arguments.hpp"
+#include "runtime/crac.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/flags/jvmFlagLimit.hpp"
 #include "runtime/handles.inline.hpp"


### PR DESCRIPTION
It is probably because I am using `--disable-precompiled-headers `.
```
src/hotspot/share/runtime/threads.cpp: In static member function 'static jint Threads::check_for_restore(JavaVMInitArgs*)': src/hotspot/share/runtime/threads.cpp:415:5: error: 'crac' has not been declared
  415 |     crac::restore();
      |     ^~~~
src/hotspot/share/runtime/threads.cpp: In static member function 'static jint Threads::create_vm(JavaVMInitArgs*, bool*)':
src/hotspot/share/runtime/threads.cpp:494:3: error: 'crac' has not been declared
  494 |   crac::vm_create_start();
      |   ^~~~
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/102/head:pull/102` \
`$ git checkout pull/102`

Update a local copy of the PR: \
`$ git checkout pull/102` \
`$ git pull https://git.openjdk.org/crac.git pull/102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 102`

View PR using the GUI difftool: \
`$ git pr show -t 102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/102.diff">https://git.openjdk.org/crac/pull/102.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/102#issuecomment-1674339711)