### PR TITLE
Fix ArchivedEnumTest.java testsuite regression

### DIFF
--- a/src/hotspot/share/cds/cdsHeapVerifier.cpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.cpp
@@ -135,7 +135,6 @@ CDSHeapVerifier::CDSHeapVerifier() : _archived_objs(0), _problems(0)
   ADD_EXCL("sun/invoke/util/ValueConversions",           "ONE_INT",                // E
                                                          "ZERO_INT");              // E
   ADD_EXCL("sun/security/util/SecurityConstants",        "PROVIDER_VER");          // C
-  ADD_EXCL("jdk/crac/impl/GlobalContext",                "IMPL_NAME");             // B
 
 
 # undef ADD_EXCL

--- a/src/hotspot/share/cds/cdsHeapVerifier.cpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.cpp
@@ -135,6 +135,7 @@ CDSHeapVerifier::CDSHeapVerifier() : _archived_objs(0), _problems(0)
   ADD_EXCL("sun/invoke/util/ValueConversions",           "ONE_INT",                // E
                                                          "ZERO_INT");              // E
   ADD_EXCL("sun/security/util/SecurityConstants",        "PROVIDER_VER");          // C
+  ADD_EXCL("jdk/crac/impl/GlobalContext",                "IMPL_NAME");             // B
 
 
 # undef ADD_EXCL

--- a/src/java.base/share/classes/jdk/crac/impl/GlobalContext.java
+++ b/src/java.base/share/classes/jdk/crac/impl/GlobalContext.java
@@ -5,12 +5,12 @@ import jdk.crac.Resource;
 import sun.security.action.GetPropertyAction;
 
 public class GlobalContext {
-    private static final String GLOBAL_CONTEXT_IMPL_PROP = "jdk.crac.globalContext.impl";
-    private static final String GLOBAL_CONTEXT_IMPL_NAME =
-        GetPropertyAction.privilegedGetProperty(GLOBAL_CONTEXT_IMPL_PROP, "");
+    private static final String IMPL_PROP = "jdk.crac.globalContext.impl";
+    private static final String IMPL_NAME =
+        GetPropertyAction.privilegedGetProperty(IMPL_PROP, "");
 
     public static Context<Resource> createGlobalContextImpl() {
-        return switch (GLOBAL_CONTEXT_IMPL_NAME) {
+        return switch (IMPL_NAME) {
             case "BlockingOrderedContext" -> new BlockingOrderedContext<>();
             case "OrderedContext" -> new OrderedContext<>();
             default -> new OrderedContext<>(); // cannot report as System.out/err are not initialized yet

--- a/src/java.base/share/classes/jdk/crac/impl/GlobalContext.java
+++ b/src/java.base/share/classes/jdk/crac/impl/GlobalContext.java
@@ -5,12 +5,10 @@ import jdk.crac.Resource;
 import sun.security.action.GetPropertyAction;
 
 public class GlobalContext {
-    private static final String IMPL_PROP = "jdk.crac.globalContext.impl";
-    private static final String IMPL_NAME =
-        GetPropertyAction.privilegedGetProperty(IMPL_PROP, "");
-
     public static Context<Resource> createGlobalContextImpl() {
-        return switch (IMPL_NAME) {
+        String impl_prop = "jdk.crac.globalContext.impl";
+        String impl_name = GetPropertyAction.privilegedGetProperty(impl_prop, "");
+        return switch (impl_name) {
             case "BlockingOrderedContext" -> new BlockingOrderedContext<>();
             case "OrderedContext" -> new OrderedContext<>();
             default -> new OrderedContext<>(); // cannot report as System.out/err are not initialized yet

--- a/src/java.base/share/classes/jdk/crac/impl/GlobalContext.java
+++ b/src/java.base/share/classes/jdk/crac/impl/GlobalContext.java
@@ -5,10 +5,11 @@ import jdk.crac.Resource;
 import sun.security.action.GetPropertyAction;
 
 public class GlobalContext {
+    private static final String GLOBAL_CONTEXT_IMPL_PROP = "jdk.crac.globalContext.impl";
+
     public static Context<Resource> createGlobalContextImpl() {
-        String impl_prop = "jdk.crac.globalContext.impl";
-        String impl_name = GetPropertyAction.privilegedGetProperty(impl_prop, "");
-        return switch (impl_name) {
+        String implName = GetPropertyAction.privilegedGetProperty(GLOBAL_CONTEXT_IMPL_PROP, "");
+        return switch (implName) {
             case "BlockingOrderedContext" -> new BlockingOrderedContext<>();
             case "OrderedContext" -> new OrderedContext<>();
             default -> new OrderedContext<>(); // cannot report as System.out/err are not initialized yet


### PR DESCRIPTION
```
java.lang.RuntimeException: 'object points to a static field that may be reinitialized at runtime' found in stdout
        at jdk.test.lib.process.OutputAnalyzer.shouldNotContain(OutputAnalyzer.java:267)
        at ArchivedEnumTest.main(ArchivedEnumTest.java:49)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:333)
        at java.base/java.lang.Thread.run(Thread.java:1570)

[1.337s][warning][cds,heap] Archive heap points to a static field that may be reinitialized at runtime:
[1.337s][warning][cds,heap] Field: jdk/crac/impl/GlobalContext::GLOBAL_CONTEXT_IMPL_NAME
[1.337s][warning][cds,heap] Value: java.lang.String
[1.337s][warning][cds,heap] {0x00000000d7561560} - klass: 'java/lang/String'
[1.337s][warning][cds,heap]  - string: ""
[1.337s][warning][cds,heap]  - ---- fields (total size 3 words):
[1.337s][warning][cds,heap]  - private 'hash' 'I' @12  0 (0x00000000)
[1.337s][warning][cds,heap]  - private final 'coder' 'B' @16  0 (0x00)
[1.338s][warning][cds,heap]  - private 'hashIsZero' 'Z' @17  true (0x01)
[1.338s][warning][cds,heap]  - injected 'flags' 'B' @18  1 (0x01)
[1.338s][warning][cds,heap]  - private final 'value' '[B' @20  [B{0x00000000d7561578} (0xd7561578)
[1.338s][warning][cds,heap] --- trace begin ---
[1.338s][warning][cds,heap] [ 0] (shared string table)
[1.338s][warning][cds,heap] [ 1] {0x00000000d7561560} java.lang.String
[1.338s][warning][cds,heap] --- trace end ---
```

I haven't found a way how to fix [src/java.base/share/classes/jdk/crac/impl/GlobalContext.java](https://github.com/openjdk/crac/blob/crac/src/java.base/share/classes/jdk/crac/impl/GlobalContext.java) not regressing its current static field performance without adding this exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/109/head:pull/109` \
`$ git checkout pull/109`

Update a local copy of the PR: \
`$ git checkout pull/109` \
`$ git pull https://git.openjdk.org/crac.git pull/109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 109`

View PR using the GUI difftool: \
`$ git pr show -t 109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/109.diff">https://git.openjdk.org/crac/pull/109.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/109#issuecomment-1704325414)