### PR TITLE
8314610: hotspot can't compile with the latest of gtest because of <iomanip>

### DIFF
--- a/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp
+++ b/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 #include "utilities/globalDefinitions.hpp"
 
 #include "utilities/vmassert_uninstall.hpp"
+#include <iomanip>
 #include <string.h>
 #include <sstream>
 #include "utilities/vmassert_reinstall.hpp"


### PR DESCRIPTION
Although a better fix with be just a new merge with master.

```
test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp: In member function 'virtual void gc_memset_with_concurrent_readers_Test::TestBody()':
test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp:82:34: error: 'setw' is not a member of 'std' 
   82 |                          << std::setw(2) << line_byte(lp, 0) << " "
      |                                  ^~~~
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8314610](https://bugs.openjdk.org/browse/JDK-8314610): hotspot can't compile with the latest of gtest because of &lt;iomanip&gt; (**Enhancement** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/152/head:pull/152` \
`$ git checkout pull/152`

Update a local copy of the PR: \
`$ git checkout pull/152` \
`$ git pull https://git.openjdk.org/crac.git pull/152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 152`

View PR using the GUI difftool: \
`$ git pr show -t 152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/152.diff">https://git.openjdk.org/crac/pull/152.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/152#issuecomment-1923272049)