### PR TITLE
8347056: [CRaC] Propagating CRaC events to JVMTI agents

### DIFF
--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -840,6 +840,14 @@ JvmtiEventControllerPrivate::set_extension_event_callback(JvmtiEnvBase *env,
     case EXT_EVENT_VIRTUAL_THREAD_UNMOUNT :
       ext_callbacks->VirtualThreadUnmount = callback;
       break;
+    case EXT_EVENT_CRAC_BEFORE_CHECKPOINT :
+      ext_callbacks->CracBeforeCheckpoint = callback;
+      env->env_event_enable()->set_user_enabled(event_type, enabling);
+      break;
+    case EXT_EVENT_CRAC_AFTER_RESTORE :
+      ext_callbacks->CracAfterRestore = callback;
+      env->env_event_enable()->set_user_enabled(event_type, enabling);
+      break;
     default:
       ShouldNotReachHere();
   }

--- a/src/hotspot/share/prims/jvmtiEventController.hpp
+++ b/src/hotspot/share/prims/jvmtiEventController.hpp
@@ -44,10 +44,12 @@ class JvmtiEnvBase;
 
 // Extension events start JVMTI_MIN_EVENT_TYPE_VAL-1 and work towards 0.
 typedef enum {
+  EXT_EVENT_CRAC_AFTER_RESTORE = JVMTI_MIN_EVENT_TYPE_VAL-5,
+  EXT_EVENT_CRAC_BEFORE_CHECKPOINT = JVMTI_MIN_EVENT_TYPE_VAL-4,
   EXT_EVENT_VIRTUAL_THREAD_UNMOUNT = JVMTI_MIN_EVENT_TYPE_VAL-3,
   EXT_EVENT_VIRTUAL_THREAD_MOUNT = JVMTI_MIN_EVENT_TYPE_VAL-2,
   EXT_EVENT_CLASS_UNLOAD = JVMTI_MIN_EVENT_TYPE_VAL-1,
-  EXT_MIN_EVENT_TYPE_VAL = EXT_EVENT_VIRTUAL_THREAD_UNMOUNT,
+  EXT_MIN_EVENT_TYPE_VAL = EXT_EVENT_CRAC_AFTER_RESTORE,
   EXT_MAX_EVENT_TYPE_VAL = EXT_EVENT_CLASS_UNLOAD
 } jvmtiExtEvent;
 
@@ -55,6 +57,8 @@ typedef struct {
   jvmtiExtensionEvent ClassUnload;
   jvmtiExtensionEvent VirtualThreadMount;
   jvmtiExtensionEvent VirtualThreadUnmount;
+  jvmtiExtensionEvent CracBeforeCheckpoint;
+  jvmtiExtensionEvent CracAfterRestore;
 } jvmtiExtEventCallbacks;
 
 

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -3211,3 +3211,39 @@ JvmtiGCMarker::~JvmtiGCMarker() {
     JvmtiExport::post_garbage_collection_finish();
   }
 }
