### PR TITLE
Remove stackoverflow.com reference as some tools do not like it

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -830,7 +830,7 @@ uint64_t VM_Version::CPUFeatures_parse(uint64_t &glibc_features) {
       | CPU_CX8 // gcc detects it to set cpu "pentium" (=32-bit only), used by OpenJDK
       | CPU_CMOV // gcc detects it to set cpu "pentiumpro" (=32-bit only), used by OpenJDK
       | CPU_FLUSH // ="clflush" in cpuinfo, not used by gcc, required by OpenJDK
-      // GLIBC_MOVBE is disabled in 'gcc -Q --help=target' and some CPUs do not support it: https://stackoverflow.com/a/5246553/2995591
+      // GLIBC_MOVBE is disabled in 'gcc -Q --help=target' and for example i7-720QM does not support it
       // GLIBC_LAHFSAHF is disabled in 'gcc -Q --help=target' and "Early Intel Pentium 4 CPUs with Intel 64 support ... lacked the LAHF and SAHF instructions"
 #endif
     ;


### PR DESCRIPTION
There exist out there some tools checking source code and they complain about this stackoverflow.com reference. It was not too important there anyway.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/150/head:pull/150` \
`$ git checkout pull/150`

Update a local copy of the PR: \
`$ git checkout pull/150` \
`$ git pull https://git.openjdk.org/crac.git pull/150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 150`

View PR using the GUI difftool: \
`$ git pr show -t 150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/150.diff">https://git.openjdk.org/crac/pull/150.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/150#issuecomment-1864014096)