### PR TITLE
Reset JVM start time and up time on restore (CRaCResetStartTime)

### DIFF
--- a/src/hotspot/os/linux/crac_linux.cpp
+++ b/src/hotspot/os/linux/crac_linux.cpp
@@ -23,7 +23,6 @@
 
 // no precompiled headers
 #include "jvm.h"
-#include "os_posix.hpp"
 #include "perfMemory_linux.hpp"
 #include "runtime/crac_structs.hpp"
 #include "runtime/crac.hpp"

--- a/src/hotspot/os/linux/crac_linux.cpp
+++ b/src/hotspot/os/linux/crac_linux.cpp
@@ -23,6 +23,7 @@
 
 // no precompiled headers
 #include "jvm.h"
+#include "os_posix.hpp"
 #include "perfMemory_linux.hpp"
 #include "runtime/crac_structs.hpp"
 #include "runtime/crac.hpp"
@@ -461,4 +462,8 @@ bool crac::read_bootid(char *dest) {
     perror("CRaC: Cannot close system boot ID file");
   }
   return true;
+}
+
+void crac::initialize_time_counters() {
+  os::Posix::init();
 }

--- a/src/hotspot/os/linux/crac_linux.cpp
+++ b/src/hotspot/os/linux/crac_linux.cpp
@@ -463,7 +463,3 @@ bool crac::read_bootid(char *dest) {
   }
   return true;
 }
-
-void crac::initialize_time_counters() {
-  os::Posix::init();
-}

--- a/src/hotspot/os/posix/crac_posix.cpp
+++ b/src/hotspot/os/posix/crac_posix.cpp
@@ -23,6 +23,7 @@
 
 // no precompiled headers
 #include "jvm.h"
+#include "os_posix.hpp"
 #include "runtime/crac.hpp"
 #include "runtime/crac_structs.hpp"
 

--- a/src/hotspot/os/posix/crac_posix.cpp
+++ b/src/hotspot/os/posix/crac_posix.cpp
@@ -40,6 +40,10 @@ void CracSHM::unlink() {
   shm_unlink(_path);
 }
 
+void crac::initialize_time_counters() {
+  os::Posix::initialize_time_counters();
+}
+
 #ifndef LINUX
 void crac::vm_create_start() {
 }

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -1255,6 +1255,10 @@ void os::Posix::init(void) {
     }
   }
 
+  initialize_time_counters();
+}
+
+void os::Posix::initialize_time_counters(void) {
   initial_time_count = javaTimeNanos();
 }
 

--- a/src/hotspot/os/posix/os_posix.hpp
+++ b/src/hotspot/os/posix/os_posix.hpp
@@ -64,6 +64,7 @@ protected:
 public:
   static void init(void);  // early initialization - no logging available
   static void init_2(void);// later initialization - logging available
+  static void initialize_time_counters(void);
 
   // Return default stack size for the specified thread type
   static size_t default_stack_size(os::ThreadType thr_type);

--- a/src/hotspot/os/windows/crac_windows.cpp
+++ b/src/hotspot/os/windows/crac_windows.cpp
@@ -53,3 +53,7 @@ void CracSHM::unlink() {
 bool crac::read_bootid(char *dest) {
   return true;
 }
+
+void crac::initialize_time_counters() {
+  os::win32::initialize_performance_counter();
+}

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -54,6 +54,7 @@ class os::win32 {
 
  public:
   // Windows-specific interface:
+  static void   initialize_performance_counter();
   static void   initialize_system_info();
   static void   setmode_streams();
 
@@ -77,8 +78,6 @@ class os::win32 {
   enum Ept { EPT_THREAD, EPT_PROCESS, EPT_PROCESS_DIE };
   // Wrapper around _endthreadex(), exit() and _exit()
   static int exit_process_or_thread(Ept what, int exit_code);
-
-  static void initialize_performance_counter();
 
  public:
   // Generic interface:

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -357,6 +357,10 @@ void VM_Crac::doit() {
     _restore_start_nanos += crac::monotonic_time_offset();
   }
 
+  if (CRaCResetStartTime) {
+    crac::initialize_time_counters();
+  }
+
   // VM_Crac::read_shm needs to be already called to read RESTORE_SETTABLE parameters.
   VM_Version::crac_restore_finalize();
 

--- a/src/hotspot/share/runtime/crac.hpp
+++ b/src/hotspot/share/runtime/crac.hpp
@@ -48,6 +48,8 @@ public:
     return javaTimeNanos_offset;
   }
 
+  static void initialize_time_counters();
+
 private:
   static bool read_bootid(char *dest);
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1996,6 +1996,9 @@ const int ObjectAlignmentInBytes = 8;
       "Mininal PID value for checkpoint'ed process")                        \
       range(1, UINT_MAX)                                                    \
                                                                             \
+  product(bool, CRaCResetStartTime, false, RESTORE_SETTABLE,                    \
+      "Reset JVM's start time and uptime on restore")                     \
+                                                                            \
   product(ccstr, CREngine, "criuengine", RESTORE_SETTABLE,                  \
       "Path or name of a program implementing checkpoint/restore and "      \
       "optional extra parameters as a comma-separated list: "               \

--- a/test/jdk/jdk/crac/ResetStartTimeTest.java
+++ b/test/jdk/jdk/crac/ResetStartTimeTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+import jdk.test.lib.Utils;
+
+import java.lang.management.ManagementFactory;
+import java.nio.file.Path;
+import java.util.*;
+
+import static jdk.test.lib.Asserts.assertLessThan;
+
+/**
+ * @test
+ * @library /test/lib
+ * @build SimpleTest
+ * @requires (os.family == "linux")
+ * @run driver/timeout=60 jdk.test.lib.crac.CracTest false
+ * @run driver/timeout=60 jdk.test.lib.crac.CracTest true
+ */
+public class SimpleTest implements CracTest {
+
+    @CracTestArg(0)
+    boolean resetUptime;
+
+    static private final long WAIT_TIMEOUT = 2 * 1000; // msecs
+
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder();
+        builder.startCheckpoint().waitForCheckpointed();
+        if (resetUptime) {
+            builder.vmOption("-XX:+CRaCResetStartTime");
+        }
+        builder.captureOutput(true).doRestore().outputAnalyzer().shouldContain(RESTORED_MESSAGE);
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Thread.sleep(WAIT_TIMEOUT);
+        final long uptime0 = ManagementFactory.getRuntimeMXBean().getUptime();
+
+        Core.checkpointRestore();
+        System.out.println(RESTORED_MESSAGE);
+
+        final long uptime1 = ManagementFactory.getRuntimeMXBean().getUptime();
+
+        if (resetUptime) {
+            assertLessThan(uptime1, uptime0);
+            assertLessThan(uptime1, WAIT_TIMEOUT);
+        } else {
+            assertLessThan(uptime0, uptime1);
+        }
+    }
+}


### PR DESCRIPTION
This change adds an opportunity reset both JVM's start time and uptime on restoring.

Resetting time may be performed with the new flag "-XX:+CRaCResetStartTime".

The flag is 'false' by default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/130/head:pull/130` \
`$ git checkout pull/130`

Update a local copy of the PR: \
`$ git checkout pull/130` \
`$ git pull https://git.openjdk.org/crac.git pull/130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 130`

View PR using the GUI difftool: \
`$ git pr show -t 130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/130.diff">https://git.openjdk.org/crac/pull/130.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/130#issuecomment-1766042838)