### PR TITLE
Improved classpath matching

### DIFF
--- a/test/jdk/jdk/crac/fileDescriptors/CheckpointWithOpenFdsTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/CheckpointWithOpenFdsTest.java
@@ -25,10 +25,23 @@ import jdk.crac.Core;
 import jdk.test.lib.Utils;
 import jdk.test.lib.crac.CracBuilder;
 import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+
+import java.io.File;
+import java.io.RandomAccessFile;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.stream.Collectors;
+
+import static jdk.test.lib.Asserts.assertEquals;
+import static jdk.test.lib.Asserts.assertTrue;
 
 /**
+ * This test includes two behaviours:
+ * 1) inheriting open FD from parent process: this is achieved using EXTRA_FD_WRAPPER
+ *    - any excess inherited FDs should be closed when JVM starts.
+ * 2) open files on classpath: these files are ignored, handling is left to CREngine
+ *
  * @test
  * @library /test/lib
  * @build CheckpointWithOpenFdsTest
@@ -38,16 +51,41 @@ import java.util.*;
 public class CheckpointWithOpenFdsTest implements CracTest {
     private static final String EXTRA_FD_WRAPPER = Path.of(Utils.TEST_SRC, "extra_fd_wrapper.sh").toString();
 
+    @CracTestArg(optional = true, value = 0)
+    String relativePathToSomeJar;
+
+    @CracTestArg(optional = true, value = 1)
+    String absolutePathToSomeJar;
+
     @Override
     public void test() throws Exception {
+        List<Path> jars = Arrays.stream(System.getProperty("java.class.path").split(File.pathSeparator))
+                .filter(p -> p.endsWith(".jar")).map(Path::of).toList();
+        assertEquals(2, jars.size()); // usually we have javatest.jar and jtreg.jar
+        assertTrue(jars.stream().allMatch(jar -> jar.toFile().exists()));
+        Path firstJar = jars.get(0);
+        Path secondJar = jars.get(1);
+        assertTrue(secondJar.isAbsolute());
+        Path cwd = Path.of(System.getProperty("user.dir"));
+        String relative = cwd.relativize(firstJar).toString();
+        String absolute = secondJar.toString();
+
         CracBuilder builder = new CracBuilder();
+        builder.classpathEntry(relative).classpathEntry(absolute).args(CracTest.args(relative, absolute));
         builder.startCheckpoint(Arrays.asList(EXTRA_FD_WRAPPER, CracBuilder.JAVA)).waitForCheckpointed();
         builder.captureOutput(true).doRestore().outputAnalyzer().shouldContain(RESTORED_MESSAGE);
     }
 
     @Override
     public void exec() throws Exception {
-        Core.checkpointRestore();
-        System.out.println(RESTORED_MESSAGE);
+        String absolute = Path.of(relativePathToSomeJar).toAbsolutePath().toString();
+
+        Path cwd = Path.of(System.getProperty("user.dir"));
+        String relative = cwd.relativize(Path.of(absolutePathToSomeJar)).toString();
+        try (var file1 = new RandomAccessFile(absolute, "r");
+             var file2 = new RandomAccessFile(relative, "r")) {
+            Core.checkpointRestore();
+            System.out.println(RESTORED_MESSAGE);
+        }
     }
 }

--- a/test/jdk/jdk/crac/fileDescriptors/CheckpointWithOpenFdsTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/CheckpointWithOpenFdsTest.java
@@ -33,8 +33,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static jdk.test.lib.Asserts.assertEquals;
-import static jdk.test.lib.Asserts.assertTrue;
+import static jdk.test.lib.Asserts.*;
 
 /**
  * This test includes two behaviours:
@@ -61,7 +60,7 @@ public class CheckpointWithOpenFdsTest implements CracTest {
     public void test() throws Exception {
         List<Path> jars = Arrays.stream(System.getProperty("java.class.path").split(File.pathSeparator))
                 .filter(p -> p.endsWith(".jar")).map(Path::of).toList();
-        assertEquals(2, jars.size()); // usually we have javatest.jar and jtreg.jar
+        assertGreaterThanOrEqual(jars.size(), 2); // usually we have at least javatest.jar and jtreg.jar
         assertTrue(jars.stream().allMatch(jar -> jar.toFile().exists()));
         Path firstJar = jars.get(0);
         Path secondJar = jars.get(1);


### PR DESCRIPTION
This fixes an issue when the classpath entry is specified using a relative path, and another part of the application opens the file using absolute one (or vice versa) - e.g. using a custom classloader that does not use PersistentJarFile underneath.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/118/head:pull/118` \
`$ git checkout pull/118`

Update a local copy of the PR: \
`$ git checkout pull/118` \
`$ git pull https://git.openjdk.org/crac.git pull/118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 118`

View PR using the GUI difftool: \
`$ git pr show -t 118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/118.diff">https://git.openjdk.org/crac/pull/118.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/118#issuecomment-1735194926)