### PR TITLE
Fix Windows build of Decoder

### DIFF
--- a/src/hotspot/share/utilities/decoder.hpp
+++ b/src/hotspot/share/utilities/decoder.hpp
@@ -122,6 +122,9 @@ public:
 
   static void print_state_on(outputStream* st);
 
+#ifdef _WINDOWS
+  static void before_checkpoint() { /* noop */ }
+#else
   static void before_checkpoint();
 
 protected:
@@ -142,7 +145,8 @@ private:
 protected:
   static Mutex* shared_decoder_lock();
 
-  friend class DecoderLocker;
+#endif // !_WINDOWS
+
 };
 
 #endif // SHARE_UTILITIES_DECODER_HPP


### PR DESCRIPTION
Fixes build failure on Windows introduced in https://github.com/openjdk/crac/pull/116

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/138/head:pull/138` \
`$ git checkout pull/138`

Update a local copy of the PR: \
`$ git checkout pull/138` \
`$ git pull https://git.openjdk.org/crac.git pull/138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 138`

View PR using the GUI difftool: \
`$ git pr show -t 138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/138.diff">https://git.openjdk.org/crac/pull/138.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/138#issuecomment-1803717744)