### PR TITLE
Drop perfdata and cppath

### DIFF
--- a/src/hotspot/os/linux/crac_linux.cpp
+++ b/src/hotspot/os/linux/crac_linux.cpp
@@ -341,7 +341,7 @@ bool VM_Crac::check_fds() {
 }
 
 bool VM_Crac::memory_checkpoint() {
-  return PerfMemoryLinux::checkpoint(CRaCCheckpointTo);
+  return PerfMemoryLinux::checkpoint();
 }
 
 void VM_Crac::memory_restore() {

--- a/src/hotspot/os/linux/perfMemory_linux.hpp
+++ b/src/hotspot/os/linux/perfMemory_linux.hpp
@@ -30,7 +30,7 @@
 class PerfMemoryLinux : AllStatic {
 
 public:
-  static bool checkpoint(const char* checkpoint_path);
+  static bool checkpoint();
   static bool restore();
 };
 

--- a/src/hotspot/os/linux/perfMemory_linux.hpp
+++ b/src/hotspot/os/linux/perfMemory_linux.hpp
@@ -30,10 +30,6 @@
 class PerfMemoryLinux : AllStatic {
 
 public:
-  static inline const char* perfdata_name() {
-    return "perfdata";
-  }
-
   static bool checkpoint(const char* checkpoint_path);
   static bool restore();
 };

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -63,7 +63,6 @@
 
 static char* backing_store_file_name = nullptr;  // name of the backing store
                                               // file, if successfully created.
-static int checkpoint_fd = -1;
 
 // Standard Memory Implementation Details
 
@@ -1356,19 +1355,36 @@ bool PerfMemoryLinux::checkpoint(const char* checkpoint_path) {
     return true;
   }
 
-  void *anon = ::mmap(nullptr, PerfMemory::capacity(), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-  if (anon == MAP_FAILED) {
-    tty->print_cr("Cannot allocate new memory for perfdata: %s", os::strerror(errno));
+  char path[JVM_MAXPATHLEN];
+  int pathlen = snprintf(path, sizeof(path),"%s/%s", checkpoint_path, perfdata_name());
+
+  RESTARTABLE(::open(path, O_RDWR|O_CREAT|O_NOFOLLOW, S_IRUSR|S_IWUSR), checkpoint_fd);
+  if (checkpoint_fd < 0) {
+    tty->print_cr("cannot open checkpoint perfdata: %s", os::strerror(errno));
     return false;
   }
-  // Note: we might be losing updates that happen between this copy and mremap
-  // TODO: consider acquiring PeriodicTask_lock around this
-  memcpy(anon, PerfMemory::start(), PerfMemory::used());
-  if (mremap(anon, PerfMemory::capacity(), PerfMemory::capacity(), MREMAP_FIXED | MREMAP_MAYMOVE, PerfMemory::start()) == MAP_FAILED) {
-    tty->print_cr("Cannot remap perfdata memory as anonymous: %s", os::strerror(errno));
-    if (munmap(anon, PerfMemory::capacity())) {
-      tty->print_cr("Cannot unmap unused private perfdata memory: %s", os::strerror(errno));
+
+  char* p = PerfMemory::start();
+  size_t len = PerfMemory::capacity();
+  do {
+    int result;
+    RESTARTABLE(::write(checkpoint_fd, p, len), result);
+    if (result == OS_ERR) {
+      tty->print_cr("cannot write data to checkpoint perfdata file: %s", os::strerror(errno));
+      ::close(checkpoint_fd);
+      checkpoint_fd = -1;
+      return false;
     }
+    p += result;
+    len -= (size_t)result;
+  } while (0 < len);
+
+  void* mmapret = ::mmap(PerfMemory::start(), PerfMemory::capacity(),
+      PROT_READ|PROT_WRITE, MAP_FIXED|MAP_SHARED, checkpoint_fd, 0);
+  if (MAP_FAILED == mmapret) {
+    tty->print_cr("cannot mmap checkpoint perfdata file: %s", os::strerror(errno));
+    ::close(checkpoint_fd);
+    checkpoint_fd = -1;
     return false;
   }
 
@@ -1378,6 +1394,10 @@ bool PerfMemoryLinux::checkpoint(const char* checkpoint_path) {
 }
 
 bool PerfMemoryLinux::restore() {
+  if (checkpoint_fd < 0) {
+    return true;
+  }
+
   int vmid = os::current_process_id();
   char* user_name = get_user_name(geteuid());
   char* dirname = get_user_tmp_dir(user_name, vmid, -1);
@@ -1388,34 +1408,41 @@ bool PerfMemoryLinux::restore() {
   int fd;
   RESTARTABLE(::open(backing_store_file_name, O_RDWR|O_CREAT|O_NOFOLLOW, S_IRUSR|S_IWUSR), fd);
   if (fd == OS_ERR) {
-    tty->print_cr("Cannot open shared perfdata file: %s", os::strerror(errno));
-    return false;
-  }
+    tty->print_cr("cannot open restore perfdata file: %s", os::strerror(errno));
 
-  if (::ftruncate(fd, PerfMemory::capacity())) {
-    tty->print_cr("Cannot restore (ftruncate) perfdata file size: %s", os::strerror(errno));
-    ::close(fd);
-    return false;
-  }
-
-  void* shared = ::mmap(nullptr, PerfMemory::capacity(), PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
-  if (MAP_FAILED == shared) {
-    tty->print_cr("cannot mmap shared perfdata file: %s", os::strerror(errno));
-    ::close(fd);
-    return false;
-  }
-  ::close(fd);
-
-  // Here is another place where we might lose the update
-  memcpy(shared, PerfMemory::start(), PerfMemory::used());
-  if (::mremap(shared, PerfMemory::capacity(), PerfMemory::capacity(), MREMAP_FIXED | MREMAP_MAYMOVE, PerfMemory::start()) == MAP_FAILED) {
-    tty->print_cr("Cannot remap shared perfdata: %s", os::strerror(errno));
-    if (munmap(shared, PerfMemory::capacity())) {
-      tty->print_cr("Cannot unmap the shared memory: %s", os::strerror(errno));
+    void* mmapret = ::mmap(PerfMemory::start(), PerfMemory::capacity(),
+        PROT_READ|PROT_WRITE, MAP_FIXED|MAP_PRIVATE, checkpoint_fd, 0);
+    if (MAP_FAILED == mmapret) {
+      tty->print_cr("cannot remap checkpoint perfdata file: %s", os::strerror(errno));
     }
     return false;
   }
 
+  char* p = PerfMemory::start();
+  size_t len = PerfMemory::capacity();
+  do {
+    int result;
+    RESTARTABLE(::write(fd, p, len), result);
+    if (result == OS_ERR) {
+      tty->print_cr("cannot write data to restore perfdata file: %s", os::strerror(errno));
+      ::close(fd);
+      return false;
+    }
+    p += result;
+    len -= (size_t)result;
+  } while (0 < len);
+
+  void* mmapret = ::mmap(PerfMemory::start(), PerfMemory::capacity(),
+      PROT_READ|PROT_WRITE, MAP_FIXED|MAP_SHARED, fd, 0);
+  if (MAP_FAILED == mmapret) {
+    tty->print_cr("cannot mmap restore perfdata file: %s", os::strerror(errno));
+    ::close(fd);
+    return false;
+  }
+
+  ::close(fd);
+  ::close(checkpoint_fd);
+  checkpoint_fd = -1;
   return true;
 }
 #endif //LINUX

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1348,9 +1348,7 @@ void PerfMemory::detach(char* addr, size_t bytes) {
 }
 
 #ifdef LINUX
-bool PerfMemoryLinux::checkpoint(const char* checkpoint_path) {
-  assert(checkpoint_path, "should be set");
-
+bool PerfMemoryLinux::checkpoint() {
   if (!backing_store_file_name) {
     return true;
   }

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1355,36 +1355,19 @@ bool PerfMemoryLinux::checkpoint(const char* checkpoint_path) {
     return true;
   }
 
-  char path[JVM_MAXPATHLEN];
-  int pathlen = snprintf(path, sizeof(path),"%s/%s", checkpoint_path, perfdata_name());
-
-  RESTARTABLE(::open(path, O_RDWR|O_CREAT|O_NOFOLLOW, S_IRUSR|S_IWUSR), checkpoint_fd);
-  if (checkpoint_fd < 0) {
-    tty->print_cr("cannot open checkpoint perfdata: %s", os::strerror(errno));
+  void *anon = ::mmap(nullptr, PerfMemory::capacity(), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (anon == MAP_FAILED) {
+    tty->print_cr("Cannot allocate new memory for perfdata: %s", os::strerror(errno));
     return false;
   }
-
-  char* p = PerfMemory::start();
-  size_t len = PerfMemory::capacity();
-  do {
-    int result;
-    RESTARTABLE(::write(checkpoint_fd, p, len), result);
-    if (result == OS_ERR) {
-      tty->print_cr("cannot write data to checkpoint perfdata file: %s", os::strerror(errno));
-      ::close(checkpoint_fd);
-      checkpoint_fd = -1;
-      return false;
+  // Note: we might be losing updates that happen between this copy and mremap
+  // TODO: consider acquiring PeriodicTask_lock around this
+  memcpy(anon, PerfMemory::start(), PerfMemory::used());
+  if (mremap(anon, PerfMemory::capacity(), PerfMemory::capacity(), MREMAP_FIXED | MREMAP_MAYMOVE, PerfMemory::start()) == MAP_FAILED) {
+    tty->print_cr("Cannot remap perfdata memory as anonymous: %s", os::strerror(errno));
+    if (munmap(anon, PerfMemory::capacity())) {
+      tty->print_cr("Cannot unmap unused private perfdata memory: %s", os::strerror(errno));
     }
-    p += result;
-    len -= (size_t)result;
-  } while (0 < len);
-
-  void* mmapret = ::mmap(PerfMemory::start(), PerfMemory::capacity(),
-      PROT_READ|PROT_WRITE, MAP_FIXED|MAP_SHARED, checkpoint_fd, 0);
-  if (MAP_FAILED == mmapret) {
-    tty->print_cr("cannot mmap checkpoint perfdata file: %s", os::strerror(errno));
-    ::close(checkpoint_fd);
-    checkpoint_fd = -1;
     return false;
   }
 
@@ -1394,10 +1377,6 @@ bool PerfMemoryLinux::checkpoint(const char* checkpoint_path) {
 }
 
 bool PerfMemoryLinux::restore() {
-  if (checkpoint_fd < 0) {
-    return true;
-  }
-
   int vmid = os::current_process_id();
   char* user_name = get_user_name(geteuid());
   char* dirname = get_user_tmp_dir(user_name, vmid, -1);
@@ -1408,41 +1387,34 @@ bool PerfMemoryLinux::restore() {
   int fd;
   RESTARTABLE(::open(backing_store_file_name, O_RDWR|O_CREAT|O_NOFOLLOW, S_IRUSR|S_IWUSR), fd);
   if (fd == OS_ERR) {
-    tty->print_cr("cannot open restore perfdata file: %s", os::strerror(errno));
-
-    void* mmapret = ::mmap(PerfMemory::start(), PerfMemory::capacity(),
-        PROT_READ|PROT_WRITE, MAP_FIXED|MAP_PRIVATE, checkpoint_fd, 0);
-    if (MAP_FAILED == mmapret) {
-      tty->print_cr("cannot remap checkpoint perfdata file: %s", os::strerror(errno));
-    }
+    tty->print_cr("Cannot open shared perfdata file: %s", os::strerror(errno));
     return false;
   }
 
-  char* p = PerfMemory::start();
-  size_t len = PerfMemory::capacity();
-  do {
-    int result;
-    RESTARTABLE(::write(fd, p, len), result);
-    if (result == OS_ERR) {
-      tty->print_cr("cannot write data to restore perfdata file: %s", os::strerror(errno));
-      ::close(fd);
-      return false;
-    }
-    p += result;
-    len -= (size_t)result;
-  } while (0 < len);
-
-  void* mmapret = ::mmap(PerfMemory::start(), PerfMemory::capacity(),
-      PROT_READ|PROT_WRITE, MAP_FIXED|MAP_SHARED, fd, 0);
-  if (MAP_FAILED == mmapret) {
-    tty->print_cr("cannot mmap restore perfdata file: %s", os::strerror(errno));
+  if (::ftruncate(fd, PerfMemory::capacity())) {
+    tty->print_cr("Cannot restore (ftruncate) perfdata file size: %s", os::strerror(errno));
     ::close(fd);
     return false;
   }
 
+  void* shared = ::mmap(nullptr, PerfMemory::capacity(), PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+  if (MAP_FAILED == shared) {
+    tty->print_cr("cannot mmap shared perfdata file: %s", os::strerror(errno));
+    ::close(fd);
+    return false;
+  }
   ::close(fd);
-  ::close(checkpoint_fd);
-  checkpoint_fd = -1;
+
+  // Here is another place where we might lose the update
+  memcpy(shared, PerfMemory::start(), PerfMemory::used());
+  if (::mremap(shared, PerfMemory::capacity(), PerfMemory::capacity(), MREMAP_FIXED | MREMAP_MAYMOVE, PerfMemory::start()) == MAP_FAILED) {
+    tty->print_cr("Cannot remap shared perfdata: %s", os::strerror(errno));
+    if (munmap(shared, PerfMemory::capacity())) {
+      tty->print_cr("Cannot unmap the shared memory: %s", os::strerror(errno));
+    }
+    return false;
+  }
+
   return true;
 }
 #endif //LINUX

--- a/src/java.base/unix/native/criuengine/criuengine.c
+++ b/src/java.base/unix/native/criuengine/criuengine.c
@@ -47,8 +47,6 @@
 
 #define SUPPRESS_ERROR_IN_PARENT 77
 
-static int create_cppath(const char *imagedir);
-
 static int g_pid;
 
 static char *verbosity = NULL; // default differs for checkpoint and restore
@@ -218,7 +216,6 @@ static int checkpoint(pid_t jvm,
         kickjvm(jvm, 0);
     }
 
-    create_cppath(imagedir);
     exit(0);
 }
 
@@ -226,48 +223,6 @@ static int restore(const char *basedir,
         const char *self,
         const char *criu,
         const char *imagedir) {
-    char *cppathpath;
-    if (-1 == asprintf(&cppathpath, "%s/cppath", imagedir)) {
-        return 1;
-    }
-
-    int fd = open(cppathpath, O_RDONLY);
-    if (fd < 0) {
-        fprintf(stderr, "CRaC restore - cannot open cppath file \"%s\": %s\n", path_abs(cppathpath), strerror(errno));
-        return 1;
-    }
-
-    char cppath[PATH_MAX];
-    int cppathlen = 0;
-    int r;
-    while ((r = read(fd, cppath + cppathlen, sizeof(cppath) - cppathlen - 1)) != 0) {
-        if (r < 0 && errno == EINTR) {
-            continue;
-        }
-        if (r < 0) {
-            perror("read cppath");
-            return 1;
-        }
-        cppathlen += r;
-    }
-    cppath[cppathlen] = '\0';
-
-    close(fd);
-
-    char *inherit_perfdata = NULL;
-    char *perfdatapath;
-    if (-1 == asprintf(&perfdatapath, "%s/" PERFDATA_NAME, imagedir)) {
-        return 1;
-    }
-    int perfdatafd = open(perfdatapath, O_RDWR);
-    if (0 < perfdatafd) {
-        if (-1 == asprintf(&inherit_perfdata, "fd[%d]:%s/" PERFDATA_NAME,
-                    perfdatafd,
-                    cppath[0] == '/' ? cppath + 1 : cppath)) {
-            return 1;
-        }
-    }
-
     const char* args[32] = {
         criu,
         "restore",
@@ -284,10 +239,6 @@ static int restore(const char *basedir,
         *arg++ = log_file;
     }
 
-    if (inherit_perfdata) {
-        *arg++ = "--inherit-fd";
-        *arg++ = inherit_perfdata;
-    }
     const char* tail[] = {
         "--exec-cmd", "--", self, "restorewait",
         NULL
@@ -327,33 +278,6 @@ static int post_resume(void) {
 
     char *strid = getenv("CRAC_NEW_ARGS_ID");
     return kickjvm(pid, strid ? atoi(strid) : 0);
-}
-
-static int create_cppath(const char *imagedir) {
-    char realdir[PATH_MAX];
-
-    if (!realpath(imagedir, realdir)) {
-        fprintf(stderr, MSGPREFIX "cannot canonicalize %s: %s\n", imagedir, strerror(errno));
-        return 1;
-    }
-
-    int dirfd = open(realdir, O_DIRECTORY);
-    if (dirfd < 0) {
-        fprintf(stderr, MSGPREFIX "can not open image dir %s: %s\n", realdir, strerror(errno));
-        return 1;
-    }
-
-    int fd = openat(dirfd, "cppath", O_CREAT | O_WRONLY | O_TRUNC, 0644);
-    if (fd < 0) {
-        fprintf(stderr, MSGPREFIX "can not open file %s/cppath: %s\n", realdir, strerror(errno));
-        return 1;
-    }
-
-    if (write(fd, realdir, strlen(realdir)) < 0) {
-        fprintf(stderr, MSGPREFIX "can not write %s/cppath: %s\n", realdir, strerror(errno));
-        return 1;
-    }
-    return 0;
 }
 
 static void sighandler(int sig, siginfo_t *info, void *uc) {

--- a/test/jdk/jdk/crac/PerfMemoryRestoreTest.java
+++ b/test/jdk/jdk/crac/PerfMemoryRestoreTest.java
@@ -65,7 +65,11 @@ public class PerfMemoryRestoreTest implements CracTest {
         }
         // Note: we need to check the checkpoint.pid(), which should be restored (when using CRIU),
         // as restored.pid() would be the criuengine restorewait process
-        checkMapped(String.valueOf(checkpoint.pid()), perfdata.toString());
+        String pidString = String.valueOf(checkpoint.pid());
+        checkMapped(pidString, perfdata.toString());
+        builder.runJcmd(pidString, "PerfCounter.print")
+                .shouldHaveExitValue(0)
+                .shouldContain("sun.perfdata.size=");
         restored.input().write('\n');
         restored.input().flush();
         restored.waitForSuccess();

--- a/test/jdk/jdk/crac/PerfMemoryRestoreTest.java
+++ b/test/jdk/jdk/crac/PerfMemoryRestoreTest.java
@@ -47,7 +47,9 @@ public class PerfMemoryRestoreTest implements CracTest {
         CracBuilder builder = new CracBuilder();
         CracProcess checkpoint = builder.startCheckpoint();
         String pid = String.valueOf(checkpoint.pid());
-        Path perfdata = Path.of(System.getProperty("java.io.tmpdir"), "hsperfdata_" + System.getProperty("user.name"), pid);
+        // This test is run only on Linux where the path is hardcoded
+        // in os::get_temp_directory() to /tmp rather than using System.getProperty("java.io.tmpdir")
+        Path perfdata = Path.of("/tmp", "hsperfdata_" + System.getProperty("user.name"), pid);
         long start = System.nanoTime();
         while (!perfdata.toFile().exists()) {
             if (System.nanoTime() - start > TimeUnit.SECONDS.toNanos(10)) {

--- a/test/jdk/jdk/crac/PerfMemoryRestoreTest.java
+++ b/test/jdk/jdk/crac/PerfMemoryRestoreTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.*;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracProcess;
+import jdk.test.lib.crac.CracTest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static jdk.test.lib.Asserts.*;
+
+/**
+ * @test ContextOrderTest
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @build PerfMemoryRestoreTest
+ * @run driver/timeout=30 jdk.test.lib.crac.CracTest
+ */
+
+public class PerfMemoryRestoreTest implements CracTest {
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder();
+        CracProcess checkpoint = builder.startCheckpoint();
+        String pid = String.valueOf(checkpoint.pid());
+        Path perfdata = Path.of(System.getProperty("java.io.tmpdir"), "hsperfdata_" + System.getProperty("user.name"), pid);
+        while (!perfdata.toFile().exists()) {
+            //noinspection BusyWait
+            Thread.sleep(10);
+        }
+        checkMapped(pid, perfdata.toString());
+
+        checkpoint.input().write('\n');
+        checkpoint.input().flush();
+        checkpoint.waitForCheckpointed();
+        assertFalse(perfdata.toFile().exists());
+
+        CracProcess restored = builder.startRestore();
+        while (!perfdata.toFile().exists()) {
+            //noinspection BusyWait
+            Thread.sleep(10);
+        }
+        // Note: we need to check the checkpoint.pid(), which should be restored (when using CRIU),
+        // as restored.pid() would be the criuengine restorewait process
+        checkMapped(String.valueOf(checkpoint.pid()), perfdata.toString());
+        restored.input().write('\n');
+        restored.input().flush();
+        restored.waitForSuccess();
+    }
+
+    private static void checkMapped(String pid, String perfdata) throws IOException {
+        String perfdataLine = Files.readAllLines(Path.of("/proc", pid, "maps")).stream()
+                .filter(line -> line.contains(perfdata))
+                .findFirst().orElseThrow(() -> new AssertionError("Missing " + perfdata + " in process maps"));
+        assertTrue(perfdataLine.contains("rw-s 00000000"), perfdataLine);
+    }
+
+    @Override
+    public void exec() throws Exception {
+        assertEquals(System.in.read(), (int) '\n');
+        Core.checkpointRestore();
+        assertEquals(System.in.read(), (int) '\n');
+    }
+}

--- a/test/lib/jdk/test/lib/crac/CracBuilder.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilder.java
@@ -4,6 +4,7 @@ import jdk.test.lib.Container;
 import jdk.test.lib.Utils;
 import jdk.test.lib.containers.docker.DockerTestUtils;
 import jdk.test.lib.containers.docker.DockerfileConfig;
+import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.util.FileUtils;
 
 import javax.imageio.IIOException;
@@ -481,14 +482,19 @@ public class CracBuilder {
     }
 
     public void checkpointViaJcmd() throws Exception {
+        runJcmd(main.getName(), "JDK.checkpoint").shouldHaveExitValue(0);
+    }
+
+    public OutputAnalyzer runJcmd(String id, String... command) throws Exception {
         List<String> cmd = new ArrayList<>();
         if (dockerImageName != null) {
             cmd.addAll(Arrays.asList(Container.ENGINE_COMMAND, "exec", CONTAINER_NAME, "/jdk/bin/jcmd"));
         } else {
             cmd.add(Utils.TEST_JDK + "/bin/jcmd");
         }
-        cmd.addAll(Arrays.asList(main().getName(), "JDK.checkpoint"));
+        cmd.add(id);
+        cmd.addAll(Arrays.asList(command));
         // This works for non-docker commands, too
-        DockerTestUtils.execute(cmd).shouldHaveExitValue(0);
+        return DockerTestUtils.execute(cmd);
     }
 }

--- a/test/lib/jdk/test/lib/crac/CracBuilder.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilder.java
@@ -482,7 +482,7 @@ public class CracBuilder {
     }
 
     public void checkpointViaJcmd() throws Exception {
-        runJcmd(main.getName(), "JDK.checkpoint").shouldHaveExitValue(0);
+        runJcmd(main().getName(), "JDK.checkpoint").shouldHaveExitValue(0);
     }
 
     public OutputAnalyzer runJcmd(String id, String... command) throws Exception {

--- a/test/lib/jdk/test/lib/crac/CracProcess.java
+++ b/test/lib/jdk/test/lib/crac/CracProcess.java
@@ -5,6 +5,7 @@ import jdk.test.lib.process.StreamPumper;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.*;
 import java.util.concurrent.TimeUnit;
 import java.util.List;
@@ -20,7 +21,7 @@ public class CracProcess {
 
     public CracProcess(CracBuilder builder, List<String> cmd) throws IOException {
         this.builder = builder;
-        ProcessBuilder pb = new ProcessBuilder().inheritIO();
+        ProcessBuilder pb = new ProcessBuilder().inheritIO().redirectInput(ProcessBuilder.Redirect.PIPE);
         if (builder.captureOutput) {
             pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
             pb.redirectError(ProcessBuilder.Redirect.PIPE);
@@ -127,5 +128,13 @@ public class CracProcess {
                 consumer.accept(line);
             }
         }).process();
+    }
+
+    public long pid() {
+        return process.pid();
+    }
+
+    public OutputStream input() {
+        return process.getOutputStream();
     }
 }


### PR DESCRIPTION
Storing PerfMemory contents into file might be fragile; if the file is corrupted (e.g. due to wrong permissions) JVM might receive SIGBUS when updating performance counters after restore.
This commit provides alternate solution, moving the shared file-mapped memory into private anonymous memory during C/R.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**) ⚠️ Review applies to [ce6cb495](https://git.openjdk.org/crac/pull/119/files/ce6cb49516137ba1122f31612830a774d8a0eea7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/119/head:pull/119` \
`$ git checkout pull/119`

Update a local copy of the PR: \
`$ git checkout pull/119` \
`$ git pull https://git.openjdk.org/crac.git pull/119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 119`

View PR using the GUI difftool: \
`$ git pr show -t 119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/119.diff">https://git.openjdk.org/crac/pull/119.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/119#issuecomment-1738058017)