### PR TITLE
8347290: [CRaC] JVM log prevents checkpoint

### DIFF
--- a/src/hotspot/os/linux/crac_linux.cpp
+++ b/src/hotspot/os/linux/crac_linux.cpp
@@ -33,6 +33,7 @@
 #include "logging/log.hpp"
 #include "logging/logConfiguration.hpp"
 #include "classfile/classLoader.hpp"
+#include "utilities/defaultStream.hpp"
 
 #include <netinet/in.h>
 
@@ -420,6 +421,10 @@ static bool is_fd_ignored(int fd, const char *path) {
   }
 
   if (LogConfiguration::is_fd_used(fd)) {
+    return true;
+  }
+
+  if (defaultStream::instance->is_fd_used(fd)) {
     return true;
   }
 

--- a/src/hotspot/share/compiler/compileLog.hpp
+++ b/src/hotspot/share/compiler/compileLog.hpp
@@ -82,6 +82,10 @@ class CompileLog : public xmlStream {
   void inline_fail   (const char* reason);
   void inline_success(const char* reason);
 
+  //CRaC purposes
+  void after_restore();
+  void before_checkpoint();
+
   // virtuals
   virtual void see_tag(const char* tag, bool push);
   virtual void pop_tag(const char* tag);
@@ -95,6 +99,8 @@ class CompileLog : public xmlStream {
   // copy all logs to the given stream
   static void finish_log(outputStream* out);
   static void finish_log_on_error(outputStream* out, char *buf, int buflen);
+  static void finish_log_on_checkpoint(outputStream* out);
+  static void swap_streams_on_restore();
 };
 
 #endif // SHARE_COMPILER_COMPILELOG_HPP

--- a/src/hotspot/share/logging/logFileOutput.cpp
+++ b/src/hotspot/share/logging/logFileOutput.cpp
@@ -489,6 +489,10 @@ void LogFileOutput::reopen() {
   assert(_stream == nullptr, "reopening an already opened log file");
 
   // Open the active log file using the same stream as before
+  jlong the_time = os::javaTimeMillis();
+  LogFileOutput::set_file_name_parameters(the_time);
+  FREE_C_HEAP_ARRAY(char, _file_name);
+  _file_name = make_file_name(_name + strlen(Prefix), _pid_str, _vm_start_time_str);
   _stream = os::fopen(_file_name, FileOpenMode);
   if (_stream == nullptr) {
     jio_fprintf(defaultStream::error_stream(), "Could not reopen log file '%s' (%s).\n",

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4017,3 +4017,10 @@ bool Arguments::copy_expand_pid(const char* src, size_t srclen,
   *b = '\0';
   return (p == src_end); // return false if not all of the source was copied
 }
+
+void Arguments::reset_for_crac_restore() {
+  if (!FLAG_IS_DEFAULT(LogVMOutput)){
+    FLAG_SET_DEFAULT(LogVMOutput, false);
+    FLAG_SET_DEFAULT(LogFile, nullptr);
+  }
+}

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -451,6 +451,8 @@ class Arguments : AllStatic {
     _vm_info->set_value(vm_info);
   }
 
+  // Reset LogVMoutput to default values
+  static void reset_for_crac_restore();
   // Property List manipulation
   static void PropertyList_add(SystemProperty *element);
   static void PropertyList_add(SystemProperty** plist, SystemProperty *element);

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1015,10 +1015,10 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, DisplayVMOutput, true, DIAGNOSTIC,                          \
           "Display all VM output on the tty, independently of LogVMOutput") \
                                                                             \
-  product(bool, LogVMOutput, false, DIAGNOSTIC,                             \
+  product(bool, LogVMOutput, false, DIAGNOSTIC | RESTORE_SETTABLE,          \
           "Save VM output to LogFile")                                      \
                                                                             \
-  product(ccstr, LogFile, nullptr, DIAGNOSTIC,                              \
+  product(ccstr, LogFile, nullptr, DIAGNOSTIC | RESTORE_SETTABLE,           \
           "If LogVMOutput or LogCompilation is on, save VM output to "      \
           "this file [default: ./hotspot_pid%p.log] (%p replaced with pid)")\
                                                                             \

--- a/src/hotspot/share/utilities/defaultStream.hpp
+++ b/src/hotspot/share/utilities/defaultStream.hpp
@@ -26,6 +26,7 @@
 #define SHARE_UTILITIES_DEFAULTSTREAM_HPP
 
 #include "utilities/xmlstream.hpp"
+#include "compiler/compileLog.hpp"
 
 class defaultStream : public xmlTextStream {
   friend void ostream_abort();
@@ -43,7 +44,7 @@ class defaultStream : public xmlTextStream {
   void init_log();
   fileStream* open_file(const char* log_name);
   void start_log();
-  void finish_log();
+  void finish_log(bool is_checkpoint = false);
   void finish_log_on_error(char *buf, int buflen);
  public:
   // must defer time stamp due to the fact that os::init() hasn't
@@ -95,11 +96,12 @@ class defaultStream : public xmlTextStream {
         xtty->end_elem();
         xtty = nullptr;
       }
-      finish_log();
+      finish_log(true);
     }
   }
   void after_restore() {
     init();
+    CompileLog::swap_streams_on_restore();
   }
 
   // advisory lock/unlock of _writer field:

--- a/src/hotspot/share/utilities/defaultStream.hpp
+++ b/src/hotspot/share/utilities/defaultStream.hpp
@@ -83,6 +83,25 @@ class defaultStream : public xmlTextStream {
     if (has_log_file()) _log_file->flush();
   }
 
+  bool is_fd_used(int fd) {
+    return has_log_file() ? fd == _log_file->get_fd() : false;
+  }
+  void before_checkpoint() {
+    if (has_log_file()){
+      if (xtty != nullptr) {
+        ttyLocker ttyl;
+        xtty->begin_elem("crac_checkpoint_vm");
+        xtty->stamp();
+        xtty->end_elem();
+        xtty = nullptr;
+      }
+      finish_log();
+    }
+  }
+  void after_restore() {
+    init();
+  }
+
   // advisory lock/unlock of _writer field:
  private:
   intx _writer;    // thread_id with current rights to output

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -794,12 +794,16 @@ void defaultStream::start_log() {
 // finish_log() is called during normal VM shutdown. finish_log_on_error() is
 // called by ostream_abort() after a fatal error.
 //
-void defaultStream::finish_log() {
+void defaultStream::finish_log(bool is_checkpoint) {
   xmlStream* xs = _outer_xmlStream;
   xs->done("tty");
 
+  if (is_checkpoint) {
+    CompileLog::finish_log_on_checkpoint(xs->out());
+  } else {
   // Other log forks are appended here, at the End of Time:
-  CompileLog::finish_log(xs->out());  // write compile logging, if any, now
+    CompileLog::finish_log(xs->out());  // write compile logging, if any, now
+  }
 
   xs->done("hotspot_log");
   xs->flush();

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -299,6 +299,7 @@ class fileStream : public outputStream {
   }
   long fileSize();
   void flush();
+  int get_fd() { return fileno(_file); }
 };
 
 // unlike fileStream, fdStream does unbuffered I/O by calling

--- a/test/jdk/jdk/crac/fileDescriptors/LoggingCompilationSimulTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/LoggingCompilationSimulTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.internal.crac.JDKFdResource;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracEngine;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static jdk.test.lib.Asserts.*;
+
+/**
+ * @test Check the -XX:+LogVMOutput together with -XX:+LogCompilation flag on simulated crac engine
+ * @library /test/lib
+ * @modules java.base/jdk.internal.crac:+open
+ * @build LoggingVMlogOpenSimulTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class LoggingVMlogOpenSimulTest implements CracTest {
+    @Override
+    public void test() throws Exception {
+        Path logPathO = Files.createTempFile(getClass().getName(), "-vmlog1.txt");
+        try {
+            CracBuilder builder = new CracBuilder().captureOutput(true);
+            builder.engine(CracEngine.SIMULATE);
+            builder.vmOption("-Xcomp");
+            builder.vmOption("-XX:+UnlockDiagnosticVMOptions");
+            builder.vmOption("-XX:+LogVMOutput");
+            builder.vmOption("-XX:+LogCompilation");
+            builder.vmOption("-XX:LogFile=" + logPathO);
+            var oa = builder.startCheckpoint().waitForSuccess().outputAnalyzer();
+            oa.shouldContain(RESTORED_MESSAGE);
+            assertNotEquals(0, Files.size(logPathO));
+        } finally {
+            Files.deleteIfExists(logPathO);
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Core.checkpointRestore();
+        System.out.println(RESTORED_MESSAGE);
+    }
+}

--- a/test/jdk/jdk/crac/fileDescriptors/LoggingCompilationTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/LoggingCompilationTest.java
@@ -34,7 +34,7 @@ import jdk.test.lib.crac.CracTest;
 import jdk.test.lib.crac.CracTestArg;
 
 /**
- * @test Checkpoint with -XX:+LogVMOutput and -XX:+LogCompilation 
+ * @test Checkpoint with -XX:+LogVMOutput and -XX:+LogCompilation
  * @library /test/lib
  * @modules java.base/jdk.internal.crac:+open
  * @requires (os.family == "linux")

--- a/test/jdk/jdk/crac/fileDescriptors/LoggingCompilationTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/LoggingCompilationTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import jdk.crac.Core;
+import static jdk.test.lib.Asserts.assertEquals;
+import static jdk.test.lib.Asserts.assertFalse;
+import static jdk.test.lib.Asserts.assertNotEquals;
+import static jdk.test.lib.Asserts.assertTrue;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+
+/**
+ * @test Checkpoint with -XX:+LogVMOutput and -XX:+LogCompilation 
+ * @library /test/lib
+ * @modules java.base/jdk.internal.crac:+open
+ * @requires (os.family == "linux")
+ * @build LoggingCompilationTest
+ * @run driver jdk.test.lib.crac.CracTest true  false
+ * @run driver jdk.test.lib.crac.CracTest false true
+ * @run driver jdk.test.lib.crac.CracTest true  true
+ */
+public class LoggingCompilationTest implements CracTest {
+
+    @CracTestArg(0)
+    boolean vmLogOnCheckpoint;
+
+    @CracTestArg(1)
+    boolean vmLogOnRestore;
+
+    @Override
+    public void test() throws Exception {
+        Path logPathO = Files.createTempFile(getClass().getName(), "-vmlog1.txt");
+        Path logPathR = Files.createTempFile(getClass().getName(), "-vmlog2.txt");
+        Files.deleteIfExists(logPathR);
+        try {
+            CracBuilder builder = new CracBuilder();
+            if (vmLogOnCheckpoint) {
+                builder.vmOption("-XX:+UnlockDiagnosticVMOptions");
+                builder.vmOption("-XX:+LogVMOutput");
+                builder.vmOption("-Xcomp");
+                builder.vmOption("-XX:+LogCompilation");
+                builder.vmOption("-XX:LogFile=" + logPathO);
+            }
+            builder.startCheckpoint().waitForCheckpointed();
+            if (vmLogOnCheckpoint) {
+                assertNotEquals(0L, Files.size(logPathO));
+                Files.deleteIfExists(logPathO);
+            } else {
+                assertEquals(0L, Files.size(logPathO));
+            }
+            builder.clearVmOptions();
+            if (vmLogOnRestore) {
+                builder.vmOption("-XX:+UnlockDiagnosticVMOptions");
+                builder.vmOption("-Xcomp");
+                builder.vmOption("-XX:+LogVMOutput");
+                builder.vmOption("-XX:LogFile=" + logPathR);
+            }
+            var oa =builder.captureOutput(true).doRestore().outputAnalyzer()
+                    .shouldNotContain("CRaC closing file descriptor")
+                    .shouldNotContain("Could not flush log")
+                    .shouldNotContain("Could not close log file")
+                    .shouldNotContain("Bad file descriptor")
+                    .shouldContain(RESTORED_MESSAGE);
+        } finally {
+            if (vmLogOnRestore) {
+                assertTrue(Files.exists(logPathR));
+            } else {
+                assertFalse(Files.exists(logPathO));
+                assertFalse(Files.exists(logPathR));
+            }
+            Files.deleteIfExists(logPathO);
+            Files.deleteIfExists(logPathR);
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Core.checkpointRestore();
+        System.out.println(RESTORED_MESSAGE);
+    }
+}

--- a/test/jdk/jdk/crac/fileDescriptors/LoggingVMlogOpenSimulTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/LoggingVMlogOpenSimulTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.internal.crac.JDKFdResource;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracEngine;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static jdk.test.lib.Asserts.*;
+
+/**
+ * @test Check the -XX:+LogVMOutput flag on simulated crac engine
+ * @library /test/lib
+ * @modules java.base/jdk.internal.crac:+open
+ * @build LoggingVMlogOpenSimulTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class LoggingVMlogOpenSimulTest implements CracTest {
+    @Override
+    public void test() throws Exception {
+        Path logPathO = Files.createTempFile(getClass().getName(), "-vmlog1.txt");
+        try {
+            CracBuilder builder = new CracBuilder().captureOutput(true);
+            builder.engine(CracEngine.SIMULATE);
+            builder.vmOption("-XX:+UnlockDiagnosticVMOptions");
+            builder.vmOption("-XX:+LogVMOutput");
+            builder.vmOption("-XX:LogFile=" + logPathO);
+            var oa = builder.startCheckpoint().waitForSuccess().outputAnalyzer();
+            oa.shouldContain(RESTORED_MESSAGE);
+            assertNotEquals(0, Files.size(logPathO));
+        } finally {
+            Files.deleteIfExists(logPathO);
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Core.checkpointRestore();
+        System.out.println(RESTORED_MESSAGE);
+    }
+}

--- a/test/jdk/jdk/crac/fileDescriptors/LoggingVMlogOpenTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/LoggingVMlogOpenTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.internal.crac.JDKFdResource;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static jdk.test.lib.Asserts.*;
+
+/**
+ * @test
+ * @library /test/lib
+ * @modules java.base/jdk.internal.crac:+open
+ * @requires (os.family == "linux")
+ * @build LoggingVMlogOpenTest
+ * @run driver jdk.test.lib.crac.CracTest true  false
+ * @run driver jdk.test.lib.crac.CracTest false true
+ * @run driver jdk.test.lib.crac.CracTest true  true
+ */
+public class LoggingVMlogOpenTest implements CracTest {
+
+    @CracTestArg(0)
+    boolean vmLogOnCheckpoint;
+
+    @CracTestArg(1)
+    boolean vmLogOnRestore;
+
+    @Override
+    public void test() throws Exception {
+        Path logPathO = Files.createTempFile(getClass().getName(), "-vmlog1.txt");
+        Path logPathR = Files.createTempFile(getClass().getName(), "-vmlog2.txt");
+        Files.deleteIfExists(logPathR);
+        try {
+            CracBuilder builder = new CracBuilder();
+            if (vmLogOnCheckpoint) {
+                builder.vmOption("-XX:+UnlockDiagnosticVMOptions");
+                builder.vmOption("-XX:+LogVMOutput");
+                builder.vmOption("-XX:LogFile=" + logPathO);
+            }
+            builder.startCheckpoint().waitForCheckpointed();
+            if (vmLogOnCheckpoint) {
+                assertNotEquals(0L, Files.size(logPathO));
+                Files.deleteIfExists(logPathO);
+            } else {
+                assertEquals(0L, Files.size(logPathO));
+            }
+            builder.clearVmOptions();
+            if (vmLogOnRestore) {
+                builder.vmOption("-XX:+UnlockDiagnosticVMOptions");
+                builder.vmOption("-XX:+LogVMOutput");
+                builder.vmOption("-XX:LogFile=" + logPathR);
+            }
+            var oa =builder.captureOutput(true).doRestore().outputAnalyzer()
+                    .shouldNotContain("CRaC closing file descriptor")
+                    .shouldNotContain("Could not flush log")
+                    .shouldNotContain("Could not close log file")
+                    .shouldNotContain("Bad file descriptor")
+                    .shouldContain(RESTORED_MESSAGE);
+        } finally {
+            if (vmLogOnRestore) {
+                assertTrue(Files.exists(logPathR));
+            } else {
+                assertFalse(Files.exists(logPathO));
+                assertFalse(Files.exists(logPathR));
+            }
+            Files.deleteIfExists(logPathO);
+            Files.deleteIfExists(logPathR);
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Core.checkpointRestore();
+        System.out.println(RESTORED_MESSAGE);
+    }
+}

--- a/test/jdk/jdk/crac/fileDescriptors/LoggingVMlogOpenTestNegative.java
+++ b/test/jdk/jdk/crac/fileDescriptors/LoggingVMlogOpenTestNegative.java
@@ -59,7 +59,7 @@ public class LoggingVMlogOpenTestNegative implements CracTest {
             builder.vmOption("-XX:+LogVMOutput");
             builder.vmOption("-XX:LogFile=" + logPathO);
             builder.startCheckpoint().waitForCheckpointed();
-           
+
             assertNotEquals(0L, Files.size(logPathO));
             Files.deleteIfExists(logPathO);
 

--- a/test/jdk/jdk/crac/fileDescriptors/LoggingVMlogOpenTestNegative.java
+++ b/test/jdk/jdk/crac/fileDescriptors/LoggingVMlogOpenTestNegative.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.internal.crac.JDKFdResource;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+import jdk.test.lib.process.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static jdk.test.lib.Asserts.*;
+
+/**
+ * @test
+ * @library /test/lib
+ * @modules java.base/jdk.internal.crac:+open
+ * @requires (os.family == "linux")
+ * @build LoggingVMlogOpenTestNegative
+ * @run driver jdk.test.lib.crac.CracTest true
+ * @run driver jdk.test.lib.crac.CracTest false
+ */
+public class LoggingVMlogOpenTestNegative implements CracTest {
+
+    @CracTestArg(0)
+    boolean scenario1;
+
+    @Override
+    public void test() throws Exception {
+        Path logPathO = Files.createTempFile(getClass().getName(), "-vmlog1.txt");
+        Path logPathR = Files.createTempFile(getClass().getName(), "-vmlog2.txt");
+        Files.deleteIfExists(logPathR);
+        try {
+            CracBuilder builder = new CracBuilder();
+            builder.vmOption("-XX:+UnlockDiagnosticVMOptions");
+            builder.vmOption("-XX:+LogVMOutput");
+            builder.vmOption("-XX:LogFile=" + logPathO);
+            builder.startCheckpoint().waitForCheckpointed();
+           
+            assertNotEquals(0L, Files.size(logPathO));
+            Files.deleteIfExists(logPathO);
+
+            builder.clearVmOptions();
+            if (scenario1) {
+                builder.vmOption("-XX:+UnlockDiagnosticVMOptions");
+                builder.vmOption("-XX:LogFile=" + logPathR);
+                builder.doRestore();
+            } else {
+                builder.vmOption("-XX:+UnlockDiagnosticVMOptions");
+                builder.vmOption("-XX:+LogCompilation");
+                builder.vmOption("-XX:LogFile=" + logPathR);
+                OutputAnalyzer oa = builder.captureOutput(true).startRestore().outputAnalyzer().shouldContain("cannot be set during restore").shouldNotHaveExitValue(0);
+            }
+        } finally {
+            assertFalse(Files.exists(logPathO));
+            assertFalse(Files.exists(logPathR));
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Core.checkpointRestore();
+        System.out.println(RESTORED_MESSAGE);
+    }
+}


### PR DESCRIPTION
Makes it possible to checkpoint a JVM that performs JVM-level logging

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8347290](https://bugs.openjdk.org/browse/JDK-8347290): [CRaC] JVM log prevents checkpoint (**Bug** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/176/head:pull/176` \
`$ git checkout pull/176`

Update a local copy of the PR: \
`$ git checkout pull/176` \
`$ git pull https://git.openjdk.org/crac.git pull/176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 176`

View PR using the GUI difftool: \
`$ git pr show -t 176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/176.diff">https://git.openjdk.org/crac/pull/176.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/176#issuecomment-2578383080)
</details>
