### PR TITLE
Fix lock usage in ReferenceQueue

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
+++ b/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
@@ -188,18 +188,25 @@ public class ReferenceQueue<T> {
     }
 
     Reference<? extends T> poll(long timeout) throws InterruptedException {
-        synchronized (lock) {
+        lock.lock();
+        try {
             Reference<? extends T> r = poll0();
             if (r != null) return r;
             // any wake (including spurious) ends the wait
-            lock.wait(timeout);
+            //noinspection ResultOfMethodCallIgnored
+            notEmpty.await(timeout, TimeUnit.MILLISECONDS);
             return poll0();
+        } finally {
+            lock.unlock();
         }
     }
 
     void wakeup() {
-        synchronized (lock) {
-            lock.notifyAll();
+        lock.lock();
+        try {
+            notEmpty.signalAll();
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/test/jdk/jdk/crac/RefQueueTest.java
+++ b/test/jdk/jdk/crac/RefQueueTest.java
@@ -37,7 +37,6 @@ import static jdk.test.lib.Asserts.assertTrue;
  * @test
  * @library /test/lib
  * @build RefQueueTest
- * @ignore the final assert does not pass even without CRaC invocation
  * @run driver jdk.test.lib.crac.CracTest
  */
 public class RefQueueTest implements CracTest {


### PR DESCRIPTION
In JDK 17 the locking used monitors, but in JDK 21 this class uses ReentrantLock. The change was not reflected during merge of new methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/110/head:pull/110` \
`$ git checkout pull/110`

Update a local copy of the PR: \
`$ git checkout pull/110` \
`$ git pull https://git.openjdk.org/crac.git pull/110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 110`

View PR using the GUI difftool: \
`$ git pr show -t 110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/110.diff">https://git.openjdk.org/crac/pull/110.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/110#issuecomment-1709759259)