### PR TITLE
8347355: [CRaC] Restore errors are not visible

### DIFF
--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -431,13 +431,6 @@ jint Threads::check_for_restore(JavaVMInitArgs* args) {
 jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   extern void JDK_Version_init();
 
-#ifdef __APPLE__
-    // BSD clock would be initialized in os::init() but we need to do that earlier
-    // as crac::restore() calls os::javaTimeNanos().
-    os::Bsd::clock_init();
-#endif
-  if (check_for_restore(args) != JNI_OK) return JNI_ERR;
-
   // Preinitialize version info.
   VM_Version::early_initialize();
 
@@ -449,6 +442,15 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 
   // Initialize the output stream module
   ostream_init();
+
+#ifdef __APPLE__
+  // BSD clock would be initialized in os::init() but we need to do that earlier
+  // as crac::restore() calls os::javaTimeNanos().
+  os::Bsd::clock_init();
+#endif
+
+  // Output stream module should be already initialized for error reporting during restore.
+  if (check_for_restore(args) != JNI_OK) return JNI_ERR;
 
   // Process java launcher properties.
   Arguments::process_sun_java_launcher_properties(args);


### PR DESCRIPTION
Moves restore call later in the VM initialization process so that possible error messages get printed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8347355](https://bugs.openjdk.org/browse/JDK-8347355): [CRaC] Restore errors are not visible (**Bug** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/178/head:pull/178` \
`$ git checkout pull/178`

Update a local copy of the PR: \
`$ git checkout pull/178` \
`$ git pull https://git.openjdk.org/crac.git pull/178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 178`

View PR using the GUI difftool: \
`$ git pr show -t 178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/178.diff">https://git.openjdk.org/crac/pull/178.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/178#issuecomment-2580515488)
</details>
