### PR TITLE
Terminate restored process when criuengine restorewait exits

### DIFF
--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -209,6 +209,15 @@ static int call_crengine() {
   return os::exec_child_process_and_wait(_crengine, _crengine_args);
 }
 
+static bool ends_with(const char *str, const char *suffix) {
+  size_t str_len = strlen(str);
+  size_t suffix_len = strlen(suffix);
+  if (suffix_len > str_len) {
+    return false;
+  }
+  return !strcmp(str + str_len - suffix_len, suffix);
+}
+
 static int checkpoint_restore(int *shmid) {
   crac::record_time_before_checkpoint();
 
@@ -236,6 +245,10 @@ static int checkpoint_restore(int *shmid) {
 #else
   // TODO add sync processing
 #endif //LINUX
+
+  if (ends_with(_crengine, "criuengine")) {
+    LINUX_ONLY(crac::set_terminate_with_parent());
+  }
 
   crac::update_javaTimeNanos_offset();
 

--- a/src/hotspot/share/runtime/crac.hpp
+++ b/src/hotspot/share/runtime/crac.hpp
@@ -43,6 +43,13 @@ public:
 
   static void record_time_before_checkpoint();
   static void update_javaTimeNanos_offset();
+#ifdef LINUX
+  // With criuengine the restored process gets restorewait process
+  // as its parent; scripts not expecting two processes might signal
+  // (e.g. terminate) the parent process but the actual restored
+  // process would get orphaned.
+  static void set_terminate_with_parent();
+#endif
 
   static jlong monotonic_time_offset() {
     return javaTimeNanos_offset;

--- a/test/jdk/jdk/crac/KillRestoredTest.java
+++ b/test/jdk/jdk/crac/KillRestoredTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import jdk.crac.*;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracEngine;
+import jdk.test.lib.crac.CracProcess;
+import jdk.test.lib.crac.CracTest;
+
+import static jdk.test.lib.Asserts.*;
+
+/**
+ * @test KillRestoredTest
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @build KillRestoredTest
+ * @run driver/timeout=20 jdk.test.lib.crac.CracTest
+ */
+public class KillRestoredTest implements CracTest {
+    @Override
+    public void test() throws Exception {
+        CracProcess checkpoint = new CracBuilder().startCheckpoint();
+        checkpoint.waitForCheckpointed();
+        CracProcess restore = new CracBuilder().startRestore();
+        assertTrue(processExists(restore.pid())); // criu or criuengine
+        while (!processExists(checkpoint.pid())) { // actually restored process
+            Thread.sleep(50);
+        }
+        String children = Files.readString(Path.of("/proc/" + restore.pid() + "/task/" + restore.pid() + "/children")).trim();
+        assertEquals(String.valueOf(checkpoint.pid()), children);
+        new ProcessBuilder().inheritIO().command("kill", "-9", String.valueOf(restore.pid())).start().waitFor();
+        assertEquals(137, restore.waitFor());
+        assertFalse(processExists(restore.pid()));
+        // While the PID is the same, checkpoint.waitFor() would wait for a different process
+        while (processExists(checkpoint.pid())) {
+            Thread.sleep(50);// signal delivery and termination might take a bit
+        }
+    }
+
+    private boolean processExists(long pid) {
+        File procDir = new File("/proc/" + pid);
+        return procDir.exists() && procDir.isDirectory();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Core.checkpointRestore();
+        Thread.sleep(60_000);
+    }
+}

--- a/test/lib/jdk/test/lib/crac/CracProcess.java
+++ b/test/lib/jdk/test/lib/crac/CracProcess.java
@@ -128,4 +128,8 @@ public class CracProcess {
             }
         }).process();
     }
+
+    public long pid() {
+        return process.pid();
+    }
 }


### PR DESCRIPTION
With criuengine the restored process gets restorewait process as its parent; scripts not expecting two processes might signal (e.g. terminate) the parent process but the actual restored process would get orphaned.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/131/head:pull/131` \
`$ git checkout pull/131`

Update a local copy of the PR: \
`$ git checkout pull/131` \
`$ git pull https://git.openjdk.org/crac.git pull/131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 131`

View PR using the GUI difftool: \
`$ git pr show -t 131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/131.diff">https://git.openjdk.org/crac/pull/131.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/131#issuecomment-1770689505)