### PR TITLE
Improve C/R exception printout

### DIFF
--- a/src/java.base/share/classes/javax/crac/CheckpointException.java
+++ b/src/java.base/share/classes/javax/crac/CheckpointException.java
@@ -26,6 +26,11 @@
 
 package javax.crac;
 
+import jdk.crac.impl.ExceptionPrinter;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
 /**
  * This exception works as an aggregate for all errors found during checkpoint;
  * these are recorded as {@linkplain #getSuppressed() suppressed exceptions}.
@@ -39,5 +44,15 @@ public final class CheckpointException extends Exception {
      */
     public CheckpointException() {
         super(null, null, true, false);
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        ExceptionPrinter.print(this, s);
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter w) {
+        ExceptionPrinter.print(this, w);
     }
 }

--- a/src/java.base/share/classes/javax/crac/CheckpointException.java
+++ b/src/java.base/share/classes/javax/crac/CheckpointException.java
@@ -26,33 +26,25 @@
 
 package javax.crac;
 
-import jdk.crac.impl.ExceptionPrinter;
-
-import java.io.PrintStream;
-import java.io.PrintWriter;
-
 /**
  * This exception works as an aggregate for all errors found during checkpoint;
- * these are recorded as {@linkplain #getSuppressed() suppressed exceptions}.
+ * these are recorded as {@linkplain #getNestedExceptions() nested exceptions}.
  * The exception does not have any own message, cause nor collects stack trace.
  */
-public final class CheckpointException extends Exception {
+public final class CheckpointException extends ExceptionBase {
     private static final long serialVersionUID = 6859967688386143096L;
 
     /**
-     * Creates a {@code CheckpointException}.
+     * Create exception with no nested exceptions.
      */
     public CheckpointException() {
-        super(null, null, true, false);
     }
 
-    @Override
-    public void printStackTrace(PrintStream s) {
-        ExceptionPrinter.print(this, s);
-    }
-
-    @Override
-    public void printStackTrace(PrintWriter w) {
-        ExceptionPrinter.print(this, w);
+    /**
+     * Create exception with provided nested exceptions.
+     * @param nested Nested exceptions.
+     */
+    public CheckpointException(Throwable[] nested) {
+        super(nested);
     }
 }

--- a/src/java.base/share/classes/javax/crac/ContextWrapper.java
+++ b/src/java.base/share/classes/javax/crac/ContextWrapper.java
@@ -46,11 +46,7 @@ class ContextWrapper extends Context<Resource> {
         try {
             this.context.beforeCheckpoint(convertContext(context));
         } catch (jdk.crac.CheckpointException e) {
-            CheckpointException newException = new CheckpointException();
-            for (Throwable t : e.getSuppressed()) {
-                newException.addSuppressed(t);
-            }
-            throw newException;
+            throw new CheckpointException(e.getNestedExceptions());
         }
     }
 
@@ -60,11 +56,7 @@ class ContextWrapper extends Context<Resource> {
         try {
             this.context.afterRestore(convertContext(context));
         } catch (jdk.crac.RestoreException e) {
-            RestoreException newException = new RestoreException();
-            for (Throwable t : e.getSuppressed()) {
-                newException.addSuppressed(t);
-            }
-            throw newException;
+            throw new RestoreException(e.getNestedExceptions());
         }
     }
 

--- a/src/java.base/share/classes/javax/crac/Core.java
+++ b/src/java.base/share/classes/javax/crac/Core.java
@@ -72,17 +72,9 @@ public class Core {
         try {
             jdk.crac.Core.checkpointRestore();
         } catch (jdk.crac.CheckpointException e) {
-            CheckpointException newException = new CheckpointException();
-            for (Throwable t : e.getSuppressed()) {
-                newException.addSuppressed(t);
-            }
-            throw newException;
+            throw new CheckpointException(e.getNestedExceptions());
         } catch (jdk.crac.RestoreException e) {
-            RestoreException newException = new RestoreException();
-            for (Throwable t : e.getSuppressed()) {
-                newException.addSuppressed(t);
-            }
-            throw newException;
+            throw new RestoreException(e.getNestedExceptions());
         }
     }
 }

--- a/src/java.base/share/classes/javax/crac/ExceptionBase.java
+++ b/src/java.base/share/classes/javax/crac/ExceptionBase.java
@@ -1,0 +1,62 @@
+package javax.crac;
+
+import jdk.crac.CheckpointException;
+import jdk.crac.RestoreException;
+import jdk.crac.impl.ExceptionPrinter;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ * Common base for {@link CheckpointException} and {@link RestoreException}.
+ */
+public abstract class ExceptionBase extends Exception {
+    private static final long serialVersionUID = -6281937111554065647L;
+    private static final Throwable[] EMPTY_THROWABLE_ARRAY = new Throwable[0];
+    private ArrayList<Throwable> nested;
+
+    ExceptionBase() {
+        super(null, null, false, false);
+    }
+
+    ExceptionBase(Throwable[] nested) {
+        this();
+        if (nested != null && nested.length > 0) {
+            this.nested = new ArrayList<>(Arrays.asList(nested));
+        }
+    }
+
+    /**
+     * Add exception to the list of nested exceptions.
+     * @param throwable Added exception
+     */
+    public void addNestedException(Throwable throwable) {
+        if (this.nested == null) {
+            this.nested = new ArrayList<>();
+        }
+        this.nested.add(throwable);
+    }
+
+    /**
+     * Returns an array containing all the exceptions that this exception holds as nested exceptions.
+     * @return an array containing all nested exceptions.
+     */
+    public Throwable[] getNestedExceptions() {
+        if (nested == null) {
+            return EMPTY_THROWABLE_ARRAY;
+        }
+        return nested.toArray(EMPTY_THROWABLE_ARRAY);
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        ExceptionPrinter.print(this, s);
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter w) {
+        ExceptionPrinter.print(this, w);
+    }
+}

--- a/src/java.base/share/classes/javax/crac/ResourceWrapper.java
+++ b/src/java.base/share/classes/javax/crac/ResourceWrapper.java
@@ -60,11 +60,7 @@ class ResourceWrapper extends WeakReference<Resource> implements jdk.crac.Resour
             try {
                 r.beforeCheckpoint(this.context);
             } catch (CheckpointException e) {
-                Exception newException = new jdk.crac.CheckpointException();
-                for (Throwable t : e.getSuppressed()) {
-                    newException.addSuppressed(t);
-                }
-                throw newException;
+                throw new jdk.crac.CheckpointException(e.getNestedExceptions());
             }
         }
     }
