### PR TITLE
8346768: [CRaC] Ignore errors parsing classpath

### DIFF
--- a/src/java.base/share/classes/jdk/internal/crac/JDKFileResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKFileResource.java
@@ -25,9 +25,14 @@ public abstract class JDKFileResource extends JDKFdResource {
                 .split(File.pathSeparator);
         CLASSPATH_ENTRIES = new Path[items.length];
         for (int i = 0; i < items.length; i++) {
-            // On Windows, path with forward slashes starting with '/' is an accepted classpath
-            // element, even though it might seem as invalid and parsing in Path.of(...) would fail.
-            CLASSPATH_ENTRIES[i] = new File(items[i]).toPath();
+            try {
+                // On Windows, path with forward slashes starting with '/' is an accepted classpath
+                // element, even though it might seem as invalid and parsing in Path.of(...) would fail.
+                CLASSPATH_ENTRIES[i] = new File(items[i]).toPath();
+            } catch (Exception e) {
+                // Ignore any exception parsing the path: URLClassPath.toFileURL() ignores IOExceptions
+                // as well, here we might get InvalidPathException
+            }
         }
     }
 
@@ -56,7 +61,7 @@ public abstract class JDKFileResource extends JDKFdResource {
         Path p = Path.of(path);
         for (Path entry : CLASSPATH_ENTRIES) {
             try {
-                if (Files.isSameFile(p, entry)) {
+                if (entry != null && Files.isSameFile(p, entry)) {
                     return true;
                 }
             } catch (IOException e) {


### PR DESCRIPTION
CRaC's classpath parsing now ignores exceptions being thrown when parsing the paths.

`ClasspathParseTest` is extended to test the failure does not occur at least on Windows (no test case was found to trigger `new File(...).toPath()` exceptions on other platforms).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8346768](https://bugs.openjdk.org/browse/JDK-8346768): [CRaC] Ignore errors parsing classpath (**Bug** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/168/head:pull/168` \
`$ git checkout pull/168`

Update a local copy of the PR: \
`$ git checkout pull/168` \
`$ git pull https://git.openjdk.org/crac.git pull/168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 168`

View PR using the GUI difftool: \
`$ git pr show -t 168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/168.diff">https://git.openjdk.org/crac/pull/168.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/168#issuecomment-2559291130)
</details>
