### PR TITLE
Fix OSX failure in SunMiscSignalTest

### DIFF
--- a/src/hotspot/os/posix/include/jvm_md.h
+++ b/src/hotspot/os/posix/include/jvm_md.h
@@ -92,9 +92,8 @@
 #define SHUTDOWN3_SIGNAL SIGTERM
 
 #if defined(LINUX)
+// The signal is blocked by default; this should not break SunMiscSignalTest
 #define RESTORE_SIGNAL   (SIGRTMIN + 2)
-#elif defined(__APPLE__)
-#define RESTORE_SIGNAL   SIGUSR2
 #endif
 
 #endif /* !_JAVASOFT_JVM_MD_H_ */

--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -1546,7 +1546,10 @@ static void signal_sets_init() {
   }
 
   sigemptyset(&blocked_sigs);
+// RESTORE_SIGNAL is used only on Linux, other platform don't send this
+#ifdef LINUX
   sigaddset(&blocked_sigs, RESTORE_SIGNAL);
+#endif
 
   debug_only(signal_sets_initialized = true);
 }


### PR DESCRIPTION
Fixes GHA failure in SunMiscSignalTest on OSX

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)
 * [Roman Marchenko](https://openjdk.org/census#rmarchenko) (@wkia - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/123/head:pull/123` \
`$ git checkout pull/123`

Update a local copy of the PR: \
`$ git checkout pull/123` \
`$ git pull https://git.openjdk.org/crac.git pull/123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 123`

View PR using the GUI difftool: \
`$ git pr show -t 123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/123.diff">https://git.openjdk.org/crac/pull/123.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/123#issuecomment-1750672357)