@@ -77,11 +73,7 @@ class ResourceWrapper extends WeakReference<Resource> implements jdk.crac.Resour
             try {
                 r.afterRestore(this.context);
             } catch (RestoreException e) {
-                Exception newException = new jdk.crac.RestoreException();
-                for (Throwable t : e.getSuppressed()) {
-                    newException.addSuppressed(t);
-                }
-                throw newException;
+                throw new jdk.crac.RestoreException(e.getNestedExceptions());
             }
         }
     }

--- a/src/java.base/share/classes/javax/crac/RestoreException.java
+++ b/src/java.base/share/classes/javax/crac/RestoreException.java
@@ -26,6 +26,11 @@
 
 package javax.crac;
 
+import jdk.crac.impl.ExceptionPrinter;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
 /**
  * This exception works as an aggregate for all errors found during checkpoint;
  * these are recorded as {@linkplain #getSuppressed() suppressed exceptions}.
@@ -39,6 +44,16 @@ public final class RestoreException extends Exception {
      */
     public RestoreException() {
         super(null, null, true, false);
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        ExceptionPrinter.print(this, s);
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter w) {
+        ExceptionPrinter.print(this, w);
     }
 }
 

--- a/src/java.base/share/classes/javax/crac/RestoreException.java
+++ b/src/java.base/share/classes/javax/crac/RestoreException.java
@@ -26,34 +26,26 @@
 
 package javax.crac;
 
