### PR TITLE
8347257: [CRaC] Checkpoint call may sometimes hang

### DIFF
--- a/src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java
+++ b/src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java
@@ -134,26 +134,6 @@ public abstract class PhantomCleanable<T> extends PhantomReference<T>
         }
     }
 
-    PhantomCleanable<?> cleanIfNull() {
-        if (this == list) {
-            // The reference representing the list itself does not have
-            // a referent, we will skip it.
-            return next;
-        }
-        PhantomCleanable<?> oldNext = next;
-        if (refersTo(null)) {
-            try {
-                clean();
-            } catch (Throwable t) {
-                // This method is called only from CleanerImpl and that one
-                // ignores any exceptions thrown; we will do the same here.
-                // The exception cannot be caught (and ignored) by the caller
-                // since we want to continue traversing the list.
-            }
-        }
-        return oldNext;
-    }
-
     /**
      * Unregister this PhantomCleanable and clear the reference.
      * Due to inherent concurrency, {@link #performCleanup()} may still be invoked.

--- a/test/jdk/jdk/crac/LinkedCleanableRefTest.java
+++ b/test/jdk/jdk/crac/LinkedCleanableRefTest.java
@@ -38,10 +38,10 @@ import java.lang.reflect.Field;
 
 /**
  * @test
- * @modules java.base/jdk.internal.ref 
+ * @modules java.base/jdk.internal.ref
  * @library /test/lib
  * @build LinkedCleanableRefTest
- * @run driver jdk.test.lib.crac.CracTest 
+ * @run driver jdk.test.lib.crac.CracTest
  */
 public class LinkedCleanableRefTest implements CracTest {
     static private String RESTORED = "RESTORED";

--- a/test/jdk/jdk/crac/LinkedCleanableRefTest.java
+++ b/test/jdk/jdk/crac/LinkedCleanableRefTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.*;
+import jdk.crac.management.*;
+import jdk.internal.ref.CleanerFactory;
+import jdk.internal.ref.CleanerImpl;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracEngine;
+import jdk.test.lib.crac.CracProcess;
+import jdk.test.lib.crac.CracTest;
+
+import static jdk.test.lib.Asserts.*;
+
+import java.lang.reflect.Field;
+
+/**
+ * @test
+ * @modules java.base/jdk.internal.ref 
+ * @library /test/lib
+ * @build LinkedCleanableRefTest
+ * @run driver jdk.test.lib.crac.CracTest 
+ */
+public class LinkedCleanableRefTest implements CracTest {
+    static private String RESTORED = "RESTORED";
+    static private String CLEAN = "CLEAN=";
+
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder().engine(CracEngine.SIMULATE).captureOutput(true);
+        builder.vmOption("--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED");
+        builder.vmOption("--add-opens=java.base/java.lang.ref=ALL-UNNAMED");
+        CracProcess process = builder.startCheckpoint();
+        try {
+            process.waitForSuccess();
+            process.outputAnalyzer()
+                    .shouldContain(RESTORED)
+                    .shouldContain(CLEAN + "true");
+        } finally {
+            process.destroyForcibly();
+        }
+    }
+
+    private static class Closer implements Runnable {
+        private CleanerImpl.PhantomCleanableRef anotherRef;
+        static private boolean cleanningInProgress = false;
+
+        Closer(CleanerImpl.PhantomCleanableRef anotherRef) {
+            this.anotherRef = anotherRef;
+        }
+
+        public void run() {
+            if (null != anotherRef) {
+                cleanningInProgress = true;
+                anotherRef.clean();
+                cleanningInProgress = false;
+            } else {
+                System.out.println(CLEAN + cleanningInProgress);
+            }
+        }
+    }
+
+    void setReferentToNull(CleanerImpl.PhantomCleanableRef ref) throws Exception {
+        // Access to field: java.lang.ref.Reference.referent
+        Field f = ref.getClass().getSuperclass().getSuperclass().getSuperclass().getDeclaredField("referent");
+        f.setAccessible(true);
+        f.set(ref, null);
+    }
+
+    @Override
+    public void exec() throws Exception {
+        var obj = new Object();
+        var cleaner = CleanerFactory.cleaner();
+        var ref = (CleanerImpl.PhantomCleanableRef) cleaner.register(obj, new Closer(null));
+        var ref2 = (CleanerImpl.PhantomCleanableRef) cleaner.register(obj, new Closer(ref));
+
+        setReferentToNull(ref);
+        setReferentToNull(ref2);
+        obj = null;
+
+        Core.checkpointRestore();
+        System.out.println("RESTORED");
+    }
+}


### PR DESCRIPTION
When checkpointing, "Common-Cleaner" thread sometimes runs into an infinite loop. This change fixes the infinite loop.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8347257](https://bugs.openjdk.org/browse/JDK-8347257): [CRaC] Checkpoint call may sometimes hang (**Bug** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/175/head:pull/175` \
`$ git checkout pull/175`

Update a local copy of the PR: \
`$ git checkout pull/175` \
`$ git pull https://git.openjdk.org/crac.git pull/175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 175`

View PR using the GUI difftool: \
`$ git pr show -t 175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/175.diff">https://git.openjdk.org/crac/pull/175.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/175#issuecomment-2577450056)
</details>
