### PR TITLE
8328344: [CRaC] Avoid error when running with -XX:+PerfDisableSharedMem

### DIFF
--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1375,6 +1375,10 @@ bool PerfMemoryLinux::checkpoint() {
 }
 
 bool PerfMemoryLinux::restore() {
+  if (!backing_store_file_name) {
+    return true;
+  }
+
   int vmid = os::current_process_id();
   char* user_name = get_user_name(geteuid());
   if (!user_name) {

--- a/test/jdk/jdk/crac/PerfMemoryRestoreTest.java
+++ b/test/jdk/jdk/crac/PerfMemoryRestoreTest.java
@@ -31,7 +31,6 @@ import jdk.test.lib.process.OutputAnalyzer;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static jdk.test.lib.Asserts.*;
@@ -46,6 +45,7 @@ import static jdk.test.lib.Asserts.*;
  */
 
 public class PerfMemoryRestoreTest implements CracTest {
+    private static final int PERFDATA_CREATE_DELAY_MS = 100;
 
     @CracTestArg(0)
     boolean perfDisableSharedMem;
@@ -65,7 +65,7 @@ public class PerfMemoryRestoreTest implements CracTest {
         // in os::get_temp_directory() to /tmp rather than using System.getProperty("java.io.tmpdir")
         Path perfdata = Path.of("/tmp", "hsperfdata_" + System.getProperty("user.name"), pid);
         if (perfDisableSharedMem) {
-            Thread.sleep(100);
+            Thread.sleep(PERFDATA_CREATE_DELAY_MS);
             assertFalse(perfdata.toFile().exists(), "Perf data file exists although we run with -XX:+PerfDisableSharedMem");
         } else {
             waitForFile(perfdata);
@@ -83,7 +83,7 @@ public class PerfMemoryRestoreTest implements CracTest {
         // as restored.pid() would be the criuengine restorewait process
         String pidString = String.valueOf(checkpoint.pid());
         if (perfDisableSharedMem) {
-            Thread.sleep(100);
+            Thread.sleep(PERFDATA_CREATE_DELAY_MS);
             assertFalse(perfdata.toFile().exists(), "Perf data file exists although we run with -XX:+PerfDisableSharedMem");
         } else {
             waitForFile(perfdata);

--- a/test/jdk/jdk/crac/PerfMemoryRestoreTest.java
+++ b/test/jdk/jdk/crac/PerfMemoryRestoreTest.java
@@ -31,6 +31,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static jdk.test.lib.Asserts.*;
@@ -73,7 +74,7 @@ public class PerfMemoryRestoreTest implements CracTest {
                 }
             }
             //noinspection BusyWait
-            Thread.sleep(10);
+            Thread.sleep(perfDisableSharedMem == true ? Duration.ofSeconds(10) : Duration.ofMillis(10));
         }
         if (perfDisableSharedMem) {
             if (perfdata.toFile().exists()) {
@@ -100,7 +101,7 @@ public class PerfMemoryRestoreTest implements CracTest {
                 }
             }
             //noinspection BusyWait
-            Thread.sleep(10);
+            Thread.sleep(perfDisableSharedMem == true ? Duration.ofSeconds(10) : Duration.ofMillis(10));
         }
         // Note: we need to check the checkpoint.pid(), which should be restored (when using CRIU),
         // as restored.pid() would be the criuengine restorewait process


### PR DESCRIPTION
CRaC tries to unconditionally restore the hsperf file, even if the checkpointed JVM process was started with `-XX:+PerfDisableSharedMem`.

The fix is trivial: check for the existence of the hsperf file in `PerfMemoryLinux::restore()` just as we already do it in `PerfMemoryLinux::checkpoint()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8328344](https://bugs.openjdk.org/browse/JDK-8328344): [CRaC] Avoid error when running with -XX:+PerfDisableSharedMem (**Enhancement** - P4)


### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.org/crac.git pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/153.diff">https://git.openjdk.org/crac/pull/153.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/crac/pull/153#issuecomment-2003615152)