### PR TITLE
Stop JMX RMI before checkpoint & restart after restore

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -167,7 +167,9 @@ module java.base {
         jdk.sctp,
         jdk.crypto.cryptoki;
     exports jdk.internal.crac to
-        jdk.sctp;
+        java.rmi,
+        jdk.sctp,
+        jdk.management.agent;
     exports jdk.internal.foreign to
         jdk.incubator.vector;
     exports jdk.internal.event to

--- a/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPTransport.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPTransport.java
@@ -65,6 +65,11 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import jdk.crac.Context;
+import jdk.crac.Resource;
+import jdk.internal.crac.Core;
+import jdk.internal.crac.JDKResource;
 import sun.rmi.runtime.Log;
 import sun.rmi.runtime.NewThreadAction;
 import sun.rmi.transport.Channel;
@@ -285,7 +290,7 @@ public class TCPTransport extends Transport {
             tcpLog.log(Log.VERBOSE,
                     "server socket: " + server + ", exportCount: " + exportCount);
         }
-        if (exportCount == 0 && getEndpoint().getListenPort() != 0) {
+        if (exportCount == 0) {
             ServerSocket ss = server;
             server = null;
             try {
@@ -650,7 +655,7 @@ public class TCPTransport extends Transport {
     /**
      * Services messages on accepted connection
      */
-    private class ConnectionHandler implements Runnable {
+    private class ConnectionHandler implements Runnable, JDKResource {
 
         /** int value of "POST" in ASCII (Java's specified data formats
          *  make this once-reviled tactic again socially acceptable) */
@@ -673,6 +678,7 @@ public class TCPTransport extends Transport {
         ConnectionHandler(Socket socket, String remoteHost) {
             this.socket = socket;
             this.remoteHost = remoteHost;
+            Core.Priority.NORMAL.getContext().register(this);
         }
 
         String getClientHost() {
@@ -863,6 +869,16 @@ public class TCPTransport extends Transport {
             } finally {
                 closeSocket(socket);
             }
+        }
+
+        @Override
+        public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+            closeSocket(socket);
+        }
+
+        @Override
+        public void afterRestore(Context<? extends Resource> context) throws Exception {
+            // noop, the connection is not reopened
         }
     }
 }

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/Agent.java
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/Agent.java
@@ -52,6 +52,11 @@ import javax.management.remote.JMXConnectorServer;
 import javax.management.remote.JMXServiceURL;
 
 import static jdk.internal.agent.AgentConfigurationError.*;
+
+import jdk.crac.Context;
+import jdk.crac.Resource;
+import jdk.internal.crac.Core;
+import jdk.internal.crac.JDKResource;
 import jdk.internal.vm.VMSupport;
 import sun.management.jdp.JdpController;
 import sun.management.jdp.JdpException;
@@ -257,8 +262,10 @@ public class Agent {
 
     // The only active agent allowed
     private static JMXConnectorServer jmxServer = null;
+    private static JMXConnectorServer localServer = null;
     // The properties used to configure the server
     private static Properties configProps = null;
+    private static JDKResource cracResource;
 
     // Parse string com.sun.management.prop=xxx,com.sun.management.prop=yyyy
     // and return property set if args is null or empty
@@ -315,8 +322,8 @@ public class Agent {
 
         // start local connector if not started
         if (agentProps.get(LOCAL_CONNECTOR_ADDRESS_PROP) == null) {
-            JMXConnectorServer cs = ConnectorBootstrap.startLocalConnectorServer();
-            String address = cs.getAddress().toString();
+            localServer = ConnectorBootstrap.startLocalConnectorServer();
+            String address = localServer.getAddress().toString();
             // Add the local connector address to the agent properties
             agentProps.put(LOCAL_CONNECTOR_ADDRESS_PROP, address);
 
@@ -329,6 +336,20 @@ public class Agent {
                 warning(EXPORT_ADDRESS_FAILED, x.getMessage());
             }
         }
+    }
+
+    private static synchronized void stopLocalManagementAgent() throws IOException {
+        Properties agentProps = VMSupport.getAgentProperties();
+        agentProps.remove(LOCAL_CONNECTOR_ADDRESS_PROP);
+        try {
+            localServer.stop();
+            localServer = null;
+        } catch (IOException e) {
+            warning(CONNECTOR_SERVER_IO_ERROR, e.getMessage());
+            // rethrowing to fail the checkpoint
+            throw e;
+        }
+        ConnectorAddressLink.unexportLocal();
     }
 
     /*
@@ -448,6 +469,21 @@ public class Agent {
                     startDiscoveryService(props);
                 }
                 startLocalManagementAgent();
+            }
+            if (cracResource == null) {
+                cracResource = new JDKResource() {
+                    @Override
+                    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+                        stopRemoteManagementAgent();
+                        stopLocalManagementAgent();
+                    }
+
+                    @Override
+                    public void afterRestore(Context<? extends Resource> context) throws Exception {
+                        startAgent();
+                    }
+                };
+                Core.Priority.NORMAL.getContext().register(cracResource);
             }
 
         } catch (AgentConfigurationError e) {

--- a/test/jdk/jdk/crac/RemoteJmxTest.java
+++ b/test/jdk/jdk/crac/RemoteJmxTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.*;
+import jdk.crac.management.*;
+
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracProcess;
+import jdk.test.lib.crac.CracTest;
+
+import javax.management.JMX;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.test.lib.Asserts.*;
+
+/**
+ * @test
+ * @library /test/lib
+ * @build RemoteJmxTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class RemoteJmxTest implements CracTest {
+    private static final String PORT = "9995";
+    private static final String BOOTED = "BOOTED";
+    private static final String RESTORED = "RESTORED";
+
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder().captureOutput(true);
+        builder.javaOption("java.rmi.server.hostname", "localhost")
+                .javaOption("com.sun.management.jmxremote", "true")
+                .javaOption("com.sun.management.jmxremote.port", PORT)
+                .javaOption("com.sun.management.jmxremote.rmi.port", PORT)
+                .javaOption("com.sun.management.jmxremote.ssl", "false")
+                .javaOption("com.sun.management.jmxremote.authenticate", "false")
+                .javaOption("sun.rmi.transport.tcp.logLevel", "FINER")
+                .javaOption("jdk.crac.collect-fd-stacktraces", "true");
+        CracProcess checkpointed = builder.startCheckpoint();
+        checkpointed.waitForStdout(BOOTED);
+        assertEquals(-1L, getUptimeFromRestoreFromJmx());
+        checkpointed.sendNewline();
+        checkpointed.waitForCheckpointed();
+        CracProcess restored = builder.startRestore();
+        restored.waitForStdout(RESTORED);
+        assertGreaterThanOrEqual(getUptimeFromRestoreFromJmx(), 0L);
+        restored.sendNewline();
+        restored.waitForSuccess();
+    }
+
+    private long getUptimeFromRestoreFromJmx() throws IOException, MalformedObjectNameException {
+        JMXConnector conn = JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:" + PORT + "/jmxrmi"));
+        CRaCMXBean cracBean = JMX.newMBeanProxy(conn.getMBeanServerConnection(), new ObjectName("jdk.management:type=CRaC"), CRaCMXBean.class);
+        return cracBean.getUptimeSinceRestore();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        System.out.println(BOOTED);
+        assertEquals((int)'\n', System.in.read());
+        Core.checkpointRestore();
+        System.out.println(RESTORED);
+        assertEquals((int)'\n', System.in.read());
+    }
+}


### PR DESCRIPTION
When JMX is exposed over RMI through system properties `com.sun.management.jmxremote.*` the checkpoint would fail; this PR closes all sockets and reopens listening sockets after restore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/146/head:pull/146` \
`$ git checkout pull/146`

Update a local copy of the PR: \
`$ git checkout pull/146` \
`$ git pull https://git.openjdk.org/crac.git pull/146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 146`

View PR using the GUI difftool: \
`$ git pr show -t 146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/146.diff">https://git.openjdk.org/crac/pull/146.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/146#issuecomment-1842669685)