### PR TITLE
Ignore errors parsing classpath

### DIFF
--- a/src/java.base/share/classes/jdk/internal/crac/JDKFileResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKFileResource.java
@@ -25,9 +25,14 @@ public abstract class JDKFileResource extends JDKFdResource {
                 .split(File.pathSeparator);
         CLASSPATH_ENTRIES = new Path[items.length];
         for (int i = 0; i < items.length; i++) {
-            // On Windows, path with forward slashes starting with '/' is an accepted classpath
-            // element, even though it might seem as invalid and parsing in Path.of(...) would fail.
-            CLASSPATH_ENTRIES[i] = new File(items[i]).toPath();
+            try {
+                // On Windows, path with forward slashes starting with '/' is an accepted classpath
+                // element, even though it might seem as invalid and parsing in Path.of(...) would fail.
+                CLASSPATH_ENTRIES[i] = new File(items[i]).toPath();
+            } catch (Exception e) {
+                // Ignore any exception parsing the path: URLClassPath.toFileURL() ignores IOExceptions
+                // as well, here we might get InvalidPathException
+            }
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/crac/JDKFileResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKFileResource.java
@@ -61,7 +61,7 @@ public abstract class JDKFileResource extends JDKFdResource {
         Path p = Path.of(path);
         for (Path entry : CLASSPATH_ENTRIES) {
             try {
-                if (Files.isSameFile(p, entry)) {
+                if (entry != null && Files.isSameFile(p, entry)) {
                     return true;
                 }
             } catch (IOException e) {

--- a/test/jdk/jdk/crac/fileDescriptors/ClasspathParseTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/ClasspathParseTest.java
@@ -21,33 +21,52 @@
  * questions.
  */
 
+import jdk.crac.Core;
 import jdk.test.lib.Utils;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracEngine;
+import jdk.test.lib.crac.CracTest;
 
 import java.io.File;
-import java.io.IOException;
-
-import static jdk.test.lib.Asserts.assertEquals;
+import java.io.FileInputStream;
+import java.util.Arrays;
 
 /**
  * @test
  * @library /test/lib
- * @run driver ClasspathParseTest
+ * @modules java.base/jdk.internal.crac:+open
+ * @build ClasspathParseTest
+ * @run driver jdk.test.lib.crac.CracTest
  */
-public class ClasspathParseTest {
+public class ClasspathParseTest implements CracTest {
     public static final String JAVA = Utils.TEST_JDK + "/bin/java";
 
-    public static void main(String[] args) throws IOException, InterruptedException {
-        if (args.length == 0) {
-            String classpath = ClasspathParseTest.class.getProtectionDomain().getCodeSource().getLocation().getPath();
-            classpath += File.pathSeparator + "file:/C:\\some\\invalid/path";
-            int exit = new ProcessBuilder().command(JAVA, "-cp", classpath, ClasspathParseTest.class.getName(), "ignored")
-                    .inheritIO().start().waitFor();
-            assertEquals(0, exit);
-        } else {
-            // assert that code source path started with "/" as we expect (even on Windows)
-            if (!System.getProperty("java.class.path").startsWith("/")) {
-                System.exit(2);
-            }
+    @Override
+    public void test() throws Exception {
+        String someJar = Arrays.stream(System.getProperty("java.class.path").split(File.pathSeparator))
+                .filter(f -> f.endsWith(".jar")).findAny()
+                .orElseThrow(() -> new AssertionError("there should be some jar on classpath"));
+        new CracBuilder()
+                .engine(CracEngine.SIMULATE)
+                .printResources(true)
+                .classpathEntry(ClasspathParseTest.class.getProtectionDomain().getCodeSource().getLocation().getPath())
+                .classpathEntry("file:/C:\\some\\invalid/path")
+                .classpathEntry(someJar)
+                .startCheckpoint().waitForSuccess();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        // assert that code source path started with "/" as we expect (even on Windows)
+        String cp = System.getProperty("java.class.path");
+        if (!cp.startsWith("/")) {
+            System.exit(2);
+        }
+        String someJar = Arrays.stream(cp.split(File.pathSeparator)).filter(f -> f.endsWith(".jar")).findAny()
+                .orElseThrow(() -> new AssertionError("jar file should be provided on classpath"));
+        try (var fis = new FileInputStream(someJar)) {
+            Core.checkpointRestore();
         }
     }
 }
+

--- a/test/jdk/jdk/crac/fileDescriptors/ClasspathParseTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/ClasspathParseTest.java
@@ -23,6 +23,7 @@
 
 import jdk.test.lib.Utils;
 
+import java.io.File;
 import java.io.IOException;
 
 import static jdk.test.lib.Asserts.assertEquals;
@@ -38,6 +39,7 @@ public class ClasspathParseTest {
     public static void main(String[] args) throws IOException, InterruptedException {
         if (args.length == 0) {
             String classpath = ClasspathParseTest.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+            classpath += File.pathSeparator + "file:/C:\\some\\invalid/path";
             int exit = new ProcessBuilder().command(JAVA, "-cp", classpath, ClasspathParseTest.class.getName(), "ignored")
                     .inheritIO().start().waitFor();
             assertEquals(0, exit);


### PR DESCRIPTION
This test is relevant mostly on Windows - trying to use URI in the form of `file:/C:/path/to/...` as classpath element. On Linux, this is parsed as two items as `File.pathSeparator` is `:`. However on Windows the second colon triggers an exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/149/head:pull/149` \
`$ git checkout pull/149`

Update a local copy of the PR: \
`$ git checkout pull/149` \
`$ git pull https://git.openjdk.org/crac.git pull/149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 149`

View PR using the GUI difftool: \
`$ git pr show -t 149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/149.diff">https://git.openjdk.org/crac/pull/149.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/149#issuecomment-1857584519)