### PR TITLE
Update the "modified criu" link to the latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ bash configure
 make images
 mv build/linux-x86_64-server-release/images/jdk/ .
 ```
-2. Download a build of [modified CRIU](https://github.com/org-crac/criu/releases/tag/release-crac)
+2. Download a build of [modified CRIU](https://github.com/CRaC/criu/releases/tag/release-1.4)
 3. Extract and copy `criu` binary over a same named file in the JDK
 ```
 cp criu-dist/sbin/criu jdk/lib/criu


### PR DESCRIPTION
The modified criu binary downloaded from the release that is linked from the README causes CRaC to segfault while checkpointing. Updating to the latest release helps resolve the problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/126/head:pull/126` \
`$ git checkout pull/126`

Update a local copy of the PR: \
`$ git checkout pull/126` \
`$ git pull https://git.openjdk.org/crac.git pull/126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 126`

View PR using the GUI difftool: \
`$ git pr show -t 126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/126.diff">https://git.openjdk.org/crac/pull/126.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/126#issuecomment-1763740377)