### PR TITLE
8346765: [CRaC] Could not find criuengine on Windows and Mac

### DIFF
--- a/src/hotspot/os/bsd/globals_bsd.hpp
+++ b/src/hotspot/os/bsd/globals_bsd.hpp
@@ -50,5 +50,6 @@ define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, false);
 define_pd_global(bool, UseThreadPriorities, true) ;
 define_pd_global(ccstrlist, CRAllowedOpenFilePrefixes, nullptr);
+define_pd_global(ccstr, CREngine, "simengine");
 
 #endif // OS_BSD_GLOBALS_BSD_HPP

--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -108,7 +108,7 @@ define_pd_global(size_t, PreTouchParallelChunkSize, 4 * M);
 define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, false);
 define_pd_global(bool, UseThreadPriorities, true) ;
-
+define_pd_global(ccstr, CREngine, "criuengine");
 // On some systems using SSSD files in this directory are left open
 // after calling getpwuid_r, getpwname_r, getgrgid_r, getgrname_r
 // or other functions in this family.

--- a/src/hotspot/os/windows/globals_windows.hpp
+++ b/src/hotspot/os/windows/globals_windows.hpp
@@ -56,5 +56,6 @@ define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, true);
 define_pd_global(bool, UseThreadPriorities, true) ;
 define_pd_global(ccstrlist, CRAllowedOpenFilePrefixes, nullptr);
+define_pd_global(ccstr, CREngine, "simengine");
 
 #endif // OS_WINDOWS_GLOBALS_WINDOWS_HPP

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -146,10 +146,11 @@ static bool compute_crengine() {
     size_t pathlen = cr_util_path(path, sizeof(path));
     strcat(path + pathlen, os::file_separator());
     strcat(path + pathlen, exec);
+    WINDOWS_ONLY(strcat(path + pathlen, ".exe"));
 
     struct stat st;
     if (0 != os::stat(path, &st)) {
-      warning("Could not find %s: %s", path, os::strerror(errno));
+      warning("Could not find CREngine %s: %s", path, os::strerror(errno));
       return false;
     }
     _crengine = os::strdup_check_oom(path);

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1961,7 +1961,7 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, CRaCResetStartTime, true, DIAGNOSTIC | RESTORE_SETTABLE,    \
       "Reset JVM's start time and uptime on restore")                       \
                                                                             \
-  product(ccstr, CREngine, "criuengine", RESTORE_SETTABLE,                  \
+  product_pd(ccstr, CREngine, RESTORE_SETTABLE,                             \
       "Path or name of a program implementing checkpoint/restore and "      \
       "optional extra parameters as a comma-separated list: "               \
       "-XX:CREngine=program,--key,value,--anotherkey results in calling "   \

--- a/test/jdk/jdk/crac/CracVersionTest.java
+++ b/test/jdk/jdk/crac/CracVersionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ import org.junit.Test;
+
+ import jdk.test.lib.process.OutputAnalyzer;
+ import jdk.test.lib.process.ProcessTools;
+ /*
+  * @test CracVersionTest
+  * @library /test/lib
+  * @build CracVersionTest
+  * @run junit/othervm CracVersionTest
+  */
+ public class CracVersionTest {
+     @Test
+     public void test_default() throws Exception {
+         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                 "-XX:CRaCCheckpointTo=cr",
+                 "-version");
+         OutputAnalyzer out = new OutputAnalyzer(pb.start());
+         out.shouldHaveExitValue(0);
+     }
+
+     private final String UNKNOWN_ENGINE = "unknown";
+
+     @Test
+     public void test_fail() throws Exception {
+         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                 "-XX:CRaCCheckpointTo=cr",
+                 "-XX:CREngine=" + UNKNOWN_ENGINE,
+                 "-version");
+         OutputAnalyzer out = new OutputAnalyzer(pb.start());
+         out.shouldHaveExitValue(1);
+         if (System.getProperty("os.name").contains("Windows")) {
+            out.shouldContain(UNKNOWN_ENGINE + ".exe:");
+         } else {
+            out.shouldContain(UNKNOWN_ENGINE + ":");
+         }
+     }
+ }

--- a/test/lib/jdk/test/lib/crac/CracEngine.java
+++ b/test/lib/jdk/test/lib/crac/CracEngine.java
@@ -2,8 +2,8 @@ package jdk.test.lib.crac;
 
 public enum CracEngine {
     CRIU("criuengine"),
-    PAUSE(System.getProperty("os.name").contains("Windows") ? "pauseengine.exe" : "pauseengine"),
-    SIMULATE(System.getProperty("os.name").contains("Windows") ? "simengine.exe" : "simengine");
+    PAUSE("pauseengine"),
+    SIMULATE("simengine");
 
     public final String engine;
 


### PR DESCRIPTION
Sets `simengine` as the default `CREngine` on Windows and Mac since `criuengine` (the previous default) does not exist there.

Also adds the corresponding test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8346765](https://bugs.openjdk.org/browse/JDK-8346765): [CRaC] Could not find criuengine on Windows and Mac (**Bug** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/166/head:pull/166` \
`$ git checkout pull/166`

Update a local copy of the PR: \
`$ git checkout pull/166` \
`$ git pull https://git.openjdk.org/crac.git pull/166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 166`

View PR using the GUI difftool: \
`$ git pr show -t 166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/166.diff">https://git.openjdk.org/crac/pull/166.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/166#issuecomment-2559253297)
</details>
