### PR TITLE
8347060: [CRaC] Some tests cannot run in parallel

### DIFF
--- a/test/jdk/jdk/crac/DaemonAfterRestore.java
+++ b/test/jdk/jdk/crac/DaemonAfterRestore.java
@@ -61,7 +61,7 @@ public class DaemonAfterRestore implements CracTest {
                 firstOutputFuture.cancel(false);
             });
         firstOutputFuture.get(10, TimeUnit.SECONDS);
-        builder.checkpointViaJcmd();
+        builder.checkpointViaJcmd(checkpointProcess.pid());
         checkpointProcess.waitForCheckpointed();
 
         builder.startRestore().waitForSuccess()

--- a/test/jdk/jdk/crac/java/lang/System/TimedWaitingTest.java
+++ b/test/jdk/jdk/crac/java/lang/System/TimedWaitingTest.java
@@ -64,7 +64,7 @@ public class TimedWaitingTest implements CracTest {
         String imageName = Common.imageName("timed-waiting");
 
         CracBuilder builder = new CracBuilder();
-        Path bootIdFile = Files.createTempFile("NanoTimeTest-", "-boot_id");
+        Path bootIdFile = Files.createTempFile("TimedWaitingTest-", "-boot_id");
         try {
             builder.withBaseImage("ghcr.io/crac/test-base", "latest")
                     .dockerOptions("-v", bootIdFile + ":/fake_boot_id")

--- a/test/lib/jdk/test/lib/crac/CracBuilder.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilder.java
@@ -7,7 +7,6 @@ import jdk.test.lib.containers.docker.DockerfileConfig;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.util.FileUtils;
 
-import javax.imageio.IIOException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;


### PR DESCRIPTION
Fixes some CRaC tests so that they can be run concurrently. This should somewhat stabilize those tests in GitHub Actions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8347060](https://bugs.openjdk.org/browse/JDK-8347060): [CRaC] Some tests cannot run in parallel (**Enhancement** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.org/crac.git pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/173.diff">https://git.openjdk.org/crac/pull/173.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/173#issuecomment-2574508512)
</details>
