### PR TITLE
More robust classpath parsing

### DIFF
--- a/src/java.base/share/classes/jdk/internal/crac/JDKFileResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKFileResource.java
@@ -25,13 +25,9 @@ public abstract class JDKFileResource extends JDKFdResource {
                 .split(File.pathSeparator);
         CLASSPATH_ENTRIES = new Path[items.length];
         for (int i = 0; i < items.length; i++) {
-            String path = items[i];
             // On Windows, path with forward slashes starting with '/' is an accepted classpath
             // element, even though it might seem as invalid and parsing in Path.of(...) would fail.
-            if (path.startsWith("/") && File.separatorChar != '/') {
-                path = path.substring(1);
-            }
-            CLASSPATH_ENTRIES[i] = Path.of(path);
+            CLASSPATH_ENTRIES[i] = new File(items[i]).toPath();
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/crac/JDKFileResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKFileResource.java
@@ -25,7 +25,13 @@ public abstract class JDKFileResource extends JDKFdResource {
                 .split(File.pathSeparator);
         CLASSPATH_ENTRIES = new Path[items.length];
         for (int i = 0; i < items.length; i++) {
-            CLASSPATH_ENTRIES[i] = Path.of(items[i]);
+            String path = items[i];
+            // On Windows, path with forward slashes starting with '/' is an accepted classpath
+            // element, even though it might seem as invalid and parsing in Path.of(...) would fail.
+            if (path.startsWith("/") && File.separatorChar != '/') {
+                path = path.substring(1);
+            }
+            CLASSPATH_ENTRIES[i] = Path.of(path);
         }
     }
 

--- a/test/jdk/jdk/crac/fileDescriptors/ClasspathParseTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/ClasspathParseTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.Utils;
+
+import java.io.IOException;
+
+import static jdk.test.lib.Asserts.assertEquals;
+
+/**
+ * @test
+ * @library /test/lib
+ * @run driver ClasspathParseTest
+ */
+public class ClasspathParseTest {
+    public static final String JAVA = Utils.TEST_JDK + "/bin/java";
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        if (args.length == 0) {
+            String classpath = ClasspathParseTest.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+            int exit = new ProcessBuilder().command(JAVA, "-cp", classpath, ClasspathParseTest.class.getName(), "ignored")
+                    .inheritIO().start().waitFor();
+            assertEquals(0, exit);
+        } else {
+            // assert that code source path started with "/" as we expect (even on Windows)
+            if (!System.getProperty("java.class.path").startsWith("/")) {
+                System.exit(2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
On Windows, path with forward slashes starting with `/` is an accepted classpath element, even though it might seem as invalid and parsing in `Path.of(...)` would fail.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Roman Marchenko](https://openjdk.org/census#rmarchenko) (@wkia - no project role)
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/140/head:pull/140` \
`$ git checkout pull/140`

Update a local copy of the PR: \
`$ git checkout pull/140` \
`$ git pull https://git.openjdk.org/crac.git pull/140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 140`

View PR using the GUI difftool: \
`$ git pr show -t 140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/140.diff">https://git.openjdk.org/crac/pull/140.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/140#issuecomment-1812585704)