### PR TITLE
Fix test when running as root

### DIFF
--- a/test/jdk/jdk/crac/fileDescriptors/ReopenFailureTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/ReopenFailureTest.java
@@ -89,7 +89,12 @@ public class ReopenFailureTest extends FDPolicyTestBase implements CracTest {
                 Core.checkpointRestore();
                 fail("Should throw");
             } catch (RestoreException ex) {
-                assertEquals(2, ex.getSuppressed().length);
+                // When running this as root we get only one exception for the missing file
+                if (Files.isWritable(Path.of(log2))) {
+                    assertEquals(1, ex.getSuppressed().length);
+                } else {
+                    assertEquals(2, ex.getSuppressed().length);
+                }
             }
         }
     }


### PR DESCRIPTION
Root can reopen the file even without permissions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/128/head:pull/128` \
`$ git checkout pull/128`

Update a local copy of the PR: \
`$ git checkout pull/128` \
`$ git pull https://git.openjdk.org/crac.git pull/128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 128`

View PR using the GUI difftool: \
`$ git pr show -t 128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/128.diff">https://git.openjdk.org/crac/pull/128.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/128#issuecomment-1765839899)