### PR TITLE
Add Checkpoint timeout

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2044,7 +2044,7 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, CRPauseOnCheckpointError, false, DIAGNOSTIC,                \
       "Pauses the checkpoint when a problem is found on VM level.")         \
                                                                             \
-  product(uint, CRaCCheckpointTimeout, 600,                                 \
+  product(uint, CRaCCheckpointTimeout, 0,                                 \
       "Timeout, in seconds, to limit the time spent on checkpoint."         \
       "A value of zero means no timeout.")                                  \
       range(0, UINT_MAX)                                                    \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2044,6 +2044,11 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, CRPauseOnCheckpointError, false, DIAGNOSTIC,                \
       "Pauses the checkpoint when a problem is found on VM level.")         \
                                                                             \
+  product(uint, CRaCCheckpointTimeout, 10,                                  \
+      "Timeout, in seconds, to limit the time spent on checkpoint."         \
+      "A value of zero means no timeout.")                                  \
+      range(0, UINT_MAX)                                                    \
+                                                                            \
   product(int, LockingMode, LM_LEGACY, EXPERIMENTAL,                        \
           "Select locking mode: "                                           \
           "0: monitors only (LM_MONITOR), "                                 \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2044,7 +2044,7 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, CRPauseOnCheckpointError, false, DIAGNOSTIC,                \
       "Pauses the checkpoint when a problem is found on VM level.")         \
                                                                             \
-  product(uint, CRaCCheckpointTimeout, 10,                                  \
+  product(uint, CRaCCheckpointTimeout, 600,                                  \
       "Timeout, in seconds, to limit the time spent on checkpoint."         \
       "A value of zero means no timeout.")                                  \
       range(0, UINT_MAX)                                                    \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2044,7 +2044,7 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, CRPauseOnCheckpointError, false, DIAGNOSTIC,                \
       "Pauses the checkpoint when a problem is found on VM level.")         \
                                                                             \
-  product(uint, CRaCCheckpointTimeout, 600,                                  \
+  product(uint, CRaCCheckpointTimeout, 600,                                 \
       "Timeout, in seconds, to limit the time spent on checkpoint."         \
       "A value of zero means no timeout.")                                  \
       range(0, UINT_MAX)                                                    \

--- a/test/jdk/jdk/crac/CracTimeoutTest.java
+++ b/test/jdk/jdk/crac/CracTimeoutTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import jdk.crac.*;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+
+import java.util.Arrays;
+
+import static jdk.test.lib.Asserts.*;
+
+/**
+ * @test CracTimeoutTest
+ * @library /test/lib
+ * @build CracTimeoutTest
+ * @run driver jdk.test.lib.crac.CracTest
+ * @requires (os.family == "linux")
+ */
+
+public class CracTimeoutTest implements CracTest {
+    public static final String EXCEPTION_MESSAGE = "Native checkpoint failed.";
+    public static final String TIMEOUT_MESSAGE = "The checkpoint was not generated within 10 seconds.\n" +
+                                   "You can change the time-out period by -XX:CRaCCheckpointTimeout=.";
+
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder().env("CRAC_CRIU_OPTS", "-V")
+                .vmOption("-XX:CRaCCheckpointTimeout=10").captureOutput(true);
+        builder.startCheckpoint().waitForSuccess().outputAnalyzer().shouldContain(TIMEOUT_MESSAGE);
+    }
+
+    @Override
+    public void exec() throws Exception {
+        long startTime = 0;
+        try {
+            startTime = System.currentTimeMillis();
+            Core.checkpointRestore();
+            fail("Was supposed to throw");
+        } catch (CheckpointException e) {
+            long endTime = System.currentTimeMillis();
+            assertEquals(1, e.getSuppressed().length, Arrays.toString(e.getSuppressed()));
+            assertEquals(EXCEPTION_MESSAGE, e.getSuppressed()[0].getMessage());
+            long elapsedTime = endTime - startTime;
+            assertTrue(elapsedTime >= 10000 && elapsedTime <= 11000, "Elapsed time is not between 10 and 11 seconds.");
+        }
+    }
+}


### PR DESCRIPTION
Java process sometimes hangs when checkpoint for some reasons.
For example, this problems occurs if you specify certain options for CRAC_CRIU_OPTS.

```
# export CRAC_CRIU_OPTS=-V
# java -XX:CRaCCheckpointTo=/work/cp CRACTest
CR: Checkpoint ...
```
CRACTest process is not killed and is waiting for checkpoint.

```
# ls /work/cp
cppath  perfdata
```

To avoid this problem, I want to add the checkpoint timeout.
Can I submit a pull request to this repository? I would like you to review this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/147/head:pull/147` \
`$ git checkout pull/147`

Update a local copy of the PR: \
`$ git checkout pull/147` \
`$ git pull https://git.openjdk.org/crac.git pull/147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 147`

View PR using the GUI difftool: \
`$ git pr show -t 147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/147.diff">https://git.openjdk.org/crac/pull/147.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/147#issuecomment-1846839302)