### PR TITLE
8347350: [CRaC] Support JRT FS FD

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jimage/BasicImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/BasicImageReader.java
@@ -147,7 +147,7 @@ public class BasicImageReader implements AutoCloseable {
         if (memoryMap.capacity() < indexSize) {
             throw new IOException("The image file \"" + name + "\" is corrupted");
         }
-        
+
         initMappedBuffers();
 
         stringsReader = new ImageStringsReader(this);

--- a/test/jdk/jdk/crac/fileDescriptors/BasicImageReaderTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/BasicImageReaderTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import jdk.crac.Core;
+
+import static jdk.test.lib.Asserts.assertTrue;
+
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracEngine;
+import jdk.test.lib.crac.CracProcess;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+
+import jdk.internal.jimage.BasicImageReader;
+import jdk.internal.jimage.ImageLocation;
+
+/**
+ * @test
+ * @summary Tests checkpoint/restore for BasicImageReader with an open descriptor.
+ * @library /test/lib
+ * @modules java.base/jdk.internal.jimage
+ * @build BasicImageReaderTest
+ * @run driver jdk.test.lib.crac.CracTest true true
+ * @run driver jdk.test.lib.crac.CracTest true false
+ * @run driver jdk.test.lib.crac.CracTest false true
+ * @run driver jdk.test.lib.crac.CracTest false false
+ */
+public class BasicImageReaderTest implements CracTest {
+    @CracTestArg(0)
+    boolean useJvmMap;
+
+    @CracTestArg(1)
+    boolean imageMapAll;
+
+    @Override
+    public void test() throws Exception {
+        CracProcess cp = new CracBuilder().engine(CracEngine.SIMULATE).captureOutput(true)
+            .vmOption("--add-opens=java.base/jdk.internal.jimage=ALL-UNNAMED")
+            .startCheckpoint();
+        cp.outputAnalyzer()
+            .shouldHaveExitValue(0);
+    }
+
+    @Override
+    public void exec() throws Exception {
+        System.setProperty("jdk.image.use.jvm.map", String.valueOf(useJvmMap));
+        System.setProperty("jdk.image.map.all", String.valueOf(imageMapAll));
+
+        Path imageFile = Paths.get(System.getProperty("java.home"), "lib", "modules");
+        BasicImageReader reader = BasicImageReader.open(imageFile);
+
+        readClass(reader, "java.base", "java/lang/String.class");
+        readClass(reader, "java.logging", "java/util/logging/Logger.class");
+
+        Core.checkpointRestore();
+        System.out.println("RESTORED");
+
+        readClass(reader, "java.base", "java/lang/String.class");
+        readClass(reader, "java.logging", "java/util/logging/Logger.class");
+    }
+
+    private void readClass(BasicImageReader reader, String moduleName, String className) throws Exception {
+        final int classMagic = 0xCAFEBABE;
+
+        System.out.printf("reading: module: %s, path: %s%n", moduleName, className);
+        ImageLocation location = reader.findLocation(moduleName, className);
+        assertTrue(location != null);
+
+        long size = location.getUncompressedSize();
+        assertTrue(size > 0);
+
+        ByteBuffer buffer = reader.getResourceBuffer(location);
+        assertTrue(buffer != null);
+
+        final int magic = buffer.getInt();
+        assertTrue(magic == classMagic);
+    }
+}

--- a/test/jdk/jdk/crac/fileDescriptors/JrtFsTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/JrtFsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import jdk.crac.Core;
+
+import static jdk.test.lib.Asserts.assertTrue;
+
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracEngine;
+import jdk.test.lib.crac.CracProcess;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+
+/**
+ * @test
+ * @summary Tests creating JRT FS and checkpoint'ing with an open file descriptor.
+ * @library /test/lib
+ * @build JrtFsTest
+ * @run driver jdk.test.lib.crac.CracTest true true
+ * @run driver jdk.test.lib.crac.CracTest true false
+ * @run driver jdk.test.lib.crac.CracTest false true
+ * @run driver jdk.test.lib.crac.CracTest false false
+ */
+public class JrtFsTest implements CracTest {
+    @CracTestArg(0)
+    boolean useJvmMap;
+
+    @CracTestArg(1)
+    boolean imageMapAll;
+
+    @Override
+    public void test() throws Exception {
+        CracProcess cp = new CracBuilder().engine(CracEngine.SIMULATE).captureOutput(true)
+            .startCheckpoint();
+        cp.outputAnalyzer()
+            .shouldHaveExitValue(0);
+    }
+
+    @Override
+    public void exec() throws Exception {
+        System.setProperty("jdk.image.use.jvm.map", String.valueOf(useJvmMap));
+        System.setProperty("jdk.image.map.all", String.valueOf(imageMapAll));
+        Map<String, String> env = new HashMap<>();
+        env.put("java.home", System.getProperty("java.home"));
+        FileSystem fs = FileSystems.newFileSystem(URI.create("jrt:/"), env);
+
+        byte[] classBytes1;
+        {
+            Path objectClassPath = fs.getPath("/modules/java.base", "java/lang/Object.class");
+            classBytes1 = Files.readAllBytes(objectClassPath);
+            System.out.println("Read " + classBytes1.length + " bytes from Object.class");
+        }
+
+        Core.checkpointRestore();
+        System.out.println("RESTORED");
+
+        byte[] classBytes2;
+        {
+            Path objectClassPath = fs.getPath("/modules/java.base", "java/lang/Object.class");
+            classBytes2 = Files.readAllBytes(objectClassPath);
+            System.out.println("Read " + classBytes2.length + " bytes from Object.class");
+        }
+        assertTrue(Arrays.equals(classBytes1, classBytes2));
+    }
+}


### PR DESCRIPTION
Fixes CRaC code in `jdk.internal.jimage.BasicImageReader` which was throwing exceptions when trying to use CRaC API from another module.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8347350](https://bugs.openjdk.org/browse/JDK-8347350): [CRaC] Support JRT FS FD (**Bug** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/177/head:pull/177` \
`$ git checkout pull/177`

Update a local copy of the PR: \
`$ git checkout pull/177` \
`$ git pull https://git.openjdk.org/crac.git pull/177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 177`

View PR using the GUI difftool: \
`$ git pr show -t 177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/177.diff">https://git.openjdk.org/crac/pull/177.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/177#issuecomment-2580379914)
</details>
