### PR TITLE
CRaC: criuengine.c: Use asprintf()

### DIFF
--- a/src/java.base/unix/native/criuengine/criuengine.c
+++ b/src/java.base/unix/native/criuengine/criuengine.c
@@ -93,16 +93,11 @@ static void print_command_args_to_stderr(const char **args) {
 }
 
 static const char *join_path(const char *path1, const char *path2) {
-    char *retval = malloc(strlen(path1) + 1 + strlen(path2) + 1);
-    if (!retval) {
-        perror("malloc");
+    char *retval;
+    if (asprintf(&retval, "%s/%s", path1, path2) == -1) {
+        perror("asprintf");
         exit(1);
     }
-    char *d = retval;
-    d = stpcpy(d, path1);
-    *d++ = '/';
-    d = stpcpy(d, path2);
-    *d++ = 0;
     return retval;
 }
 


### PR DESCRIPTION
- suggested by Anton Kozlov

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/114/head:pull/114` \
`$ git checkout pull/114`

Update a local copy of the PR: \
`$ git checkout pull/114` \
`$ git pull https://git.openjdk.org/crac.git pull/114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 114`

View PR using the GUI difftool: \
`$ git pr show -t 114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/114.diff">https://git.openjdk.org/crac/pull/114.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/114#issuecomment-1725798322)