### PR TITLE
Fix compilation error on OSX

### DIFF
--- a/src/hotspot/os/posix/crac_posix.cpp
+++ b/src/hotspot/os/posix/crac_posix.cpp
@@ -23,6 +23,7 @@
 
 // no precompiled headers
 #include "jvm.h"
+#include "runtime/crac.hpp"
 #include "runtime/crac_structs.hpp"
 
 #include <sys/mman.h>


### PR DESCRIPTION
```
src/hotspot/os/posix/crac_posix.cpp:43:6: error: use of undeclared identifier 'crac'
void crac::vm_create_start() {
     ^
src/hotspot/os/posix/crac_posix.cpp:60:6: error: use of undeclared identifier 'crac'
bool crac::read_bootid(char *dest) {
     ^
2 errors generated.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/120/head:pull/120` \
`$ git checkout pull/120`

Update a local copy of the PR: \
`$ git checkout pull/120` \
`$ git pull https://git.openjdk.org/crac.git pull/120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 120`

View PR using the GUI difftool: \
`$ git pr show -t 120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/120.diff">https://git.openjdk.org/crac/pull/120.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/120#issuecomment-1740569170)