### PR TITLE
Support CRaC with Java agents that use appendToBootstrapClassLoaderSearch

### DIFF
--- a/src/hotspot/os/linux/crac_linux.cpp
+++ b/src/hotspot/os/linux/crac_linux.cpp
@@ -361,6 +361,11 @@ bool VM_Crac::check_fds() {
       }
     }
 
+    if (ClassLoader::is_in_boot_append_entries(details)) {
+      print_resources("OK: appended to bootclasspath\n");
+      continue;
+    }
+
     print_resources("BAD: opened by application\n");
     ok = false;
 

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -825,6 +825,17 @@ void ClassLoader::add_to_boot_append_entries(ClassPathEntry *new_entry) {
   }
 }
 
+bool ClassLoader::is_in_boot_append_entries(const char* path) {
+  ClassPathEntry* e = first_append_entry();
+  while (e != nullptr) {
+    if (strcmp(e->name(), path) == 0) {
+      return true;
+    }
+    e = e->next();
+  }
+  return false;
+}
+
 // Record the path entries specified in -cp during dump time. The recorded
 // information will be used at runtime for loading the archived app classes.
 //

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -409,6 +409,7 @@ class ClassLoader: AllStatic {
 
   // adds a class path to the boot append entries
   static void add_to_boot_append_entries(ClassPathEntry* new_entry);
+  static bool is_in_boot_append_entries(const char* path);
 
   // creates a class path zip entry (returns null if JAR file cannot be opened)
   static ClassPathZipEntry* create_class_path_zip_entry(const char *apath, bool is_boot_append);


### PR DESCRIPTION
`Instrumentation.appendToBootstrapClassLoaderSearch(jarfile)` ends up creating a file descriptor for the jarfile in native code that cannot be closed or claimed from Java:

https://github.com/openjdk/jdk/blob/jdk-25%2B2/src/hotspot/share/prims/jvmtiEnv.cpp#L671

These FDs can be ignored and left to the CRaC engine.

Without this change you cannot use CRaC with Java agents that call `appendToBootstrapClassLoaderSearch`, unless you use `-XX:CRAllowedOpenFilePrefixes` as a workaround.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/162/head:pull/162` \
`$ git checkout pull/162`

Update a local copy of the PR: \
`$ git checkout pull/162` \
`$ git pull https://git.openjdk.org/crac.git pull/162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 162`

View PR using the GUI difftool: \
`$ git pr show -t 162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/162.diff">https://git.openjdk.org/crac/pull/162.diff</a>

</details>
