### PR TITLE
8347055: [CRaC] Remote JMX support

### DIFF
--- a/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
@@ -227,6 +227,14 @@ public class Core {
             }
         }
 
+        // The agent should be started only after all Resources are restored so that it finds
+        // the system in consistent state and is free to register more Resources (e.g. because
+        // it may open configuration file for JMX).
+        if (newProperties != null && Arrays.stream(newProperties).anyMatch(prop -> prop.startsWith("com.sun.management")) ||
+                System.getProperties().keySet().stream().anyMatch(prop -> prop.toString().startsWith("com.sun.management"))) {
+            tryStartManagementAgent();
+        }
+
         if (newArguments != null && newArguments.length() > 0) {
             String[] args = newArguments.split(" ");
             if (args.length > 0) {
@@ -319,5 +327,18 @@ public class Core {
             return null;
         }
         return null;
+    }
+
+    private static void tryStartManagementAgent() {
+        try {
+            Class<?> agentClass = Class.forName("jdk.internal.agent.Agent");
+            Method startAgent = agentClass.getMethod("startAgent");
+            startAgent.setAccessible(true);
+            startAgent.invoke(null);
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            LoggerContainer.error(e, "Cannot find JMX agent start method");
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            LoggerContainer.error(e, "Cannot start JXM agent");
+        }
     }
 }

