### PR TITLE
Test CRIU restore with output redirected to file during checkpoint

### DIFF
--- a/test/jdk/jdk/crac/fileDescriptors/OutputToFileTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/OutputToFileTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static jdk.test.lib.Asserts.assertTrue;
+
+/**
+ * @test
+ * @requires (os.family == "linux")
+ * @library /test/lib
+ * @build OutputToFileTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class OutputToFileTest implements CracTest {
+    @Override
+    public void test() throws Exception {
+        Path stdin = Files.createTempFile(getClass().getSimpleName(), ".in");
+        Files.writeString(stdin, "foobar");
+        Path stdout = Files.createTempFile(getClass().getSimpleName(), ".out");
+        Path stderr = Files.createTempFile(getClass().getSimpleName(), ".err");
+        new CracBuilder().inputFrom(stdin).outputTo(stdout, stderr).doCheckpoint();
+        assertTrue(stdin.toFile().delete());
+        assertTrue(stdout.toFile().delete());
+        assertTrue(stderr.toFile().delete());
+        new CracBuilder().doRestore();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Core.checkpointRestore();
+    }
+}

--- a/test/lib/jdk/test/lib/crac/CracBuilder.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilder.java
@@ -6,7 +6,6 @@ import jdk.test.lib.containers.docker.DockerTestUtils;
 import jdk.test.lib.containers.docker.DockerfileConfig;
 import jdk.test.lib.util.FileUtils;
 
-import javax.imageio.IIOException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
@@ -46,6 +45,9 @@ public class CracBuilder {
     Class<?> main;
     String[] args;
     boolean captureOutput;
+    Path stdinPath;
+    Path stdoutPath;
+    Path stderrPath;
     String dockerImageBaseName;
     String dockerImageBaseVersion;
     String dockerImageName;
@@ -196,6 +198,17 @@ public class CracBuilder {
 
     public CracBuilder captureOutput(boolean captureOutput) {
         this.captureOutput = captureOutput;
+        return this;
+    }
+
+    public CracBuilder inputFrom(Path stdinPath) {
+        this.stdinPath = stdinPath;
+        return this;
+    }
+
+    public CracBuilder outputTo(Path stdoutPath, Path stderrPath) {
+        this.stdoutPath = stdoutPath;
+        this.stderrPath = stderrPath;
         return this;
     }
 

--- a/test/lib/jdk/test/lib/crac/CracProcess.java
+++ b/test/lib/jdk/test/lib/crac/CracProcess.java
@@ -3,6 +3,7 @@ package jdk.test.lib.crac;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.StreamPumper;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.*;
@@ -24,6 +25,17 @@ public class CracProcess {
         if (builder.captureOutput) {
             pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
             pb.redirectError(ProcessBuilder.Redirect.PIPE);
+            assertNull(builder.stdoutPath);
+            assertNull(builder.stderrPath);
+        }
+        if (builder.stdinPath != null) {
+            pb.redirectInput(builder.stdinPath.toFile());
+        }
+        if (builder.stdoutPath != null) {
+            pb.redirectOutput(builder.stdoutPath.toFile());
+        }
+        if (builder.stderrPath != null) {
+            pb.redirectError(builder.stderrPath.toFile());
         }
         pb.environment().putAll(builder.env);
         this.process = pb.command(cmd).start();


### PR DESCRIPTION
Posting as a draft - this test will fail until https://github.com/CRaC/criu/pull/13 is integrated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/132/head:pull/132` \
`$ git checkout pull/132`

Update a local copy of the PR: \
`$ git checkout pull/132` \
`$ git pull https://git.openjdk.org/crac.git pull/132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 132`

View PR using the GUI difftool: \
`$ git pr show -t 132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/132.diff">https://git.openjdk.org/crac/pull/132.diff</a>

</details>