+
+void JvmtiExport::post_crac_before_checkpoint() {
+  JavaThread *thread = JavaThread::current();
+  HandleMark hm(thread);
+  EVT_TRIG_TRACE(EXT_EVENT_CRAC_BEFORE_CHECKPOINT, ("Trg CRaC Before Checkpoint event triggered"));
+  JvmtiEnvIterator it;
+  for (JvmtiEnv* env = it.first(); env != nullptr; env = it.next(env)) {
+    if (env->is_enabled((jvmtiEvent)EXT_EVENT_CRAC_BEFORE_CHECKPOINT)) {
+      EVT_TRACE(EXT_EVENT_CRAC_BEFORE_CHECKPOINT, ("[?] Evt Before Checkpoint sent"));
+      JvmtiEventMark jem(thread);
+      JvmtiJavaThreadEventTransition jet(thread);
+      jvmtiExtensionEvent callback = env->ext_callbacks()->CracBeforeCheckpoint;
+      if (callback != nullptr) {
+        (*callback)(env->jvmti_external());
+      }
+    }
+  }
+}
+
+void JvmtiExport::post_crac_after_restore() {
+  JavaThread *thread = JavaThread::current();
+  HandleMark hm(thread);
+  EVT_TRIG_TRACE(EXT_EVENT_CRAC_AFTER_RESTORE, ("Trg CRaC After Restore event triggered"));
+  JvmtiEnvIterator it;
+  for (JvmtiEnv* env = it.first(); env != nullptr; env = it.next(env)) {
+    if (env->is_enabled((jvmtiEvent)EXT_EVENT_CRAC_AFTER_RESTORE)) {
+      EVT_TRACE(EXT_EVENT_CRAC_AFTER_RESTORE, ("[?] Evt After Restore sent"));
+      JvmtiEventMark jem(thread);
+      JvmtiJavaThreadEventTransition jet(thread);
+      jvmtiExtensionEvent callback = env->ext_callbacks()->CracAfterRestore;
+      if (callback != nullptr) {
+        (*callback)(env->jvmti_external());
+      }
+    }
+  }
+}

--- a/src/hotspot/share/prims/jvmtiExport.hpp
+++ b/src/hotspot/share/prims/jvmtiExport.hpp
@@ -360,6 +360,9 @@ class JvmtiExport : public AllStatic {
   static void post_vthread_mount         (jthread vthread) NOT_JVMTI_RETURN;
   static void post_vthread_unmount       (jthread vthread) NOT_JVMTI_RETURN;
 
+  static void post_crac_before_checkpoint() NOT_JVMTI_RETURN;
+  static void post_crac_after_restore() NOT_JVMTI_RETURN;
+
   static void continuation_yield_cleanup (JavaThread* thread, jint continuation_frame_count) NOT_JVMTI_RETURN;
 
   // Support for java.lang.instrument agent loading.

--- a/src/hotspot/share/prims/jvmtiExtensions.cpp
+++ b/src/hotspot/share/prims/jvmtiExtensions.cpp
@@ -239,6 +239,12 @@ void JvmtiExtensions::register_extensions() {
     { (char*)"JNI Environment", JVMTI_KIND_IN_PTR, JVMTI_TYPE_JNIENV, JNI_FALSE },
     { (char*)"Virtual Thread", JVMTI_KIND_IN, JVMTI_TYPE_JTHREAD, JNI_FALSE }
   };
+  static jvmtiParamInfo crac_before_checkpoint_params[] = {
+    { (char*)"JNI Environment", JVMTI_KIND_IN_PTR, JVMTI_TYPE_JNIENV, JNI_FALSE }
+  };
+  static jvmtiParamInfo crac_after_restore_params[] = {
+    { (char*)"JNI Environment", JVMTI_KIND_IN_PTR, JVMTI_TYPE_JNIENV, JNI_FALSE }
+  };
 
   static jvmtiExtensionEventInfo class_unload_ext_event = {
     EXT_EVENT_CLASS_UNLOAD,
@@ -261,10 +267,26 @@ void JvmtiExtensions::register_extensions() {
     sizeof(virtual_thread_event_params)/sizeof(virtual_thread_event_params[0]),
     virtual_thread_event_params
   };
+  static jvmtiExtensionEventInfo crac_before_checkpoint_ext_event = {
+    EXT_EVENT_CRAC_BEFORE_CHECKPOINT,
+    (char*)"jdk.crac.events.BeforeCheckpoint",
+    (char*)"CRAC_BEFORE_CHECKPOINT event",
+    sizeof(crac_before_checkpoint_params)/sizeof(crac_before_checkpoint_params[0]),
+    crac_before_checkpoint_params
+  };
+  static jvmtiExtensionEventInfo crac_after_restore_ext_event = {
+    EXT_EVENT_CRAC_AFTER_RESTORE,
+    (char*)"jdk.crac.events.AfterRestore",
+    (char*)"CRAC_AFTER_RESTORE event",
+    sizeof(crac_after_restore_params)/sizeof(crac_after_restore_params[0]),
+    crac_after_restore_params
+  };
 
   _ext_events->append(&class_unload_ext_event);
   _ext_events->append(&virtual_thread_mount_ext_event);
   _ext_events->append(&virtual_thread_unmount_ext_event);
+  _ext_events->append(&crac_before_checkpoint_ext_event);
+  _ext_events->append(&crac_after_restore_ext_event);
 }
 
 

--- a/src/hotspot/share/prims/jvmtiUtil.hpp
+++ b/src/hotspot/share/prims/jvmtiUtil.hpp
@@ -57,7 +57,7 @@ public:
       return _event_threaded[num];
     }
     if (num >= EXT_MIN_EVENT_TYPE_VAL && num <= EXT_MAX_EVENT_TYPE_VAL) {
-      return (num != EXT_EVENT_CLASS_UNLOAD);
+      return (num != EXT_EVENT_CLASS_UNLOAD && num != EXT_EVENT_CRAC_BEFORE_CHECKPOINT && num != EXT_EVENT_CRAC_AFTER_RESTORE);
     }
     ShouldNotReachHere();
     return false;

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -29,6 +29,7 @@
 #include "logging/logConfiguration.hpp"
 #include "memory/oopFactory.hpp"
 #include "oops/typeArrayOop.inline.hpp"