-import jdk.crac.impl.ExceptionPrinter;
-
-import java.io.PrintStream;
-import java.io.PrintWriter;
-
 /**
  * This exception works as an aggregate for all errors found during checkpoint;
- * these are recorded as {@linkplain #getSuppressed() suppressed exceptions}.
+ * these are recorded as {@linkplain #getNestedExceptions() nested exceptions}.
  * The exception does not have any own message, cause nor collects stack trace.
  */
-public final class RestoreException extends Exception {
+public final class RestoreException extends ExceptionBase {
     private static final long serialVersionUID = -4091592505524280559L;
 
     /**
-     * Creates a {@code RestoreException}.
+     * Create exception with no nested exceptions.
      */
     public RestoreException() {
-        super(null, null, true, false);
     }
 
-    @Override
-    public void printStackTrace(PrintStream s) {
-        ExceptionPrinter.print(this, s);
-    }
-
-    @Override
-    public void printStackTrace(PrintWriter w) {
-        ExceptionPrinter.print(this, w);
+    /**
+     * Create exception with provided nested exceptions.
+     * @param nested Nested exceptions.
+     */
+    public RestoreException(Throwable[] nested) {
+        super(nested);
     }
 }
 

--- a/src/java.base/share/classes/javax/crac/package-info.java
+++ b/src/java.base/share/classes/javax/crac/package-info.java
@@ -60,10 +60,10 @@ restoring instances from the image.
  * The current instance is terminated.
  * Later, a new instance is created by some means, for example via Java launcher in a special mode.
  * The new instance is started at the point where the image was created, it is followed by the restore notification.
- * Exceptions from restore notification are provided as suppressed ones by a {@code RestoreException} (in a sense of {@link Throwable#addSuppressed}).
+ * Exceptions from restore notification are provided as nested ones by a {@link javax.crac.RestoreException#getNestedExceptions()}.
  * <p>
  * If the global {@code Context} throws an exception during checkpoint notification then restore notificaion starts immediately without the image creation.
- * In this case, exceptions from checkpoint and restore notifications are provided as suppressed ones by {@code CheckpointException}.
+ * In this case, exceptions from checkpoint and restore notifications are provided as {@link javax.crac.ExceptionBase#getNestedExceptions() nested} by {@code CheckpointException}.
  * <p>
  * {@code UnsupportedOperationException} is thrown if the service is not supported.
  * No notification is performed in this case.
@@ -82,12 +82,12 @@ restoring instances from the image.
  *   </li>
  *   <li>{@code Resource} is always notified of restore, regardless of its checkpoint or others' restore notification have thrown an exception or not.
  *   </li>
- *   <li>When an exception is thrown during notificaion, it is caught by the {@code Context} and is suppressed by a {@code CheckpointException} or {@code RestoreException}, depends on the throwing method.
+ *   <li>When an exception is thrown during notification, it is caught by the {@code Context} and is nested into a {@code CheckpointException} or {@code RestoreException}, depending on the throwing method.
  *   </li>
- *   <li>When the {@code Resource} is a {@code Context} and it throws {@code CheckpointException} or {@code RestoreException}, exceptions suppressed by the original exception are suppressed by another {@code CheckpointException} or {@code RestoreException}, depends on the throwing method.
+ *   <li>When the {@code Resource} is a {@code Context} and it throws {@code CheckpointException} or {@code RestoreException}, exceptions nested in the original exception are provided as nested in another {@code CheckpointException} or {@code RestoreException}, depending on the throwing method.
  *   </li>
  * </ul>
- * <li>All exceptions thrown by {@code Resource} are suppressed by {@code CheckpointException} or {@code RestoreException} thrown by the {@code Context}.
+ * <li>All exceptions thrown by {@code Resource} are {@link javax.crac.ExceptionBase#getNestedExceptions() nested} in {@code CheckpointException} or {@code RestoreException} thrown by the {@code Context}.
  * </li>
  * </ul>
  *

--- a/src/java.base/share/classes/jdk/crac/CheckpointException.java
+++ b/src/java.base/share/classes/jdk/crac/CheckpointException.java
@@ -26,6 +26,11 @@
 
 package jdk.crac;
 
+import jdk.crac.impl.ExceptionPrinter;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
 /**
  * This exception works as an aggregate for all errors found during checkpoint;
  * these are recorded as {@linkplain #getSuppressed() suppressed exceptions}.
@@ -39,5 +44,15 @@ public final class CheckpointException extends Exception {
      */
     public CheckpointException() {
         super(null, null, true, false);
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        ExceptionPrinter.print(this, s);
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter w) {
+        ExceptionPrinter.print(this, w);
     }
 }

--- a/src/java.base/share/classes/jdk/crac/CheckpointException.java
+++ b/src/java.base/share/classes/jdk/crac/CheckpointException.java
@@ -26,33 +26,25 @@
 
 package jdk.crac;
 
-import jdk.crac.impl.ExceptionPrinter;
-
-import java.io.PrintStream;
-import java.io.PrintWriter;
-
 /**
  * This exception works as an aggregate for all errors found during checkpoint;
- * these are recorded as {@linkplain #getSuppressed() suppressed exceptions}.
+ * these are recorded as {@linkplain #getNestedExceptions() nested exceptions}.
  * The exception does not have any own message, cause nor collects stack trace.
  */
-public final class CheckpointException extends Exception {
+public final class CheckpointException extends ExceptionBase {
     private static final long serialVersionUID = 8879167591426115859L;
 
     /**
-     * Creates a {@code CheckpointException}.
+     * Create exception with no nested exceptions.
      */
     public CheckpointException() {
-        super(null, null, true, false);
     }
 
-    @Override
-    public void printStackTrace(PrintStream s) {
-        ExceptionPrinter.print(this, s);
-    }
-
-    @Override
-    public void printStackTrace(PrintWriter w) {
-        ExceptionPrinter.print(this, w);
+    /**
+     * Create exception with provided nested exceptions.
+     * @param nested Nested exceptions.
+     */
+    public CheckpointException(Throwable[] nested) {
+        super(nested);
     }
 }

--- a/src/java.base/share/classes/jdk/crac/Core.java
+++ b/src/java.base/share/classes/jdk/crac/Core.java
@@ -32,7 +32,6 @@ import jdk.internal.crac.ClaimedFDs;
 import jdk.internal.crac.JDKResource;
 import jdk.internal.crac.LoggerContainer;
 import sun.security.action.GetBooleanAction;
-import sun.security.action.GetPropertyAction;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -222,7 +221,7 @@ public class Core {
             globalContext.afterRestore(null);
         } catch (RestoreException re) {
             if (checkpointException.hasException()) {
-                checkpointException.resuppress(re);
+                checkpointException.addNestedExceptions(re);
             } else {
                 restoreException.handle(re);
             }
@@ -290,7 +289,7 @@ public class Core {
             // beforeCheckpoint/afterRestore methods
             if (checkpointInProgress) {
                 CheckpointException ex = new CheckpointException();
-                ex.addSuppressed(new IllegalStateException("Recursive checkpoint is not allowed"));
+                ex.addNestedException(new IllegalStateException("Recursive checkpoint is not allowed"));
                 throw ex;
             }
 

--- a/src/java.base/share/classes/jdk/crac/ExceptionBase.java
+++ b/src/java.base/share/classes/jdk/crac/ExceptionBase.java
@@ -1,0 +1,60 @@
+package jdk.crac;
+
+import jdk.crac.impl.ExceptionPrinter;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ * Common base for {@link CheckpointException} and {@link RestoreException}
+ */
+public abstract class ExceptionBase extends Exception {
+    private static final long serialVersionUID = -8131840538114148870L;
+    private static final Throwable[] EMPTY_THROWABLE_ARRAY = new Throwable[0];
+    private ArrayList<Throwable> nested;
+
+    ExceptionBase() {
+        super(null, null, false, false);
+    }
+
+    ExceptionBase(Throwable[] nested) {
+        this();
+        if (nested != null && nested.length > 0) {
+            this.nested = new ArrayList<>(Arrays.asList(nested));
+        }
+    }
+
+    /**
+     * Add exception to the list of nested exceptions.
+     * @param throwable Added exception
+     */
+    public void addNestedException(Throwable throwable) {
+        if (this.nested == null) {
+            this.nested = new ArrayList<>();
+        }
+        this.nested.add(throwable);
+    }
+
+    /**
+     * Returns an array containing all the exceptions that this exception holds as nested exceptions.
+     * @return an array containing all nested exceptions.
+     */
+    public Throwable[] getNestedExceptions() {
+        if (nested == null) {
+            return EMPTY_THROWABLE_ARRAY;
+        }
+        return nested.toArray(EMPTY_THROWABLE_ARRAY);
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        ExceptionPrinter.print(this, s);
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter w) {
+        ExceptionPrinter.print(this, w);
+    }
+}

--- a/src/java.base/share/classes/jdk/crac/RestoreException.java
+++ b/src/java.base/share/classes/jdk/crac/RestoreException.java
@@ -28,16 +28,23 @@ package jdk.crac;
 
 /**
  * This exception works as an aggregate for all errors found during restore;
- * these are recorded as {@linkplain #getSuppressed() suppressed exceptions}.
+ * these are recorded as {@linkplain #getNestedExceptions() nested exceptions}.
  * The exception does not have any own message, cause nor collects stack trace.
  */
-public final class RestoreException extends Exception {
+public final class RestoreException extends ExceptionBase {
     private static final long serialVersionUID = 5235124335683732665L;
 
     /**
-     * Creates a {@code RestoreException}.
+     * Create exception with no nested exceptions.
      */
     public RestoreException() {
-        super(null, null, true, false);
+    }
+
+    /**
+     * Create exception with provided nested exceptions.
+     * @param nested Nested exceptions.
+     */
+    public RestoreException(Throwable[] nested) {
+        super(nested);
     }
 }

--- a/src/java.base/share/classes/jdk/crac/impl/ExceptionHolder.java
+++ b/src/java.base/share/classes/jdk/crac/impl/ExceptionHolder.java
@@ -1,8 +1,10 @@
 package jdk.crac.impl;
 
+import jdk.crac.ExceptionBase;
+
 import java.util.function.Supplier;
 
-public class ExceptionHolder<E extends Exception> {
+public class ExceptionHolder<E extends ExceptionBase> {
     E exception = null;
     final Supplier<E> constructor;
 
@@ -27,10 +29,10 @@ public class ExceptionHolder<E extends Exception> {
         return exception != null;
     }
 
-    public void resuppress(Exception e) {
+    public void addNestedExceptions(ExceptionBase e) {
         E exception = get();
-        for (Throwable t : e.getSuppressed()) {
-            exception.addSuppressed(t);
+        for (Throwable t : e.getNestedExceptions()) {
+            exception.addNestedException(t);
         }
     }
 
@@ -41,7 +43,7 @@ public class ExceptionHolder<E extends Exception> {
 
         E exception = get();
         if (exception.getClass() == e.getClass()) {
-            resuppress(e);
+            addNestedExceptions((ExceptionBase) e);
         } else {
             if (e instanceof InterruptedException) {
                 // FIXME interrupt re-set should be up to the Context implementation, as
@@ -49,7 +51,7 @@ public class ExceptionHolder<E extends Exception> {
                 // notification, rather than exiting as soon as possible.
                 Thread.currentThread().interrupt();
             }
-            exception.addSuppressed(e);
+            exception.addNestedException(e);
         }
     }
 }

--- a/src/java.base/share/classes/jdk/crac/impl/ExceptionPrinter.java
+++ b/src/java.base/share/classes/jdk/crac/impl/ExceptionPrinter.java
@@ -1,0 +1,43 @@
+package jdk.crac.impl;
+
+import jdk.crac.CheckpointException;
+import jdk.crac.RestoreException;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public final class ExceptionPrinter {
+    private static final String MSG_FORMAT = "%s: Failed with %s inner exceptions%n";
+    private static final String CAUSE_FORMAT = "Cause %d/%d: ";
+
+    public static void print(Exception exception, PrintStream s) {
+        assertExceptionType(exception);
+        Throwable[] suppressed = exception.getSuppressed();
+        s.printf(MSG_FORMAT, exception.getClass().getName(), suppressed.length);
+        for (int i = 0; i < suppressed.length; ++i) {
+            s.printf(CAUSE_FORMAT, i + 1, suppressed.length);
+            suppressed[i].printStackTrace(s);
+        }
+    }
+
+    public static void print(Exception exception, PrintWriter w) {
+        assertExceptionType(exception);
+        Throwable[] suppressed = exception.getSuppressed();
+        w.printf(MSG_FORMAT, exception.getClass().getName(), suppressed.length);
+        for (int i = 0; i < suppressed.length; ++i) {
+            w.printf(CAUSE_FORMAT, i + 1, suppressed.length);
+            suppressed[i].printStackTrace(w);
+        }
+    }
+
+    private static void assertExceptionType(Exception exception) {
+        Objects.requireNonNull(exception);
+        if (Stream.of(CheckpointException.class, RestoreException.class,
+                javax.crac.CheckpointException.class, javax.crac.RestoreException.class)
+                .noneMatch(cls -> cls.isInstance(exception))) {
+            throw new IllegalArgumentException("This printer is meant only for C/R exceptions", exception);
+        }
+    }
+}

--- a/src/java.base/share/classes/jdk/crac/impl/ExceptionPrinter.java
+++ b/src/java.base/share/classes/jdk/crac/impl/ExceptionPrinter.java
@@ -1,42 +1,40 @@
 package jdk.crac.impl;
 
-import jdk.crac.CheckpointException;
-import jdk.crac.RestoreException;
+import jdk.crac.ExceptionBase;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 public final class ExceptionPrinter {
-    private static final String MSG_FORMAT = "%s: Failed with %s inner exceptions%n";
+    private static final String MSG_FORMAT = "%s: Failed with %s nested exceptions%n";
     private static final String CAUSE_FORMAT = "Cause %d/%d: ";
 
     public static void print(Exception exception, PrintStream s) {
-        assertExceptionType(exception);
-        Throwable[] suppressed = exception.getSuppressed();
-        s.printf(MSG_FORMAT, exception.getClass().getName(), suppressed.length);
-        for (int i = 0; i < suppressed.length; ++i) {
-            s.printf(CAUSE_FORMAT, i + 1, suppressed.length);
-            suppressed[i].printStackTrace(s);
+        Throwable[] nested = getNestedExceptions(exception);
+        s.printf(MSG_FORMAT, exception.getClass().getName(), nested.length);
+        for (int i = 0; i < nested.length; ++i) {
+            s.printf(CAUSE_FORMAT, i + 1, nested.length);
+            nested[i].printStackTrace(s);
         }
     }
 
     public static void print(Exception exception, PrintWriter w) {
-        assertExceptionType(exception);
-        Throwable[] suppressed = exception.getSuppressed();
-        w.printf(MSG_FORMAT, exception.getClass().getName(), suppressed.length);
-        for (int i = 0; i < suppressed.length; ++i) {
-            w.printf(CAUSE_FORMAT, i + 1, suppressed.length);
-            suppressed[i].printStackTrace(w);
+        Throwable[] nested = getNestedExceptions(exception);
+        w.printf(MSG_FORMAT, exception.getClass().getName(), nested.length);
+        for (int i = 0; i < nested.length; ++i) {
+            w.printf(CAUSE_FORMAT, i + 1, nested.length);
+            nested[i].printStackTrace(w);
         }
     }
 
-    private static void assertExceptionType(Exception exception) {
+    private static Throwable[] getNestedExceptions(Exception exception) {
         Objects.requireNonNull(exception);
-        if (Stream.of(CheckpointException.class, RestoreException.class,
-                javax.crac.CheckpointException.class, javax.crac.RestoreException.class)
-                .noneMatch(cls -> cls.isInstance(exception))) {
+        if (exception instanceof ExceptionBase ex) {
+            return ex.getNestedExceptions();
+        } else if (exception instanceof javax.crac.ExceptionBase ex) {
+            return ex.getNestedExceptions();
+        } else {
             throw new IllegalArgumentException("This printer is meant only for C/R exceptions", exception);
         }
     }

--- a/src/java.base/share/classes/jdk/crac/package-info.java
+++ b/src/java.base/share/classes/jdk/crac/package-info.java
@@ -60,10 +60,10 @@ restoring instances from the image.
  * The current instance is terminated.
  * Later, a new instance is created by some means, for example via Java launcher in a special mode.
  * The new instance is started at the point where the image was created, it is followed by the restore notification.
- * Exceptions from restore notification are provided as suppressed ones by a {@code RestoreException} (in a sense of {@link Throwable#addSuppressed}).
+ * Exceptions from restore notification are provided as nested ones by a {@link javax.crac.RestoreException#getNestedExceptions()}.
  * <p>
  * If the global {@code Context} throws an exception during checkpoint notification then restore notificaion starts immediately without the image creation.
- * In this case, exceptions from checkpoint and restore notifications are provided as suppressed ones by {@code CheckpointException}.
+ * In this case, exceptions from checkpoint and restore notifications are provided as {@link javax.crac.ExceptionBase#getNestedExceptions() nested} by {@code CheckpointException}.
  * <p>
  * {@code UnsupportedOperationException} is thrown if the service is not supported.
  * No notification is performed in this case.
@@ -82,12 +82,12 @@ restoring instances from the image.
  *   </li>
  *   <li>{@code Resource} is always notified of restore, regardless of its checkpoint or others' restore notification have thrown an exception or not.
  *   </li>
- *   <li>When an exception is thrown during notificaion, it is caught by the {@code Context} and is suppressed by a {@code CheckpointException} or {@code RestoreException}, depends on the throwing method.
+ *   <li>When an exception is thrown during notification, it is caught by the {@code Context} and is nested into a {@code CheckpointException} or {@code RestoreException}, depending on the throwing method.
  *   </li>
- *   <li>When the {@code Resource} is a {@code Context} and it throws {@code CheckpointException} or {@code RestoreException}, exceptions suppressed by the original exception are suppressed by another {@code CheckpointException} or {@code RestoreException}, depends on the throwing method.
+ *   <li>When the {@code Resource} is a {@code Context} and it throws {@code CheckpointException} or {@code RestoreException}, exceptions nested in the original exception are provided as nested in another {@code CheckpointException} or {@code RestoreException}, depending on the throwing method.
  *   </li>
  * </ul>
- * <li>All exceptions thrown by {@code Resource} are suppressed by {@code CheckpointException} or {@code RestoreException} thrown by the {@code Context}.
+ * <li>All exceptions thrown by {@code Resource} are {@link javax.crac.ExceptionBase#getNestedExceptions() nested} in {@code CheckpointException} or {@code RestoreException} thrown by the {@code Context}.
  * </li>
  * </ul>
  *

--- a/test/jdk/jdk/crac/ContextOrderTest.java
+++ b/test/jdk/jdk/crac/ContextOrderTest.java
@@ -179,7 +179,7 @@ public class ContextOrderTest {
             Core.checkpointRestore();
             fail("Expected to throw CheckpointException");
         } catch (CheckpointException e) {
-            assertEquals(4, e.getSuppressed().length);
+            assertEquals(4, e.getNestedExceptions().length);
         }
         assertEquals("regular2-before", recorder.poll());
         assertEquals("throwing1-before", recorder.poll());

--- a/test/jdk/jdk/crac/DryRunTest.java
+++ b/test/jdk/jdk/crac/DryRunTest.java
@@ -57,7 +57,7 @@ public class DryRunTest implements CracTest {
         OutputAnalyzer output = new CracBuilder().engine(CracEngine.SIMULATE).printResources(true).captureOutput(true)
                 .startCheckpoint().outputAnalyzer().shouldHaveExitValue(0);
         String err = output.getStderr();
-        assertTrue(err.contains("CheckpointException: Failed with 2 inner exceptions"), err);
+        assertTrue(err.contains("CheckpointException: Failed with 2 nested exceptions"), err);
         int firstCause = err.indexOf("Cause 1/2: java.lang.RuntimeException: should not pass");
         int secondCause = err.indexOf("Cause 2/2: jdk.crac.impl.CheckpointOpenFileException");
         assertGreaterThan(firstCause, 0, err);
@@ -84,7 +84,7 @@ public class DryRunTest implements CracTest {
 
             ce.printStackTrace();
 
-            for (Throwable e : ce.getSuppressed()) {
+            for (Throwable e : ce.getNestedExceptions()) {
                 String name = e.getClass().getName();
                 switch (name) {
                     case "java.lang.RuntimeException":                exceptions |= 0x1; break;

--- a/test/jdk/jdk/crac/FailedResourceTest.java
+++ b/test/jdk/jdk/crac/FailedResourceTest.java
@@ -66,8 +66,8 @@ public class FailedResourceTest implements CracTest {
             Core.checkpointRestore();
             fail("Was supposed to throw");
         } catch (CheckpointException e) {
-            assertEquals(1, e.getSuppressed().length, Arrays.toString(e.getSuppressed()));
-            assertEquals(EXCEPTION_MESSAGE, e.getSuppressed()[0].getMessage());
+            assertEquals(1, e.getNestedExceptions().length, Arrays.toString(e.getSuppressed()));
+            assertEquals(EXCEPTION_MESSAGE, e.getNestedExceptions()[0].getMessage());
         } catch (RestoreException e) {
             fail("Shouldn't error in restore", e);
         }

--- a/test/jdk/jdk/crac/fileDescriptors/ProcessPipelineTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/ProcessPipelineTest.java
@@ -68,7 +68,7 @@ public class ProcessPipelineTest implements CracTest {
                 fail("Should have failed");
             } catch (CheckpointException e) {
                 // One for pipe to the first process, another for pipe from the last
-                assertEquals(2, e.getSuppressed().length);
+                assertEquals(2, e.getNestedExceptions().length);
             }
         }
         // This time it should succeed

--- a/test/jdk/jdk/crac/fileDescriptors/ReopenFailureTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/ReopenFailureTest.java
@@ -91,9 +91,9 @@ public class ReopenFailureTest extends FDPolicyTestBase implements CracTest {
             } catch (RestoreException ex) {
                 // When running this as root we get only one exception for the missing file
                 if (Files.isWritable(Path.of(log2))) {
-                    assertEquals(1, ex.getSuppressed().length);
+                    assertEquals(1, ex.getNestedExceptions().length);
                 } else {
-                    assertEquals(2, ex.getSuppressed().length);
+                    assertEquals(2, ex.getNestedExceptions().length);
                 }
             }
         }


### PR DESCRIPTION
Some users might get confused by the inner exceptions reported during C/R as *suppressed* exceptions. This PR changes the printout to make it look as if the exception had multiple causes. For example the DryRunTest will report this:
```
jdk.crac.CheckpointException: Failed with 2 inner exceptions
Cause 1/2: java.lang.RuntimeException: should not pass
	at DryRunTest$CRResource.beforeCheckpoint(DryRunTest.java:47)
	at java.base/jdk.crac.impl.AbstractContext.invokeBeforeCheckpoint(AbstractContext.java:44)
	... (redacted)
Cause 2/2: jdk.crac.impl.CheckpointOpenFileException: /tmp/jtreg-DryRunTest6956725915963168340.tmp
	at java.base/jdk.internal.crac.JDKFileResource.lambda$beforeCheckpoint$1(JDKFileResource.java:89)
	at java.base/jdk.crac.Core.checkpointRestore1(Core.java:174)
        ... (redacted)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/145/head:pull/145` \
`$ git checkout pull/145`

Update a local copy of the PR: \
`$ git checkout pull/145` \
`$ git pull https://git.openjdk.org/crac.git pull/145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 145`

View PR using the GUI difftool: \
`$ git pr show -t 145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/145.diff">https://git.openjdk.org/crac/pull/145.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/145#issuecomment-1825358097)
</details>
