### PR TITLE
Adjusting CRaC tests

### DIFF
--- a/test/jdk/jdk/crac/ContainerPidAdjustmentTest.java
+++ b/test/jdk/jdk/crac/ContainerPidAdjustmentTest.java
@@ -39,21 +39,21 @@ import java.util.Arrays;
  * @requires (os.family == "linux")
  * @library /test/lib
  * @build ContainerPidAdjustmentTest
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest  true   false  INF     true   128
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest  true   true   1       false  1
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest  true   true   100     true   100
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest  false  false  INF     false  1
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest  false  true   1       false  1
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest  false  true   1       true   1
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest  false  true   200     true   200
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest  false  true   1000    false  1000
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest  false  true   2000    true   2000   1000
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest  false  true   0       true   -1
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest  false  true   -10     true   -1
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest  false  true   blabla  true   -1
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest  false  true   5000000 true   -1
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest  false  true   5000000 true   -1     4194200
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest  false  true   4194303 true   -1
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest  true   false  INF     true   128
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest  true   true   1       false  1
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest  true   true   100     true   100
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest  false  false  INF     false  1
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest  false  true   1       false  1
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest  false  true   1       true   1
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest  false  true   200     true   200
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest  false  true   1000    false  1000
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest  false  true   2000    true   2000   1000
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest  false  true   0       true   -1
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest  false  true   -10     true   -1
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest  false  true   blabla  true   -1
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest  false  true   5000000 true   -1
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest  false  true   5000000 true   -1     4194200
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest  false  true   4194303 true   -1
 
  */
 public class ContainerPidAdjustmentTest implements CracTest {

--- a/test/jdk/jdk/crac/SecureRandom/InterlockTest.java
+++ b/test/jdk/jdk/crac/SecureRandom/InterlockTest.java
@@ -33,10 +33,13 @@ import java.security.SecureRandom;
  * @library /test/lib
  * @build InterlockTest
  * @run driver/timeout=60 jdk.test.lib.crac.CracTest SHA1PRNG 100
- * @run driver/timeout=60 jdk.test.lib.crac.CracTest NativePRNGBlocking 100
  * @run driver/timeout=60 jdk.test.lib.crac.CracTest NativePRNGNonBlocking 100
  * @run driver/timeout=60 jdk.test.lib.crac.CracTest NativePRNG 100
  */
+
+/* NativePRNGBlocking is exluded as on some machines /dev/random is exhausted
+ * too soon, making the test running too long. */
+
 public class InterlockTest implements Resource, CracTest {
     private static final long MIN_TIMEOUT = 100;
     private static final long MAX_TIMEOUT = 1000;


### PR DESCRIPTION
Fixing the CRaC tests to adapt them for different platforms

- Extended test timeouts to accomodate slower docker image builds.
- NativePRNGBlocking is exluded as on some machines /dev/random is exhausted too soon
- Adjusting timeout to prevent test failing on centOS 7

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/144/head:pull/144` \
`$ git checkout pull/144`

Update a local copy of the PR: \
`$ git checkout pull/144` \
`$ git pull https://git.openjdk.org/crac.git pull/144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 144`

View PR using the GUI difftool: \
`$ git pr show -t 144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/144.diff">https://git.openjdk.org/crac/pull/144.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/144#issuecomment-1822342858)