### PR TITLE
8346178: [CRaC] Failure in com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java

### DIFF
--- a/test/jdk/com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java
+++ b/test/jdk/com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java
@@ -233,6 +233,9 @@ public class DcmdMBeanPermissionsTest {
         sm.grantPermission(new java.lang.RuntimePermission("modifyThread"));
         sm.grantPermission(new java.security.SecurityPermission("getProperty.jdk.jar.disabledAlgorithms"));
         for(MBeanOperationInfo opInfo : info.getOperations()) {
+            if (opInfo.getName().equals("jdkCheckpoint")) {
+                continue;
+            }
             Permission opPermission = new MBeanPermission(info.getClassName(),
                     opInfo.getName(),
                     on,


### PR DESCRIPTION
The test takes all dcmd commands and invokes each to check if a command exceeds permissions set up in the test.

This fix simply excludes `jdk.checkpoint` command from the test and keeps the rest of the test logic untouched. This approach was chosen because (1) checkpointing requires many permissions and it would be better to create a separate test for this if we want to "document" these permissions since the current test does not separate permission sets by commands, (2) the test would need additional adjustments to actually perform a checkpoint due to the CRaC specifics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8346178](https://bugs.openjdk.org/browse/JDK-8346178): [CRaC] Failure in com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java (**Bug** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/161/head:pull/161` \
`$ git checkout pull/161`

Update a local copy of the PR: \
`$ git checkout pull/161` \
`$ git pull https://git.openjdk.org/crac.git pull/161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 161`

View PR using the GUI difftool: \
`$ git pr show -t 161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/161.diff">https://git.openjdk.org/crac/pull/161.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/161#issuecomment-2541683361)
</details>
