### PR TITLE
Fix clang compilation error

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1020,7 +1020,7 @@ public:
   // Returns whether this collection actually executed.
   bool try_collect(GCCause::Cause cause, const G1GCCounters& counters_before);
 
-  virtual void finish_collection() {
+  virtual void finish_collection() override {
     G1UncommitRegionTask::finish_collection();
   }
 


### PR DESCRIPTION
```
src/hotspot/share/gc/g1/g1CollectedHeap.hpp:1023:16: error: 'finish_collection' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  virtual void finish_collection() {
               ^
src/hotspot/share/gc/shared/collectedHeap.hpp:396:16: note: overridden virtual function is here
  virtual void finish_collection() {}
               ^
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/117/head:pull/117` \
`$ git checkout pull/117`

Update a local copy of the PR: \
`$ git checkout pull/117` \
`$ git pull https://git.openjdk.org/crac.git pull/117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 117`

View PR using the GUI difftool: \
`$ git pr show -t 117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/117.diff">https://git.openjdk.org/crac/pull/117.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/117#issuecomment-1733837267)