### PR TITLE
Fix CPUFeatures crash on new->old CPU

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -64,7 +64,7 @@ public:
   // Initialization
   static void initialize();
   static void crac_restore() {}
-  static void crac_restore_finalize() {}
+  static void crac_restore_finalize(char ignore_cpu_features) {}
   static void check_virtualizations();
 
   static void print_platform_virtualization_info(outputStream*);

--- a/src/hotspot/cpu/arm/vm_version_arm.hpp
+++ b/src/hotspot/cpu/arm/vm_version_arm.hpp
@@ -42,7 +42,7 @@ class VM_Version: public Abstract_VM_Version {
   static void initialize();
   static bool is_initialized()      { return _is_initialized; }
   static void crac_restore() {}
-  static void crac_restore_finalize() {}
+  static void crac_restore_finalize(char ignore_cpu_features) {}
 
 
  protected:

--- a/src/hotspot/cpu/ppc/vm_version_ppc.hpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.hpp
@@ -88,7 +88,7 @@ public:
   static void initialize();
   static void check_virtualizations();
   static void crac_restore() {}
-  static void crac_restore_finalize() {}
+  static void crac_restore_finalize(char ignore_cpu_features) {}
 
   // Override Abstract_VM_Version implementation
   static void print_platform_virtualization_info(outputStream*);

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -198,7 +198,7 @@ class VM_Version : public Abstract_VM_Version {
   static void initialize();
   static void initialize_cpu_information();
   static void crac_restore() {}
-  static void crac_restore_finalize() {}
+  static void crac_restore_finalize(char ignore_cpu_features) {}
 
   constexpr static bool supports_stack_watermark_barrier() { return true; }
 

--- a/src/hotspot/cpu/s390/vm_version_s390.hpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.hpp
@@ -407,7 +407,7 @@ class VM_Version: public Abstract_VM_Version {
   static void print_features();
   static bool is_determine_features_test_running() { return _is_determine_features_test_running; }
   static void crac_restore() {}
-  static void crac_restore_finalize() {}
+  static void crac_restore_finalize(char ignore_cpu_features) {}
 
   // Override Abstract_VM_Version implementation
   static void print_platform_virtualization_info(outputStream*);

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -2773,6 +2773,7 @@ void VM_Version::crac_restore() {
     print_using_features_cr();
 }
 
+// This function may be called twice.
 void VM_Version::crac_restore_finalize() {
   if (_crac_restore_missing_features && !IgnoreCPUFeatures) {
     vm_exit_during_initialization();

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -2774,7 +2774,9 @@ void VM_Version::crac_restore() {
 }
 
 // This function may be called twice.
-void VM_Version::crac_restore_finalize() {
+void VM_Version::crac_restore_finalize(char ignore_cpu_features) {
+  if (ignore_cpu_features)
+    IgnoreCPUFeatures = ignore_cpu_features == '+';
   if (_crac_restore_missing_features && !IgnoreCPUFeatures) {
     vm_exit_during_initialization();
   }

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1398,11 +1398,16 @@ void VM_Version::nonlibc_tty_print_uint64_comma_uint64(uint64_t num1, uint64_t n
 }
 
 void VM_Version::print_using_features_cr() {
+  // We are running still before crac_restore_finalize() so we cannot use string functions.
   if (_ignore_glibc_not_using) {
-    tty->print_cr("CPU features are being kept intact as requested by -XX:CPUFeatures=ignore");
+    static const char msg[] = "CPU features are being kept intact as requested by -XX:CPUFeatures=ignore";
+    tty->print_raw(msg, sizeof(msg) - 1);
   } else {
-    tty->print_cr("CPU features being used are: -XX:CPUFeatures=" UINT64_FORMAT_X "," UINT64_FORMAT_X, _features, _glibc_features);
+    static const char prefix[] = "CPU features being used are: -XX:CPUFeatures=";
+    tty->print_raw(prefix, sizeof(prefix) - 1);
+    nonlibc_tty_print_uint64_comma_uint64(_features, _glibc_features);
   }
+  tty->cr();
 }
 
 void VM_Version::get_processor_features_hardware() {

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -680,7 +680,7 @@ public:
   // Initialization
   static void initialize();
   static void crac_restore();
-  static void crac_restore_finalize();
+  static void crac_restore_finalize(char ignore_cpu_features);
 
   // Override Abstract_VM_Version implementation
   static void print_platform_virtualization_info(outputStream*);

--- a/src/hotspot/cpu/zero/vm_version_zero.hpp
+++ b/src/hotspot/cpu/zero/vm_version_zero.hpp
@@ -33,7 +33,7 @@ class VM_Version : public Abstract_VM_Version {
  public:
   static void initialize();
   static void crac_restore() {}
-  static void crac_restore_finalize() {}
+  static void crac_restore_finalize(char ignore_cpu_features) {}
 
   // No _features_names[] available on this CPU.
   static void insert_features_names(char* buf, size_t buflen, uint64_t features = _features) {}

--- a/src/hotspot/os/posix/crac_posix.cpp
+++ b/src/hotspot/os/posix/crac_posix.cpp
@@ -30,7 +30,8 @@
 #include <sys/mman.h>
 
 int CracSHM::open(int mode) {
-  int shmfd = shm_open(_path, mode, 0600);
+  // shm_open() is using glibc string functions, therefore it cannot be used before calling crac_restore_finalize().
+  int shmfd = ::open(_path, mode, 0600);
   if (-1 == shmfd) {
     perror("shm_open");
   }
@@ -38,7 +39,7 @@ int CracSHM::open(int mode) {
 }
 
 void CracSHM::unlink() {
-  shm_unlink(_path);
+  ::unlink(_path);
 }
 
 void crac::initialize_time_counters() {

--- a/src/hotspot/os/posix/crac_posix.cpp
+++ b/src/hotspot/os/posix/crac_posix.cpp
@@ -29,6 +29,8 @@
 
 #include <sys/mman.h>
 
+const char CracSHM::_prefix[] = "/tmp/cracshm.";
+
 int CracSHM::open(int mode) {
   // shm_open() is using glibc string functions, therefore it cannot be used before calling crac_restore_finalize().
   int shmfd = ::open(_path, mode, 0600);

--- a/src/hotspot/os/windows/crac_windows.cpp
+++ b/src/hotspot/os/windows/crac_windows.cpp
@@ -43,6 +43,8 @@ bool VM_Crac::memory_checkpoint() {
 void VM_Crac::memory_restore() {
 }
 
+const char CracSHM::_prefix[] = "";
+
 int CracSHM::open(int mode) {
   return -1;
 }

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -523,7 +523,8 @@ bool CracRestoreParameters::read_from(int fd) {
     perror("read (ignoring restore parameters)");
     return false;
   }
-  IgnoreCPUFeatures = hdr._ignore_cpu_features;
+  if (hdr._ignore_cpu_features)
+    IgnoreCPUFeatures = hdr._ignore_cpu_features == '+';
   VM_Version::crac_restore_finalize();
 
   struct stat st;

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -351,7 +351,7 @@ void VM_Crac::doit() {
   VM_Version::crac_restore();
 
   if (shmid <= 0 || !VM_Crac::read_shm(shmid)) {
-    VM_Version::crac_restore_finalize();
+    VM_Version::crac_restore_finalize(0);
 
     _restore_start_time = os::javaTimeMillis();
     _restore_start_nanos = os::javaTimeNanos();
@@ -523,9 +523,7 @@ bool CracRestoreParameters::read_from(int fd) {
     perror("read (ignoring restore parameters)");
     return false;
   }
-  if (hdr._ignore_cpu_features)
-    IgnoreCPUFeatures = hdr._ignore_cpu_features == '+';
-  VM_Version::crac_restore_finalize();
+  VM_Version::crac_restore_finalize(hdr._ignore_cpu_features);
 
   struct stat st;
   if (fstat(fd, &st) || st.st_size < (ssize_t)sizeof(hdr)) {

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -526,12 +526,13 @@ bool CracRestoreParameters::read_from(int fd) {
   VM_Version::crac_restore_finalize(hdr._ignore_cpu_features);
 
   struct stat st;
-  if (fstat(fd, &st) || st.st_size < (ssize_t)sizeof(hdr)) {
+  if (fstat(fd, &st) || st.st_size < (ssize_t)sizeof(hdr) || st.st_size > UINT_MAX) {
     perror("fstat (ignoring restore parameters)");
     return false;
   }
 
-  size_t contents_size = st.st_size - sizeof(hdr);
+  // size_t: MSVC: conversion from 'size_t' to 'unsigned int', possible loss of data
+  unsigned contents_size = st.st_size - sizeof(hdr);
   char *contents = NEW_C_HEAP_ARRAY(char, contents_size, mtInternal);
   if (read(fd, contents, contents_size) < 0) {
     perror("read (ignoring restore parameters)");

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -526,7 +526,7 @@ bool CracRestoreParameters::read_from(int fd) {
   VM_Version::crac_restore_finalize(hdr._ignore_cpu_features);
 
   struct stat st;
-  if (fstat(fd, &st) || st.st_size < (ssize_t)sizeof(hdr) || st.st_size > UINT_MAX) {
+  if (fstat(fd, &st) || st.st_size < (ssize_t)sizeof(hdr) || st.st_size > INT_MAX) {
     perror("fstat (ignoring restore parameters)");
     return false;
   }

--- a/src/hotspot/share/runtime/crac_structs.hpp
+++ b/src/hotspot/share/runtime/crac_structs.hpp
@@ -60,6 +60,7 @@ class CracRestoreParameters : public CHeapObj<mtInternal> {
     int _nflags;
     int _nprops;
     int _env_memory_size;
+    bool _ignore_cpu_features;
   };
 
   static bool write_check_error(int fd, const void *buf, int count) {
@@ -115,16 +116,13 @@ class CracRestoreParameters : public CHeapObj<mtInternal> {
       const char *args,
       jlong restore_time,
       jlong restore_nanos) {
-    if (!write_check_error(fd, (void *)&IgnoreCPUFeatures, sizeof(IgnoreCPUFeatures))) {
-      return false;
-    }
-
     header hdr = {
       restore_time,
       restore_nanos,
       num_flags,
       system_props_length(props),
-      env_vars_size(os::get_environ())
+      env_vars_size(os::get_environ()),
+      IgnoreCPUFeatures
     };
 
     if (!write_check_error(fd, (void *)&hdr, sizeof(header))) {

--- a/src/hotspot/share/runtime/crac_structs.hpp
+++ b/src/hotspot/share/runtime/crac_structs.hpp
@@ -60,7 +60,7 @@ class CracRestoreParameters : public CHeapObj<mtInternal> {
     int _nflags;
     int _nprops;
     int _env_memory_size;
-    bool _ignore_cpu_features;
+    char _ignore_cpu_features; // IgnoreCPUFeatures: 0 to keep the checkpointed value, '+' for true, '-' for false
   };
 
   static bool write_check_error(int fd, const void *buf, int count) {
@@ -122,8 +122,14 @@ class CracRestoreParameters : public CHeapObj<mtInternal> {
       num_flags,
       system_props_length(props),
       env_vars_size(os::get_environ()),
-      IgnoreCPUFeatures
+      0 // _ignore_cpu_features
     };
+
+    for (int i = 0; i < num_flags; ++i) {
+      if ((flags[i][0] == '+' || flags[i][0] == '-') && strcmp(flags[i] + 1, "IgnoreCPUFeatures") == 0) {
+        hdr._ignore_cpu_features = flags[i][0];
+      }
+    }
 
     if (!write_check_error(fd, (void *)&hdr, sizeof(header))) {
       return false;

--- a/src/hotspot/share/runtime/crac_structs.hpp
+++ b/src/hotspot/share/runtime/crac_structs.hpp
@@ -218,12 +218,12 @@ class CracSHM {
     write_dec(d, id / 10);
     *d++ = '0' + id % 10;
   }
+  static const char _prefix[];
 public:
   CracSHM(int id) {
     assert(id > 0, "id is expected to be a PID and therefore > 0");
     char *d = _path;
-    const char prefix[] = "/tmp/cracshm.";
-    const char *cs = prefix;
+    const char *cs = _prefix;
     while (*cs) {
       *d++ = *cs++;
     }


### PR DESCRIPTION
- reproducible on i7-1165G7 "qemu-kvm -cpu host" for a checkpoint and "qemu-kvm -cpu SandyBridge" for its restore

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/134/head:pull/134` \
`$ git checkout pull/134`

Update a local copy of the PR: \
`$ git checkout pull/134` \
`$ git pull https://git.openjdk.org/crac.git pull/134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 134`

View PR using the GUI difftool: \
`$ git pr show -t 134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/134.diff">https://git.openjdk.org/crac/pull/134.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/134#issuecomment-1779515285)