### PR TITLE
Fix: docker: Error response from daemon: Conflict. The container name "/crac-test" is already in use

### DIFF
--- a/test/lib/jdk/test/lib/crac/CracBuilder.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilder.java
@@ -18,7 +18,9 @@ import static jdk.test.lib.Asserts.*;
 
 public class CracBuilder {
     private static final String DEFAULT_IMAGE_DIR = "cr";
-    public static final String CONTAINER_NAME = "crac-test";
+    // Make it unique so that tests running in parallel do not conflict with:
+    // docker: Error response from daemon: Conflict. The container name "/crac-test" is already in use by container "<hash>". You have to remove (or rename) that container to be able to reuse that name.
+    public static final String CONTAINER_NAME = "crac-test" + ProcessHandle.current().pid();
     public static final String JAVA = Utils.TEST_JDK + "/bin/java";
     public static final String DOCKER_JAVA = "/jdk/bin/java";
     private static final List<String> CRIU_CANDIDATES = Arrays.asList(Utils.TEST_JDK + "/lib/criu", "/usr/sbin/criu", "/sbin/criu");


### PR DESCRIPTION
Reproducibility is occasional only, reproduced with:
```
(set -ex;KIND=fastdebug;: rm -rf build/linux-x86_64-server-$KIND;export PATH="$(echo "$PATH"|sed 's#:/usr/lib64/ccache:#:'$HOME'/ccache:#')";: bash configure --disable-precompiled-headers --disable-ccache --with-debug-level=$KIND --with-jtreg=$HOME/azul/jtreg/build/images/jtreg --with-boot-jdk=/usr/lib/jvm/java-21;MAKEFLAGS= time n sudo make -C build/linux-x86_64-server-$KIND JOBS=$[4+32] LOG_LEVEL=debug STRIP_POLICY=no_strip LOG_CMDLINES=true run-test TEST="test/jdk/jdk/crac/java/lang/System")|&tee log
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/115/head:pull/115` \
`$ git checkout pull/115`

Update a local copy of the PR: \
`$ git checkout pull/115` \
`$ git pull https://git.openjdk.org/crac.git pull/115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 115`

View PR using the GUI difftool: \
`$ git pr show -t 115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/115.diff">https://git.openjdk.org/crac/pull/115.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/115#issuecomment-1727619431)