### PR TITLE
Ignore open files in /var/lib/sss/mc

### DIFF
--- a/src/hotspot/os/aix/globals_aix.hpp
+++ b/src/hotspot/os/aix/globals_aix.hpp
@@ -90,5 +90,6 @@ define_pd_global(size_t, PreTouchParallelChunkSize, 1 * G);
 define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, false);
 define_pd_global(bool, UseThreadPriorities, true) ;
+define_pd_global(ccstrlist, CRAllowedOpenFilePrefixes, nullptr);
 
 #endif // OS_AIX_GLOBALS_AIX_HPP

--- a/src/hotspot/os/bsd/globals_bsd.hpp
+++ b/src/hotspot/os/bsd/globals_bsd.hpp
@@ -50,5 +50,6 @@ define_pd_global(size_t, PreTouchParallelChunkSize, 1 * G);
 define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, false);
 define_pd_global(bool, UseThreadPriorities, true) ;
+define_pd_global(ccstrlist, CRAllowedOpenFilePrefixes, nullptr);
 
 #endif // OS_BSD_GLOBALS_BSD_HPP

--- a/src/hotspot/os/linux/crac_linux.cpp
+++ b/src/hotspot/os/linux/crac_linux.cpp
@@ -332,8 +332,8 @@ bool VM_Crac::check_fds() {
     // On some systems using SSSD files in this directory are left open
     // after calling getpwuid_r, getpwname_r, getgrgid_r, getgrname_r
     // or other functions in this family.
-#define SSS_NSS_MEMCACHE "/var/lib/sss/mc/"
-    if (!strncmp(details, SSS_NSS_MEMCACHE, sizeof(SSS_NSS_MEMCACHE) - 1)) {
+    constexpr const char *sss_nss_memcache = "/var/lib/sss/mc/";
+    if (!strncmp(details, sss_nss_memcache, strlen(sss_nss_memcache))) {
       print_resources("OK: SSSD cache\n");
       continue;
     }

--- a/src/hotspot/os/linux/crac_linux.cpp
+++ b/src/hotspot/os/linux/crac_linux.cpp
@@ -22,6 +22,8 @@
  */
 
 // no precompiled headers
+#include <string.h>
+
 #include "jvm.h"
 #include "perfMemory_linux.hpp"
 #include "runtime/crac_structs.hpp"
@@ -325,6 +327,15 @@ bool VM_Crac::check_fds() {
         print_resources("OK: jcmd socket\n");
         continue;
       }
+    }
+
+    // On some systems using SSSD files in this directory are left open
+    // after calling getpwuid_r, getpwname_r, getgrgid_r, getgrname_r
+    // or other functions in this family.
+#define SSS_NSS_MEMCACHE "/var/lib/sss/mc/"
+    if (!strncmp(details, SSS_NSS_MEMCACHE, sizeof(SSS_NSS_MEMCACHE) - 1)) {
+      print_resources("OK: SSSD cache\n");
+      continue;
     }
 
     print_resources("BAD: opened by application\n");

--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -113,5 +113,6 @@ define_pd_global(size_t, PreTouchParallelChunkSize, 4 * M);
 define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, false);
 define_pd_global(bool, UseThreadPriorities, true) ;
+define_pd_global(ccstrlist, CRAllowedOpenFilePrefixes, "/var/lib/sss/mc/");
 
 #endif // OS_LINUX_GLOBALS_LINUX_HPP

--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -113,6 +113,10 @@ define_pd_global(size_t, PreTouchParallelChunkSize, 4 * M);
 define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, false);
 define_pd_global(bool, UseThreadPriorities, true) ;
+
+// On some systems using SSSD files in this directory are left open
+// after calling getpwuid_r, getpwname_r, getgrgid_r, getgrname_r
+// or other functions in this family.
 define_pd_global(ccstrlist, CRAllowedOpenFilePrefixes, "/var/lib/sss/mc/");
 
 #endif // OS_LINUX_GLOBALS_LINUX_HPP

--- a/src/hotspot/os/windows/globals_windows.hpp
+++ b/src/hotspot/os/windows/globals_windows.hpp
@@ -49,5 +49,6 @@ define_pd_global(size_t, PreTouchParallelChunkSize, 1 * G);
 define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, true);
 define_pd_global(bool, UseThreadPriorities, true) ;
+define_pd_global(ccstrlist, CRAllowedOpenFilePrefixes, nullptr);
 
 #endif // OS_WINDOWS_GLOBALS_WINDOWS_HPP

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2016,6 +2016,12 @@ const int ObjectAlignmentInBytes = 8;
       "excluded automatically) not in this list are closed when the VM "    \
       "is started.")                                                        \
                                                                             \
+  product_pd(ccstrlist, CRAllowedOpenFilePrefixes, "List of path prefixes " \
+      "for files that can be open during checkpoint; CRaC won't error "     \
+      "upon detecting these and will leave the handling up to C/R engine. " \
+      "This option applies only to files opened by native code; for files " \
+      "opened by Java code use -Djdk.crac.resource-policies=...")           \
+                                                                            \
   product(bool, CRAllowToSkipCheckpoint, false, DIAGNOSTIC,                 \
           "Allow implementation to not call Checkpoint if helper not found")\
                                                                             \


### PR DESCRIPTION
I was considering different ways to fix this - there are actually two problems:
1) how to detect that?
* This PR whitelisst all files in the directory (we could explicitly name `passwd`, `group`, `sid` and `initgroups`...)
* We could manually check all places in JDK that call `getpwuid*`, `getpwname*`, `getgrgid*`and `getgrname*` and maybe some other functions, and diff FDs opened before/after the call. However this a) has performance impact b) is prone to races
* Intercept the call: either catch syscalls (ptrace or seccomp), or patching `sss_open_cloexec` in memory, or preloading it? Rather complicated.
2) what to do with the open FD?
* Current solution is to leave this up to CRIU (or another C/R engine). Again the simplest
* We could close this; the FD is `fstat`-validated later on, so this would cause errors from these functions. We would need to patch the library, de-initializing the implementation (also risky).

Normally I would try to include a testcase but given that this is system-dependent (and the issue does not appear even in CentOS Stream 9 container) I've only did manual testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/137/head:pull/137` \
`$ git checkout pull/137`

Update a local copy of the PR: \
`$ git checkout pull/137` \
`$ git pull https://git.openjdk.org/crac.git pull/137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 137`

View PR using the GUI difftool: \
`$ git pr show -t 137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/137.diff">https://git.openjdk.org/crac/pull/137.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/137#issuecomment-1790910293)