--- a/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
@@ -338,7 +338,7 @@ public class Core {
         } catch (ClassNotFoundException | NoSuchMethodException e) {
             LoggerContainer.error(e, "Cannot find JMX agent start method");
         } catch (InvocationTargetException | IllegalAccessException e) {
-            LoggerContainer.error(e, "Cannot start JXM agent");
+            LoggerContainer.error(e, "Cannot start JMX agent");
         }
     }
 }

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -176,6 +176,8 @@ module java.base {
         jdk.sctp,
         jdk.crypto.cryptoki;
     exports jdk.internal.crac to
+        java.rmi,
+        jdk.management.agent,
         jdk.sctp;
     exports jdk.internal.foreign to
         jdk.incubator.vector;
@@ -424,7 +426,9 @@ module java.base {
         jdk.internal.jrtfs.JrtFileSystemProvider;
 
     exports jdk.internal.crac.mirror to
-        jdk.crac;
+	java.rmi,
+        jdk.crac,
+	jdk.management.agent;
 
     exports jdk.internal.crac.mirror.impl to
         jdk.crac;

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -426,9 +426,9 @@ module java.base {
         jdk.internal.jrtfs.JrtFileSystemProvider;
 
     exports jdk.internal.crac.mirror to
-	java.rmi,
+        java.rmi,
         jdk.crac,
-	jdk.management.agent;
+        jdk.management.agent;
 
     exports jdk.internal.crac.mirror.impl to
         jdk.crac;

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/Agent.java
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/Agent.java
@@ -463,7 +463,7 @@ public class Agent {
              * instrumentation buffer.
              */
             if (jmxremote != null || jmxremotePort != null) {
-                if (jmxremotePort != null) {
+                if (jmxremotePort != null && jmxServer == null) {
                     jmxServer = ConnectorBootstrap.
                             startRemoteConnectorServer(jmxremotePort, props);
                     startDiscoveryService(props);
@@ -476,6 +476,8 @@ public class Agent {
                     public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
                         stopRemoteManagementAgent();
                         stopLocalManagementAgent();
+                        // reload properties after restore
+                        mgmtProps = null;
                     }
 
                     @Override

--- a/test/jdk/jdk/crac/RemoteJmxTest.java
+++ b/test/jdk/jdk/crac/RemoteJmxTest.java
@@ -30,10 +30,13 @@ import jdk.test.lib.crac.CracBuilder;
 import jdk.test.lib.crac.CracEngine;
 import jdk.test.lib.crac.CracProcess;
 import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import javax.management.JMX;
@@ -42,6 +45,7 @@ import javax.management.ObjectName;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
+import java.io.IOException;
 
 import static jdk.test.lib.Asserts.*;
 
@@ -49,33 +53,39 @@ import static jdk.test.lib.Asserts.*;
  * @test
  * @library /test/lib
  * @build RemoteJmxTest
- * @run driver jdk.test.lib.crac.CracTest
+ * @run driver jdk.test.lib.crac.CracTest 9995 none
+ * @run driver jdk.test.lib.crac.CracTest 9995 10095
+ * @run driver jdk.test.lib.crac.CracTest none 10095
  */
 public class RemoteJmxTest implements CracTest {
-    private static final String PORT = "9995";
     private static final String BOOTED = "BOOTED";
     private static final String RESTORED = "RESTORED";
+    public static final String NONE = "none";
+
+    @CracTestArg(0)
+    String portBefore;
+
+    @CracTestArg(1)
+    String portAfter;
 
     @Override
     public void test() throws Exception {
         CracBuilder builder = new CracBuilder().captureOutput(true);
         builder.engine(CracEngine.SIMULATE);
-        builder.javaOption("java.rmi.server.hostname", "localhost")
-                .javaOption("com.sun.management.jmxremote", "true")
-                .javaOption("com.sun.management.jmxremote.port", PORT)
-                .javaOption("com.sun.management.jmxremote.rmi.port", PORT)
-                .javaOption("com.sun.management.jmxremote.ssl", "false")
-                .javaOption("com.sun.management.jmxremote.authenticate", "false")
-                .javaOption("sun.rmi.transport.tcp.logLevel", "FINER")
-                .javaOption("jdk.crac.collect-fd-stacktraces", "true");
+        if (!NONE.equals(portBefore)) {
+            javaOptions(portBefore).forEach(builder::javaOption);
+        }
         CracProcess process = builder.startCheckpoint();
         try {
             var reader = new BufferedReader(new InputStreamReader(process.output()));
             waitForString(reader, BOOTED);
-            assertEquals(-1L, getUptimeFromRestoreFromJmx());
+            if (!NONE.equals(portBefore)) {
+                assertEquals(-1L, getUptimeFromRestoreFromJmx(portBefore));
+            }
             process.sendNewline();
             waitForString(reader, RESTORED);
-            assertGreaterThanOrEqual(getUptimeFromRestoreFromJmx(), 0L);
+            String currentPort = NONE.equals(portAfter) ? portBefore : portAfter;
+            assertGreaterThanOrEqual(getUptimeFromRestoreFromJmx(currentPort), 0L);
             process.sendNewline();
             process.waitForSuccess();
         } finally {
@@ -91,8 +101,22 @@ public class RemoteJmxTest implements CracTest {
         }
     }
 
-    private long getUptimeFromRestoreFromJmx() throws IOException, MalformedObjectNameException {
-        JMXConnector conn = JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:" + PORT + "/jmxrmi"));
+    private static Map<String, String> javaOptions(String port) {
+        // the options are in a map, so the values will be overwritten
+        var opts = new HashMap<String, String>();
+        opts.put("java.rmi.server.hostname", "localhost");
+        opts.put("com.sun.management.jmxremote", "true");
+        opts.put("com.sun.management.jmxremote.port", port);
+        opts.put("com.sun.management.jmxremote.rmi.port", port);
+        opts.put("com.sun.management.jmxremote.ssl", "false");
+        opts.put("com.sun.management.jmxremote.authenticate", "false");
+        opts.put("sun.rmi.transport.tcp.logLevel", "FINER");
+        opts.put("jdk.crac.collect-fd-stacktraces", "true");
+        return opts;
+    }
+
+    private long getUptimeFromRestoreFromJmx(String port) throws IOException, MalformedObjectNameException {
+        JMXConnector conn = JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:" + port + "/jmxrmi"));
         CRaCMXBean cracBean = JMX.newMBeanProxy(conn.getMBeanServerConnection(), new ObjectName("jdk.management:type=CRaC"), CRaCMXBean.class);
         return cracBean.getUptimeSinceRestore();
     }
@@ -101,6 +125,9 @@ public class RemoteJmxTest implements CracTest {
     public void exec() throws Exception {
         System.out.println(BOOTED);
         assertEquals((int)'\n', System.in.read());
+        if (!NONE.equals(portAfter)) {
+            javaOptions(portAfter).forEach(System::setProperty);
+        }
         Core.checkpointRestore();
         System.out.println(RESTORED);
         assertEquals((int)'\n', System.in.read());

--- a/test/jdk/jdk/crac/RemoteJmxTest.java
+++ b/test/jdk/jdk/crac/RemoteJmxTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.*;
+import jdk.crac.management.*;
+
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracProcess;
+import jdk.test.lib.crac.CracTest;
+
+import javax.management.JMX;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.test.lib.Asserts.*;
+
+/**
+ * @test
+ * @library /test/lib
+ * @build RemoteJmxTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class RemoteJmxTest implements CracTest {
+    private static final String PORT = "9995";
+    private static final String BOOTED = "BOOTED";
+    private static final String RESTORED = "RESTORED";
+
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder().captureOutput(true);
+        builder.javaOption("java.rmi.server.hostname", "localhost")
+                .javaOption("com.sun.management.jmxremote", "true")
+                .javaOption("com.sun.management.jmxremote.port", PORT)
+                .javaOption("com.sun.management.jmxremote.rmi.port", PORT)
+                .javaOption("com.sun.management.jmxremote.ssl", "false")
+                .javaOption("com.sun.management.jmxremote.authenticate", "false")
+                .javaOption("sun.rmi.transport.tcp.logLevel", "FINER")
+                .javaOption("jdk.crac.collect-fd-stacktraces", "true");
+        CracProcess checkpointed = builder.startCheckpoint();
+        checkpointed.waitForStdout(BOOTED);
+        assertEquals(-1L, getUptimeFromRestoreFromJmx());
+        checkpointed.sendNewline();
+        checkpointed.waitForCheckpointed();
+        CracProcess restored = builder.startRestore();
+        restored.waitForStdout(RESTORED);
+        assertGreaterThanOrEqual(getUptimeFromRestoreFromJmx(), 0L);
+        restored.sendNewline();
+        restored.waitForSuccess();
+    }
+
+    private long getUptimeFromRestoreFromJmx() throws IOException, MalformedObjectNameException {
+        JMXConnector conn = JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:" + PORT + "/jmxrmi"));
+        CRaCMXBean cracBean = JMX.newMBeanProxy(conn.getMBeanServerConnection(), new ObjectName("jdk.management:type=CRaC"), CRaCMXBean.class);
+        return cracBean.getUptimeSinceRestore();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        System.out.println(BOOTED);
+        assertEquals((int)'\n', System.in.read());
+        Core.checkpointRestore();
+        System.out.println(RESTORED);
+        assertEquals((int)'\n', System.in.read());
+    }
+}

--- a/test/lib/jdk/test/lib/crac/CracProcess.java
+++ b/test/lib/jdk/test/lib/crac/CracProcess.java
@@ -160,4 +160,8 @@ public class CracProcess {
         input.write('\n');
         input.flush();
     }
+
+    public void destroyForcibly() {
+        process.destroyForcibly();
+    }
 }

--- a/test/lib/jdk/test/lib/crac/CracProcess.java
+++ b/test/lib/jdk/test/lib/crac/CracProcess.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.*;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.List;
 import java.util.function.Consumer;
@@ -96,17 +97,21 @@ public class CracProcess {
     public CracProcess waitForSuccess() throws InterruptedException {
         int exitValue = process.waitFor();
         if (exitValue != 0 && builder.captureOutput) {
-            try {
-                OutputAnalyzer oa = outputAnalyzer();
-                System.err.print(oa.getStderr());
-                System.out.print(oa.getStdout());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            printOutput();
         }
         assertEquals(0, exitValue, "Process returned unexpected exit code: " + exitValue);
         builder.log("Process %d completed with exit value %d%n", process.pid(), exitValue);
         return this;
+    }
+
+    private void printOutput() {
+        try {
+            OutputAnalyzer oa = outputAnalyzer();
+            System.err.print(oa.getStderr());
+            System.out.print(oa.getStdout());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public OutputAnalyzer outputAnalyzer() throws IOException {
@@ -119,6 +124,18 @@ public class CracProcess {
         pump(process.getInputStream(), outputConsumer);
         pump(process.getErrorStream(), errorConsumer);
         return this;
+    }
+
+    public void waitForStdout(String str) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        watch(line -> {
+            if (line.equals(str)) {
+                latch.countDown();
+            } else {
+                throw new IllegalArgumentException("Unexpected input");
+            }
+        }, System.err::println);
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
 
     private static void pump(InputStream stream, Consumer<String> consumer) {
@@ -136,5 +153,11 @@ public class CracProcess {
 
     public OutputStream input() {
         return process.getOutputStream();
+    }
+
+    public void sendNewline() throws IOException {
+        OutputStream input = process.getOutputStream();
+        input.write('\n');
+        input.flush();
     }
 }

--- a/test/lib/jdk/test/lib/crac/CracProcess.java
+++ b/test/lib/jdk/test/lib/crac/CracProcess.java
@@ -155,6 +155,10 @@ public class CracProcess {
         return process.getOutputStream();
     }
 
+    public InputStream output() {
+        return process.getInputStream();
+    }
+
     public void sendNewline() throws IOException {
         OutputStream input = process.getOutputStream();
         input.write('\n');


### PR DESCRIPTION
Makes remote JMX support CRaC: both closing/reopening the related sockets on C/R and setting up remote JMX if it was not configured before checkpoint.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8347055](https://bugs.openjdk.org/browse/JDK-8347055): [CRaC] Remote JMX support (**Enhancement** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer) ⚠️ Review applies to [f56c5344](https://git.openjdk.org/crac/pull/171/files/f56c534477c49dedb9930ade0750dcd4b2352f67)


### Contributors
 * Roman Marchenko `<rmarchenko@openjdk.org>`
 * Timofei Pushkin `<tpushkin@openjdk.org>`
 * Radim Vansa `<rvansa@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/171/head:pull/171` \
`$ git checkout pull/171`

Update a local copy of the PR: \
`$ git checkout pull/171` \
`$ git pull https://git.openjdk.org/crac.git pull/171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 171`

View PR using the GUI difftool: \
`$ git pr show -t 171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/171.diff">https://git.openjdk.org/crac/pull/171.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/171#issuecomment-2573211814)
</details>
