### PR TITLE
8346766: [CRaC] tools/launcher/HelpFlagsTest.java and tools/launcher/VersionCheck.java tests fail on Windows

### DIFF
--- a/test/jdk/tools/launcher/HelpFlagsTest.java
+++ b/test/jdk/tools/launcher/HelpFlagsTest.java
@@ -45,6 +45,9 @@ public class HelpFlagsTest extends TestHelper {
 
     // Tools that should not be tested because a usage message is pointless.
     static final String[] TOOLS_NOT_TO_TEST = {
+        "pauseengine", // crac, don't test
+        "simengine", // crac, don't test
+
         "jaccessinspector", // gui, don't test, win only
         "jaccessinspector-32", // gui, don't test, win-32 only
         "jaccesswalker",    // gui, don't test, win only

--- a/test/jdk/tools/launcher/VersionCheck.java
+++ b/test/jdk/tools/launcher/VersionCheck.java
@@ -44,6 +44,9 @@ public class VersionCheck extends TestHelper {
 
     // tools that do not accept -J-option
     static final String[] BLACKLIST_JOPTION = {
+        "pauseengine", // crac, don't test
+        "simengine", // crac, don't test
+
         "controlpanel",
         "jabswitch",
         "java-rmi",
@@ -67,6 +70,9 @@ public class VersionCheck extends TestHelper {
 
     // tools that do not accept -version
     static final String[] BLACKLIST_VERSION = {
+        "pauseengine", // crac, don't test
+        "simengine", // crac, don't test
+
         "controlpanel",
         "jaccessinspector",
         "jaccessinspector-32",


### PR DESCRIPTION
As a simple fix, CRaC's CREngine binaries are added as exceptions to the aforementioned tests.

In future the binaries can be made compliant with the tests (i.e. `-help`, `-version` and other required flags can be added).