### PR TITLE
Changing CRaCResetStartTime flag defaults

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1996,8 +1996,8 @@ const int ObjectAlignmentInBytes = 8;
       "Mininal PID value for checkpoint'ed process")                        \
       range(1, UINT_MAX)                                                    \
                                                                             \
-  product(bool, CRaCResetStartTime, false, RESTORE_SETTABLE,                    \
-      "Reset JVM's start time and uptime on restore")                     \
+  product(bool, CRaCResetStartTime, true, DIAGNOSTIC,                       \
+      "Reset JVM's start time and uptime on restore")                       \
                                                                             \
   product(ccstr, CREngine, "criuengine", RESTORE_SETTABLE,                  \
       "Path or name of a program implementing checkpoint/restore and "      \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -177,7 +177,8 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, AlwaysSafeConstructors, false, EXPERIMENTAL,                \
           "Force safe construction, as if all fields are final.")           \
                                                                             \
-  product(bool, UnlockDiagnosticVMOptions, trueInDebug, DIAGNOSTIC,         \
+  product(bool, UnlockDiagnosticVMOptions, trueInDebug,                     \
+          DIAGNOSTIC | RESTORE_SETTABLE,                                    \
           "Enable normal processing of flags relating to field diagnostics")\
                                                                             \
   product(bool, UnlockExperimentalVMOptions, false,                         \
@@ -1996,7 +1997,7 @@ const int ObjectAlignmentInBytes = 8;
       "Mininal PID value for checkpoint'ed process")                        \
       range(1, UINT_MAX)                                                    \
                                                                             \
-  product(bool, CRaCResetStartTime, true, DIAGNOSTIC,                       \
+  product(bool, CRaCResetStartTime, true, DIAGNOSTIC | RESTORE_SETTABLE,    \
       "Reset JVM's start time and uptime on restore")                       \
                                                                             \
   product(ccstr, CREngine, "criuengine", RESTORE_SETTABLE,                  \

--- a/test/jdk/jdk/crac/ResetStartTimeTest.java
+++ b/test/jdk/jdk/crac/ResetStartTimeTest.java
@@ -41,6 +41,7 @@ import static jdk.test.lib.Asserts.assertLTE;
  * @build ResetStartTimeTest
  * @run driver/timeout=60 jdk.test.lib.crac.CracTest false
  * @run driver/timeout=60 jdk.test.lib.crac.CracTest true
+ * @requires (os.family == "linux")
  */
 public class ResetStartTimeTest implements CracTest {
 
@@ -51,15 +52,14 @@ public class ResetStartTimeTest implements CracTest {
 
     @Override
     public void test() throws Exception {
-        CracBuilder builder = new CracBuilder().engine(CracEngine.SIMULATE);
+        CracBuilder builder = new CracBuilder();
+        builder.startCheckpoint().waitForCheckpointed();
         if (!resetUptime) {
             builder.vmOption("-XX:+UnlockDiagnosticVMOptions");
             builder.vmOption("-XX:-CRaCResetStartTime");
         }
-        var output = builder.captureOutput(true)
-                .startCheckpoint().waitForSuccess()
-                .outputAnalyzer();
-        output.shouldContain(RESTORED_MESSAGE);
+        builder.captureOutput(true).doRestore().waitForSuccess()
+                .outputAnalyzer().shouldContain(RESTORED_MESSAGE);
     }
 
     @Override

--- a/test/jdk/jdk/crac/ResetStartTimeTest.java
+++ b/test/jdk/jdk/crac/ResetStartTimeTest.java
@@ -52,8 +52,8 @@ public class ResetStartTimeTest implements CracTest {
     @Override
     public void test() throws Exception {
         CracBuilder builder = new CracBuilder().engine(CracEngine.SIMULATE);
-        if (resetUptime) {
-            builder.vmOption("-XX:+CRaCResetStartTime");
+        if (!resetUptime) {
+            builder.vmOption("-XX:-CRaCResetStartTime");
         }
         var output = builder.captureOutput(true)
                 .startCheckpoint().waitForSuccess()

--- a/test/jdk/jdk/crac/ResetStartTimeTest.java
+++ b/test/jdk/jdk/crac/ResetStartTimeTest.java
@@ -53,6 +53,7 @@ public class ResetStartTimeTest implements CracTest {
     public void test() throws Exception {
         CracBuilder builder = new CracBuilder().engine(CracEngine.SIMULATE);
         if (!resetUptime) {
+            builder.vmOption("-XX:+UnlockDiagnosticVMOptions");
             builder.vmOption("-XX:-CRaCResetStartTime");
         }
         var output = builder.captureOutput(true)


### PR DESCRIPTION
By the request in this comment https://github.com/openjdk/crac/pull/130/files#r1373722320

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/135/head:pull/135` \
`$ git checkout pull/135`

Update a local copy of the PR: \
`$ git checkout pull/135` \
`$ git pull https://git.openjdk.org/crac.git pull/135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 135`

View PR using the GUI difftool: \
`$ git pr show -t 135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/135.diff">https://git.openjdk.org/crac/pull/135.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/135#issuecomment-1782674754)