### PR TITLE
Fixing crash on restore when user name is not set

### DIFF
--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1401,6 +1401,9 @@ bool PerfMemoryLinux::restore() {
 
   int vmid = os::current_process_id();
   char* user_name = get_user_name(geteuid());
+  if (!user_name) {
+    return false;
+  }
   char* dirname = get_user_tmp_dir(user_name, vmid, -1);
   if (!make_user_tmp_dir(dirname)) {
     return false;


### PR DESCRIPTION
This change fixes a crash occuring during restore in a container when user name is not set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/129/head:pull/129` \
`$ git checkout pull/129`

Update a local copy of the PR: \
`$ git checkout pull/129` \
`$ git pull https://git.openjdk.org/crac.git pull/129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 129`

View PR using the GUI difftool: \
`$ git pr show -t 129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/129.diff">https://git.openjdk.org/crac/pull/129.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/129#issuecomment-1765979644)