### PR TITLE
Fix a #73 reference regression

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -336,11 +336,6 @@ public abstract sealed class Reference<T>
             }
 
             @Override
-            public <T> Reference<? extends T> pollReferenceQueue(ReferenceQueue<T> queue, long timeout) throws InterruptedException {
-                return queue.poll(timeout);
-            }
-
-            @Override
             public void wakeupReferenceQueue(ReferenceQueue<?> queue) {
                 queue.wakeup();
             }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangRefAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangRefAccess.java
@@ -57,11 +57,6 @@ public interface JavaLangRefAccess {
     void runFinalization();
 
     /**
-     * Calls package-private {@link ReferenceQueue#poll(long)}.
-     */
-    <T> Reference<? extends T> pollReferenceQueue(ReferenceQueue<T> queue, long timeout) throws InterruptedException;
-
-    /**
      * Calls package-private {@link ReferenceQueue#wakeup()}.
      */
     void wakeupReferenceQueue(ReferenceQueue<?> queue);

--- a/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
@@ -157,7 +157,7 @@ public final class CleanerImpl implements Runnable, JDKResource {
             try {
                 // Wait for a Ref, with a timeout to avoid getting hung
                 // due to a race with clear/clean
-                Cleanable ref = (Cleanable) javaLangRefAccess.pollReferenceQueue(queue, 60 * 1000L);
+                Cleanable ref = (Cleanable) queue.remove(60 * 1000L);
                 if (ref != null) {
                     ref.clean();
                 }


### PR DESCRIPTION
It fixes:
- test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
- test/jdk/java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java
- test/jdk/java/lang/ref/CleanerTest.java
@rvansa the author of #73 should know more.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/108/head:pull/108` \
`$ git checkout pull/108`

Update a local copy of the PR: \
`$ git checkout pull/108` \
`$ git pull https://git.openjdk.org/crac.git pull/108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 108`

View PR using the GUI difftool: \
`$ git pr show -t 108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/108.diff">https://git.openjdk.org/crac/pull/108.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/108#issuecomment-1703897630)