### PR TITLE
Fix OSX x86_64 CRaC crash

### DIFF
--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -395,6 +395,15 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
 
   address pc          = nullptr;
 
+  // VM_Version::crac_restore()->VM_Version::get_processor_features_hardware()
+  // executes cpuinfo without a started Java thread.
+  if (info != NULL && uc != NULL && thread == NULL && sig == SIGSEGV) {
+    pc = (address) os::Posix::ucontext_get_pc(uc);
+    if ((sig == SIGSEGV) && VM_Version::is_cpuinfo_segv_addr(pc)) {
+      stub = VM_Version::cpuinfo_cont_addr();
+    }
+  }
+
   //%note os_trap_1
   if (info != nullptr && uc != nullptr && thread != nullptr) {
     pc = (address) os::Posix::ucontext_get_pc(uc);

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -397,7 +397,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
 
   // VM_Version::crac_restore()->VM_Version::get_processor_features_hardware()
   // executes cpuinfo without a started Java thread.
-  if (info != NULL && uc != NULL && thread == NULL && sig == SIGSEGV) {
+  if (info != nullptr && uc != nullptr && thread == nullptr && sig == SIGSEGV) {
     pc = (address) os::Posix::ucontext_get_pc(uc);
     if ((sig == SIGSEGV) && VM_Version::is_cpuinfo_segv_addr(pc)) {
       stub = VM_Version::cpuinfo_cont_addr();

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -223,7 +223,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
 
   // VM_Version::crac_restore()->VM_Version::get_processor_features_hardware()
   // executes cpuinfo without a started Java thread.
-  if (info != NULL && uc != NULL && thread == NULL && sig == SIGSEGV) {
+  if (info != nullptr && uc != nullptr && thread == nullptr && sig == SIGSEGV) {
     pc = (address) os::Posix::ucontext_get_pc(uc);
     if ((sig == SIGSEGV) && VM_Version::is_cpuinfo_segv_addr(pc)) {
       stub = VM_Version::cpuinfo_cont_addr();


### PR DESCRIPTION
- copy-paste the same code from src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp

It has fixed 3 testcases but the last 4th failure looks to be unrelated to this problem.
```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/jdk/jdk/crac/JarFileFactoryCacheTest/JarFileFactoryCacheTest.java
                                                         1     1     0     0
   jtreg:test/jdk/jdk/crac/MXBean.java                   1     1     0     0
   jtreg:test/jdk/jdk/crac/RefQueueTest.java             1     1     0     0
   jtreg:test/jdk/jdk/crac/recursiveCheckpoint/Test.java
>>                                                       1     0     1     0 <<
==============================
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/121/head:pull/121` \
`$ git checkout pull/121`

Update a local copy of the PR: \
`$ git checkout pull/121` \
`$ git pull https://git.openjdk.org/crac.git pull/121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 121`

View PR using the GUI difftool: \
`$ git pr show -t 121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/121.diff">https://git.openjdk.org/crac/pull/121.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/121#issuecomment-1740655482)