### PR TITLE
Stabilize GHA testsuite

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -58,9 +58,9 @@ jobs:
         target-cpu:
           - aarch64
           - arm
-          - s390x
-          - ppc64le
-          - riscv64
+          # - s390x
+          # - ppc64le
+          # - riscv64
         include:
           - target-cpu: aarch64
             gnu-arch: aarch64
@@ -73,21 +73,21 @@ jobs:
             debian-repository: https://httpredir.debian.org/debian/
             debian-version: bullseye
             gnu-abi: eabihf
-          - target-cpu: s390x
-            gnu-arch: s390x
-            debian-arch: s390x
-            debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
-          - target-cpu: ppc64le
-            gnu-arch: powerpc64le
-            debian-arch: ppc64el
-            debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
-          - target-cpu: riscv64
-            gnu-arch: riscv64
-            debian-arch: riscv64
-            debian-repository: https://httpredir.debian.org/debian/
-            debian-version: sid
+          # - target-cpu: s390x
+          #   gnu-arch: s390x
+          #   debian-arch: s390x
+          #   debian-repository: https://httpredir.debian.org/debian/
+          #   debian-version: bullseye
+          # - target-cpu: ppc64le
+          #   gnu-arch: powerpc64le
+          #   debian-arch: ppc64el
+          #   debian-repository: https://httpredir.debian.org/debian/
+          #   debian-version: bullseye
+          # - target-cpu: riscv64
+          #   gnu-arch: riscv64
+          #   debian-arch: riscv64
+          #   debian-repository: https://httpredir.debian.org/debian/
+          #   debian-version: sid
 
     steps:
       - name: 'Checkout the JDK source'

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -99,6 +99,8 @@ runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
+# JDK-8310862 was closed but we're still seeing errors with the updated test
+runtime/ClassInitErrors/TestStackOverflowDuringInit.java 8310862 generic-all
 runtime/CompressedOops/CompressedClassPointers.java 8305765 generic-all
 runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/ErrorHandling/TestDwarf.java 8305489 linux-all


### PR DESCRIPTION
At this point Github Actions always show some failures; let's ignore platforms that we don't handle for CRaC and some problematic tests in mainline JDK. 