### PR TITLE
8321660: [CRaC] Trim native heap before checkpoint to decrease image size

### DIFF
--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -63,6 +63,7 @@ class outputStream;
   LOG_TAG(continuations) \
   LOG_TAG(coops) \
   LOG_TAG(cpu) \
+  LOG_TAG(crac) \
   LOG_TAG(cset) \
   LOG_TAG(data) \
   LOG_TAG(datacreation) \

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -40,9 +40,7 @@
 #include "services/heapDumper.hpp"
 #include "services/writeableFlags.hpp"
 #include "utilities/decoder.hpp"
-#ifdef LINUX
-#include "os_linux.inline.hpp"
-#endif
+#include "os.inline.hpp"
 
 static const char* _crengine = NULL;
 static char* _crengine_arg_str = NULL;

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -41,7 +41,7 @@
 #include "services/writeableFlags.hpp"
 #include "utilities/decoder.hpp"
 #ifdef LINUX
-#include "os_linux.hpp"
+#include "os_linux.inline.hpp"
 #endif
 
 static const char* _crengine = NULL;


### PR DESCRIPTION
Before checkpointing, we should trim the native C-heap in order to decrease the size of the generated CRaC image.

Without C-heap trimming, the size of a HelloWorld image is ~32m and the one for SpringPetclinic ~209m. If we trim the C-heap before checkpointin, the image size decreses to ~30m for HelloWorld and 170m for SpringPetclinic.

I've also added a new logging tag `crac` because I think it would be nice to log more CRaC details/internals in universal logging.  

Please let me know what you think?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8321660](https://bugs.openjdk.org/browse/JDK-8321660): [CRaC] Trim native heap before checkpoint to decrease image size (**Enhancement** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/148/head:pull/148` \
`$ git checkout pull/148`

Update a local copy of the PR: \
`$ git checkout pull/148` \
`$ git pull https://git.openjdk.org/crac.git pull/148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 148`

View PR using the GUI difftool: \
`$ git pr show -t 148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/148.diff">https://git.openjdk.org/crac/pull/148.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/148#issuecomment-1849049205)