### PR TITLE
Close files opened by Decoder before checkpoint

### DIFF
--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -37,6 +37,7 @@
 #include "runtime/vmThread.hpp"
 #include "services/heapDumper.hpp"
 #include "services/writeableFlags.hpp"
+#include "utilities/decoder.hpp"
 #ifdef LINUX
 #include "os_linux.hpp"
 #endif
@@ -309,6 +310,7 @@ void VM_Crac::doit() {
   // dry-run fails checkpoint
   bool ok = true;
 
+  Decoder::before_checkpoint();
   if (!check_fds()) {
     ok = false;
   }

--- a/src/hotspot/share/utilities/decoder.cpp
+++ b/src/hotspot/share/utilities/decoder.cpp
@@ -128,10 +128,7 @@ void Decoder::before_checkpoint() {
     delete _shared_decoder;
     _shared_decoder = nullptr;
   }
-  if (_error_handler_decoder != nullptr) {
-    delete _error_handler_decoder;
-    _error_handler_decoder = nullptr;
-  }
+  guarantee(_error_handler_decoder == nullptr, "Error handler decoder should not be present");
 }
 
 #endif // !_WINDOWS

--- a/src/hotspot/share/utilities/decoder.cpp
+++ b/src/hotspot/share/utilities/decoder.cpp
@@ -122,5 +122,17 @@ bool Decoder::get_source_info(address pc, char* filename, size_t filename_len, i
   }
 }
 
+void Decoder::before_checkpoint() {
+  MutexLocker locker(shared_decoder_lock(), Mutex::_no_safepoint_check_flag);
+  if (_shared_decoder != nullptr) {
+    delete _shared_decoder;
+    _shared_decoder = nullptr;
+  }
+  if (_error_handler_decoder != nullptr) {
+    delete _error_handler_decoder;
+    _error_handler_decoder = nullptr;
+  }
+}
+
 #endif // !_WINDOWS
 

--- a/src/hotspot/share/utilities/decoder.hpp
+++ b/src/hotspot/share/utilities/decoder.hpp
@@ -122,6 +122,8 @@ public:
 
   static void print_state_on(outputStream* st);
 
+  static void before_checkpoint();
+
 protected:
   // shared decoder instance, _shared_instance_lock is needed
   static AbstractDecoder* get_shared_instance();

--- a/test/jdk/jdk/crac/fileDescriptors/SharedLibraryTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/SharedLibraryTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.test.lib.Utils;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static jdk.test.lib.Asserts.assertEquals;
+
+/**
+ * @test
+ * @library /test/lib
+ * @requires (os.family == "linux")
+ * @build SharedLibraryTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class SharedLibraryTest implements CracTest {
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder()
+                .javaOption("test.jdk", Utils.TEST_JDK);
+        builder.copy().vmOption("-XX:NativeMemoryTracking=detail").doCheckpoint();
+        builder.doRestore();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        checkNativeMemory();
+        Core.checkpointRestore();
+        checkNativeMemory();
+    }
+
+    private static void checkNativeMemory() throws InterruptedException, IOException {
+        String jcmd = Path.of(Utils.TEST_JDK, "bin", "jcmd").toString();
+        assertEquals(0, new ProcessBuilder().inheritIO().redirectOutput(ProcessBuilder.Redirect.DISCARD).command(
+                jcmd, String.valueOf(ProcessHandle.current().pid()), "VM.native_memory", "detail"
+        ).start().waitFor());
+    }
+}


### PR DESCRIPTION
Native memory tracking needs to resolve some addresses for stack unwinding and the decoders keep some shared library files open as a cache. Since the decoder instances can be re-allocated anytime this fix just destroys them before a checkpoint.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/116/head:pull/116` \
`$ git checkout pull/116`

Update a local copy of the PR: \
`$ git checkout pull/116` \
`$ git pull https://git.openjdk.org/crac.git pull/116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 116`

View PR using the GUI difftool: \
`$ git pr show -t 116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/116.diff">https://git.openjdk.org/crac/pull/116.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/116#issuecomment-1733708271)