### PR TITLE
Add debug flag to -XX:CREngine.

### DIFF
--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -205,6 +205,14 @@ static int call_crengine() {
   }
   _crengine_args[1] = "checkpoint";
   add_crengine_arg(CRaCCheckpointTo);
+  if (CREngine &&
+      (strstr(CREngine, "-d,true") || strstr(CREngine, "--debug,true"))) {
+      tty->print("CRaC info executing: ");
+      for (unsigned int i=0; i < _crengine_argc; i++) {
+          tty->print("%s ", _crengine_args[i]);
+      }
+      tty->print_cr("");
+  }
   return os::exec_child_process_and_wait(_crengine, _crengine_args);
 }
 

--- a/src/java.base/unix/native/criuengine/criuengine.c
+++ b/src/java.base/unix/native/criuengine/criuengine.c
@@ -51,6 +51,7 @@ static int g_pid;
 
 static char *verbosity = NULL; // default differs for checkpoint and restore
 static char *log_file = NULL;
+static bool debug = false;
 
 static int kickjvm(pid_t jvm, int code) {
     union sigval sv = { .sival_int = code };
@@ -187,6 +188,9 @@ static int checkpoint(pid_t jvm,
         }
     }
     *arg++ = NULL;
+    if (debug) {
+        print_command_args_to_stderr(args);
+    }
 
     pid_t child = fork();
     if (!child) {
@@ -356,10 +360,15 @@ static char *parse_options(int argc, char *argv[]) {
         .has_arg = 1,
         .flag = NULL,
         .val = 'o',
+    }, {
+        .name = "debug",
+        .has_arg = 1,
+        .flag = NULL,
+        .val = 'd',
     }, { NULL, 0, NULL, 0} };
     bool processing = true;
     do {
-        switch (getopt_long(argc, argv, "v:o:", opts, NULL)) {
+        switch (getopt_long(argc, argv, "v:o:d:", opts, NULL)) {
             case -1:
             case '?':
                 processing = false;
@@ -372,6 +381,11 @@ static char *parse_options(int argc, char *argv[]) {
                 break;
             case 'o':
                 log_file = optarg;
+                break;
+            case 'd':
+                if (!strcmp(optarg, "true")) {
+                    debug = true;
+                }
                 break;
         }
     } while (processing);


### PR DESCRIPTION
Hello everyone,

This is my first PR for the CRAC project. I propose three modifications to the criuengine.

Firstly, I suggest adding a debug flag to the criuengine, as some JDK C/C++ native codes have the debug flag. 
My proposal is to pass the debug flag using "-XX:CREngine=criuengine,debug,true".

Secondly, the criuengine has a useful function, print_command_args_to_stderr(), which prints the criu command line. 
However, it is only called when an error occurs. I believe it would be beneficial if the criu command line is printed when the debug flag is specified.

The criu command line is built from the parameter of -XX:CREngine and environment variables such as CRAC_CRIU_PATH and CRAC_CRIU_OPT. 
It would be helpful to see how it is actually assembled.

For example:
 $ export CRAC_CRIU_PATH=/work/criu-crac-release-1.4/sbin/criu
 $ ./jdk/bin/java -XX:CREngine=/work/jdk/lib/criuengine,-v,3,-o,output3.log,-d,true -XX:CRaCCheckpointTo=cr Test

 Command: /work/criu-crac-release-1.4/sbin/criu dump -t 3232214 -D cr --shell-job '--verbosity=3' -o output3.log

Thirdly, I propose that the criuengine command line, which is executed by the JavaVM, be printed when "-XX:CREngine=criuengine,debug,true" is specified. 
For example, 
 CRaC info executing: /work/jdk/lib/criuengine checkpoint -v 3 -o output3.log -d true cr

Testing:
I have verified the jdk/crac/VMOptionsTest.java, which is a test for -XX:CREngine. I believe it's unnecessary to add a test for the debug flag to it.

Could you please review these modifications?

Thank you,
Kimura Yukihiro

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/151/head:pull/151` \
`$ git checkout pull/151`

Update a local copy of the PR: \
`$ git checkout pull/151` \
`$ git pull https://git.openjdk.org/crac.git pull/151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 151`

View PR using the GUI difftool: \
`$ git pr show -t 151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/151.diff">https://git.openjdk.org/crac/pull/151.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/151#issuecomment-1868614490)