+#include "prims/jvmtiExport.hpp"
 #include "runtime/crac_structs.hpp"
 #include "runtime/crac.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
@@ -424,6 +425,10 @@ Handle crac::checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong
     return ret_cr(JVM_CHECKPOINT_NONE, Handle(), Handle(), Handle(), Handle(), THREAD);
   }
 
+#if INCLUDE_JVMTI
+  JvmtiExport::post_crac_before_checkpoint();
+#endif
+
   Universe::heap()->set_cleanup_unused(true);
   Universe::heap()->collect(GCCause::_full_gc_alot);
   Universe::heap()->set_cleanup_unused(false);
@@ -457,6 +462,10 @@ Handle crac::checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong
   if (aio_writer) {
     aio_writer->resume();
   }
+
+#if INCLUDE_JVMTI
+  JvmtiExport::post_crac_after_restore();
+#endif
 
   if (cr.ok()) {
     oop new_args = NULL;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetExtensionEvents/extevents001/extevents001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetExtensionEvents/extevents001/extevents001.cpp
@@ -39,6 +39,7 @@ extern "C" {
 #define PARAM_KIND_MAX_VALUE  97
 
 #define NAME_PREFIX "com.sun.hotspot"
+#define CRAC_PREFIX "jdk.crac"
 
 /* ============================================================================= */
 
@@ -123,7 +124,7 @@ static int checkExtensions(jvmtiEnv* jvmti, const char phase[]) {
                                 nsk_null_string(extList[i].short_description),
                                 (int)extList[i].param_count);
                 success = NSK_FALSE;
-            } else if (strstr(extList[i].id, NAME_PREFIX) == nullptr) {
+            } else if (strstr(extList[i].id, NAME_PREFIX) == nullptr && strstr(extList[i].id, CRAC_PREFIX) == nullptr) {
                 NSK_COMPLAIN6("In %s phase GetExtensionEvents() returned event #%d with unexpected id:\n"
                               "#   event_index: %d\n"
                               "#   id:          \"%s\"\n"

--- a/test/jdk/jdk/crac/jvmtiEvents/JvmtiEventTest.java
+++ b/test/jdk/jdk/crac/jvmtiEvents/JvmtiEventTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+
+import jdk.crac.Core;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracEngine;
+import jdk.test.lib.crac.CracProcess;
+import jdk.test.lib.crac.CracTest;
+
+ /*
+ * @test
+ * @library /test/lib
+ * @build JvmtiEventTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+
+public class JvmtiEventTest implements CracTest {
+
+    private static final String JAVA_LIBRARY_PATH = System.getProperty("java.library.path") + File.separator;
+    private static final String AGENT_CALLBACK_BEFORE_CHECKPOINT = "callbackBeforeCheckpoint";
+    private static final String AGENT_CALLBACK_AFTER_RESTORE = "callbackAfterRestore";
+
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder().engine(CracEngine.SIMULATE);
+        builder.vmOption("-agentpath:" + JAVA_LIBRARY_PATH + System.mapLibraryName("CracJvmtiAgent"));
+
+        CracProcess process = builder.captureOutput(true).startCheckpoint();
+        process.waitForSuccess();
+        process.outputAnalyzer()
+                .shouldContain(AGENT_CALLBACK_BEFORE_CHECKPOINT)
+                .shouldContain(AGENT_CALLBACK_AFTER_RESTORE)
+                .shouldContain(RESTORED_MESSAGE);
+    }
+
+    @Override
+    public void exec() throws Exception {
+        System.out.println("Started");
+        Core.checkpointRestore();
+        System.out.println(RESTORED_MESSAGE);
+    }
+}

--- a/test/jdk/jdk/crac/jvmtiEvents/libCracJvmtiAgent.c
+++ b/test/jdk/jdk/crac/jvmtiEvents/libCracJvmtiAgent.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <jvmti.h>
+
+#include <string.h>
+
+void JNICALL callbackBeforeCheckpoint(jvmtiEnv* jvmti_env, ...) {
+    printf("%s:%d : %s\n", __FILE__, __LINE__, __FUNCTION__);
+    fflush(NULL);
+}
+
+void JNICALL callbackAfterRestore(jvmtiEnv* jvmti_env, ...) {
+    printf("%s:%d : %s\n", __FILE__, __LINE__, __FUNCTION__);
+    fflush(NULL);
+}
+
+JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) {
+    printf("%s:%d : %s : JVMTI agent loading...\n", __FILE__, __LINE__, __FUNCTION__);
+
+    jvmtiEnv* jvmti = NULL;
+    jint extensionEventCount = 0;
+    jvmtiExtensionEventInfo* extensionEvents = NULL;
+    (*jvm)->GetEnv(jvm, (void**)&jvmti, JVMTI_VERSION_1_0);
+    (*jvmti)->GetExtensionEvents(jvmti, &extensionEventCount, &extensionEvents);
+
+    for (int i = 0; i < extensionEventCount; ++i) {
+        if (0 == strcmp("jdk.crac.events.BeforeCheckpoint", extensionEvents[i].id)) {
+            (*jvmti)->SetExtensionEventCallback(jvmti, extensionEvents[i].extension_event_index, &callbackBeforeCheckpoint);
+        }
+        if (0 == strcmp("jdk.crac.events.AfterRestore", extensionEvents[i].id)) {
+            (*jvmti)->SetExtensionEventCallback(jvmti, extensionEvents[i].extension_event_index, &callbackAfterRestore);
+        }
+    }
+
+    return JNI_OK;
+}
+
+JNIEXPORT void JNICALL Agent_OnUnload(JavaVM* jvm) {
+    printf("%s:%d : %s : JVMTI agent unloading...\n", __FILE__, __LINE__, __FUNCTION__);
+}


### PR DESCRIPTION
Adds JVM TI extension events corresponding to CRaC's beforeCheckpoint/afterRestore events.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8347056](https://bugs.openjdk.org/browse/JDK-8347056): [CRaC] Propagating CRaC events to JVMTI agents (**Enhancement** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/172/head:pull/172` \
`$ git checkout pull/172`

Update a local copy of the PR: \
`$ git checkout pull/172` \
`$ git pull https://git.openjdk.org/crac.git pull/172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 172`

View PR using the GUI difftool: \
`$ git pr show -t 172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/172.diff">https://git.openjdk.org/crac/pull/172.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/172#issuecomment-2573243941)
</details>
