### PR TITLE
8347551: [CRaC] CRaC-related VM options are not consistent

### DIFF
--- a/src/hotspot/os/aix/globals_aix.hpp
+++ b/src/hotspot/os/aix/globals_aix.hpp
@@ -84,6 +84,6 @@ define_pd_global(size_t, PreTouchParallelChunkSize, 1 * G);
 define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, false);
 define_pd_global(bool, UseThreadPriorities, true) ;
-define_pd_global(ccstrlist, CRAllowedOpenFilePrefixes, nullptr);
+define_pd_global(ccstrlist, CRaCAllowedOpenFilePrefixes, nullptr);
 
 #endif // OS_AIX_GLOBALS_AIX_HPP

--- a/src/hotspot/os/bsd/globals_bsd.hpp
+++ b/src/hotspot/os/bsd/globals_bsd.hpp
@@ -49,7 +49,7 @@ define_pd_global(size_t, PreTouchParallelChunkSize, 1 * G);
 define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, false);
 define_pd_global(bool, UseThreadPriorities, true) ;
-define_pd_global(ccstrlist, CRAllowedOpenFilePrefixes, nullptr);
-define_pd_global(ccstr, CREngine, "simengine");
+define_pd_global(ccstrlist, CRaCAllowedOpenFilePrefixes, nullptr);
+define_pd_global(ccstr, CRaCEngine, "simengine");
 
 #endif // OS_BSD_GLOBALS_BSD_HPP

--- a/src/hotspot/os/linux/crac_linux.cpp
+++ b/src/hotspot/os/linux/crac_linux.cpp
@@ -340,8 +340,8 @@ bool VM_Crac::check_fds() {
       }
     }
 
-    if (CRAllowedOpenFilePrefixes != nullptr) {
-      const char *prefix = CRAllowedOpenFilePrefixes;
+    if (CRaCAllowedOpenFilePrefixes != nullptr) {
+      const char *prefix = CRaCAllowedOpenFilePrefixes;
       // JDK appends to ccstrlist using newline, on command line that would be comma
       size_t prefix_length = strcspn(prefix, ",\n");
       bool matched = false;
@@ -357,7 +357,7 @@ bool VM_Crac::check_fds() {
         prefix_length = strcspn(prefix, ",\n");
       }
       if (matched) {
-        print_resources("OK: allowed in -XX:CRAllowedOpenFilePrefixes\n");
+        print_resources("OK: allowed in -XX:CRaCAllowedOpenFilePrefixes\n");
         continue;
       }
     }

--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -108,10 +108,10 @@ define_pd_global(size_t, PreTouchParallelChunkSize, 4 * M);
 define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, false);
 define_pd_global(bool, UseThreadPriorities, true) ;
-define_pd_global(ccstr, CREngine, "criuengine");
+define_pd_global(ccstr, CRaCEngine, "criuengine");
 // On some systems using SSSD files in this directory are left open
 // after calling getpwuid_r, getpwname_r, getgrgid_r, getgrname_r
 // or other functions in this family.
-define_pd_global(ccstrlist, CRAllowedOpenFilePrefixes, "/var/lib/sss/mc/");
+define_pd_global(ccstrlist, CRaCAllowedOpenFilePrefixes, "/var/lib/sss/mc/");
 
 #endif // OS_LINUX_GLOBALS_LINUX_HPP

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -2094,7 +2094,7 @@ int os::exec_child_process_and_wait(const char *path, const char *argv[]) {
 
   pid_t pid = fork();
   if (pid == -1) {
-    perror("cannot fork for crengine");
+    perror("cannot fork for subprocess");
     return -1;
   }
   if (pid == 0) {

--- a/src/hotspot/os/windows/globals_windows.hpp
+++ b/src/hotspot/os/windows/globals_windows.hpp
@@ -55,7 +55,7 @@ define_pd_global(size_t, PreTouchParallelChunkSize, 1 * G);
 define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, true);
 define_pd_global(bool, UseThreadPriorities, true) ;
-define_pd_global(ccstrlist, CRAllowedOpenFilePrefixes, nullptr);
-define_pd_global(ccstr, CREngine, "simengine");
+define_pd_global(ccstrlist, CRaCAllowedOpenFilePrefixes, nullptr);
+define_pd_global(ccstr, CRaCEngine, "simengine");
 
 #endif // OS_WINDOWS_GLOBALS_WINDOWS_HPP

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -557,6 +557,15 @@ static SpecialFlag const special_jvm_flags[] = {
   { "dup option",                   JDK_Version::jdk(9), JDK_Version::undefined(), JDK_Version::undefined() },
 #endif
 
+  { "CREngine",                     JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRAllowedOpenFilePrefixes",    JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRAllowToSkipCheckpoint",      JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRHeapDumpOnCheckpointException", JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRPrintResourcesOnCheckpoint", JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRTraceStartupTime",           JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRDoThrowCheckpointException", JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRPauseOnCheckpointError",     JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+
   { nullptr, JDK_Version(0), JDK_Version(0) }
 };
 
@@ -568,6 +577,14 @@ typedef struct {
 
 static AliasedFlag const aliased_jvm_flags[] = {
   { "CreateMinidumpOnCrash",    "CreateCoredumpOnCrash" },
+  { "CREngine",                        "CRaCEngine" },
+  { "CRAllowedOpenFilePrefixes",       "CRaCAllowedOpenFilePrefixes" },
+  { "CRAllowToSkipCheckpoint",         "CRaCAllowToSkipCheckpoint "},
+  { "CRHeapDumpOnCheckpointException", "CRaCHeapDumpOnCheckpointException" },
+  { "CRPrintResourcesOnCheckpoint",    "CRaCPrintResourcesOnCheckpoint" },
+  { "CRTraceStartupTime",              "CRaCTraceStartupTime" },
+  { "CRDoThrowCheckpointException",    "CRaCDoThrowCheckpointException" },
+  { "CRPauseOnCheckpointError",        "CRaCPauseOnCheckpointError" },
   { nullptr, nullptr}
 };
 

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -518,10 +518,12 @@ Handle crac::checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong
   return ret_cr(JVM_CHECKPOINT_ERROR, Handle(), Handle(), codes, msgs, THREAD);
 }
 
-void crac::restore() {
-  jlong restore_time = os::javaTimeMillis();
-  jlong restore_nanos = os::javaTimeNanos();
+void crac::prepare_restore(crac_restore_data& restore_data) {
+  restore_data.restore_time = os::javaTimeMillis();
+  restore_data.restore_nanos = os::javaTimeNanos();
+}
 
+void crac::restore(crac_restore_data& restore_data) {
   compute_crengine();
 
   const int id = os::current_process_id();
@@ -534,8 +536,8 @@ void crac::restore() {
           Arguments::jvm_flags_array(), Arguments::num_jvm_flags(),
           Arguments::system_properties(),
           Arguments::java_command() ? Arguments::java_command() : "",
-          restore_time,
-          restore_nanos)) {
+          restore_data.restore_time,
+          restore_data.restore_nanos)) {
       char strid[32];
       snprintf(strid, sizeof(strid), "%d", id);
       LINUX_ONLY(setenv("CRAC_NEW_ARGS_ID", strid, true));

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -91,7 +91,7 @@ void VM_Crac::trace_cr(const char* msg, ...) {
 }
 
 void VM_Crac::print_resources(const char* msg, ...) {
-  if (CRPrintResourcesOnCheckpoint) {
+  if (CRaCPrintResourcesOnCheckpoint) {
     va_list ap;
     va_start(ap, msg);
 #ifdef __clang__
@@ -132,10 +132,10 @@ static bool compute_crengine() {
   os::free((char *) _crengine_arg_str);
   _crengine_arg_str = NULL;
 
-  if (!CREngine) {
+  if (!CRaCEngine) {
     return true;
   }
-  char *exec = os::strdup_check_oom(CREngine);
+  char *exec = os::strdup_check_oom(CRaCEngine);
   char *comma = strchr(exec, ',');
   if (comma != NULL) {
     *comma = '\0';
@@ -152,7 +152,7 @@ static bool compute_crengine() {
 
     struct stat st;
     if (0 != os::stat(path, &st)) {
-      warning("Could not find CREngine %s: %s", path, os::strerror(errno));
+      warning("Could not find CRaCEngine %s: %s", path, os::strerror(errno));
       return false;
     }
     _crengine = os::strdup_check_oom(path);
@@ -168,7 +168,7 @@ static bool compute_crengine() {
     bool escaped = false;
     for (char *c = arg; *c != '\0'; ++c) {
       if (_crengine_argc >= ARRAY_SIZE(_crengine_args) - 2) {
-        warning("Too many options to CREngine; cannot proceed with these: %s", arg);
+        warning("Too many options to CRaCEngine; cannot proceed with these: %s", arg);
         return false;
       }
       if (!escaped) {
@@ -195,7 +195,7 @@ static bool compute_crengine() {
 
 static void add_crengine_arg(const char *arg) {
   if (_crengine_argc >= ARRAY_SIZE(_crengine_args) - 1) {
-      warning("Too many options to CREngine; cannot add %s", arg);
+      warning("Too many options to CRaCEngine; cannot add %s", arg);
       return;
   }
   _crengine_args[_crengine_argc++] = arg;
@@ -241,7 +241,7 @@ static int checkpoint_restore(int *shmid) {
 
   crac::update_javaTimeNanos_offset();
 
-  if (CRTraceStartupTime) {
+  if (CRaCTraceStartupTime) {
     tty->print_cr("STARTUPTIME " JLONG_FORMAT " restore-native", os::javaTimeNanos());
   }
 
@@ -331,15 +331,15 @@ void VM_Crac::doit() {
     ok = false;
   }
 
-  if ((!ok || _dry_run) && CRHeapDumpOnCheckpointException) {
+  if ((!ok || _dry_run) && CRaCHeapDumpOnCheckpointException) {
     HeapDumper::dump_heap();
   }
 
-  if (!ok && CRPauseOnCheckpointError) {
+  if (!ok && CRaCPauseOnCheckpointError) {
     os::message_box("Checkpoint failed", "Errors were found during checkpoint.");
   }
 
-  if (!ok && CRDoThrowCheckpointException) {
+  if (!ok && CRaCDoThrowCheckpointException) {
     return;
   } else if (_dry_run) {
     _ok = ok;
@@ -351,7 +351,7 @@ void VM_Crac::doit() {
   }
 
   int shmid = 0;
-  if (CRAllowToSkipCheckpoint) {
+  if (CRaCAllowToSkipCheckpoint) {
     trace_cr("Skip Checkpoint");
   } else {
     trace_cr("Checkpoint ...");

--- a/src/hotspot/share/runtime/crac.hpp
+++ b/src/hotspot/share/runtime/crac.hpp
@@ -36,7 +36,13 @@ public:
   static void vm_create_start();
   static bool prepare_checkpoint();
   static Handle checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong jcmd_stream, TRAPS);
-  static void restore();
+
+  struct crac_restore_data {
+    jlong restore_time;
+    jlong restore_nanos;
+  };
+  static void prepare_restore(crac_restore_data& restore_data);
+  static void restore(crac_restore_data& restore_data);
 
   static jlong restore_start_time();
   static jlong uptime_since_restore();

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1961,10 +1961,10 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, CRaCResetStartTime, true, DIAGNOSTIC | RESTORE_SETTABLE,    \
       "Reset JVM's start time and uptime on restore")                       \
                                                                             \
-  product_pd(ccstr, CREngine, RESTORE_SETTABLE,                             \
+  product_pd(ccstr, CRaCEngine, RESTORE_SETTABLE,                           \
       "Path or name of a program implementing checkpoint/restore and "      \
       "optional extra parameters as a comma-separated list: "               \
-      "-XX:CREngine=program,--key,value,--anotherkey results in calling "   \
+      "-XX:CRaCEngine=program,--key,value,--anotherkey results in calling " \
       "'program --key value --anotherkey'. Commas used as part of args "    \
       "should be escaped with a backslash character ('\\').")               \
                                                                             \
@@ -1978,31 +1978,32 @@ const int ObjectAlignmentInBytes = 8;
       "excluded automatically) not in this list are closed when the VM "    \
       "is started.")                                                        \
                                                                             \
-  product_pd(ccstrlist, CRAllowedOpenFilePrefixes, "List of path prefixes " \
-      "for files that can be open during checkpoint; CRaC won't error "     \
-      "upon detecting these and will leave the handling up to C/R engine. " \
-      "This option applies only to files opened by native code; for files " \
-      "opened by Java code use -Djdk.crac.resource-policies=...")           \
+  product_pd(ccstrlist, CRaCAllowedOpenFilePrefixes, "List of path "        \
+      "prefixes for files that can be open during checkpoint; CRaC won't "  \
+      "error upon detecting these and will leave the handling up to C/R "   \
+      "engine. This option applies only to files opened by native code; "   \
+      "for files opened by Java code use -Djdk.crac.resource-policies=...") \
                                                                             \
-  product(bool, CRAllowToSkipCheckpoint, false, DIAGNOSTIC,                 \
+  product(bool, CRaCAllowToSkipCheckpoint, false, DIAGNOSTIC,               \
       "Allow implementation to not call Checkpoint if helper not found")    \
                                                                             \
-  product(bool, CRHeapDumpOnCheckpointException, false, DIAGNOSTIC,         \
+  product(bool, CRaCHeapDumpOnCheckpointException, false, DIAGNOSTIC,       \
       "Dump heap on CheckpointException thrown because of CRaC "            \
       "precondition failed")                                                \
                                                                             \
-  product(bool, CRPrintResourcesOnCheckpoint, false, DIAGNOSTIC,            \
+  product(bool, CRaCPrintResourcesOnCheckpoint, false, DIAGNOSTIC,          \
       "Print resources to decide CheckpointException")                      \
                                                                             \
-  product(bool, CRTraceStartupTime, false, DIAGNOSTIC,                      \
+  product(bool, CRaCTraceStartupTime, false, DIAGNOSTIC,                    \
       "Trace startup time")                                                 \
                                                                             \
-  product(bool, CRDoThrowCheckpointException, true, EXPERIMENTAL,           \
+  product(bool, CRaCDoThrowCheckpointException, true, EXPERIMENTAL,         \
       "Throw CheckpointException if uncheckpointable resource handle found")\
                                                                             \
+  /* Not renaming to CRaCTrace, this should be obsoleted */                 \
   product(bool, CRTrace, true, RESTORE_SETTABLE, "Minimal C/R tracing")     \
                                                                             \
-  product(bool, CRPauseOnCheckpointError, false, DIAGNOSTIC,                \
+  product(bool, CRaCPauseOnCheckpointError, false, DIAGNOSTIC,              \
       "Pauses the checkpoint when a problem is found on VM level.")         \
                                                                             \
   product(int, LockingMode, LM_LIGHTWEIGHT,                                 \

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -413,12 +413,12 @@ void Threads::initialize_jsr292_core_classes(TRAPS) {
   initialize_class(vmSymbols::java_lang_invoke_MethodHandleNatives(), CHECK);
 }
 
-jint Threads::check_for_restore(JavaVMInitArgs* args) {
+static jint check_for_restore(JavaVMInitArgs* args, crac::crac_restore_data& restore_data) {
   if (Arguments::is_restore_option_set(args)) {
     if (!Arguments::parse_options_for_restore(args)) {
       return JNI_ERR;
     }
-    crac::restore();
+    crac::restore(restore_data);
     if (!CRaCIgnoreRestoreIfUnavailable) {
       // FIXME switch to unified hotspot logging
       warning("cannot restore");
@@ -431,6 +431,14 @@ jint Threads::check_for_restore(JavaVMInitArgs* args) {
 jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   extern void JDK_Version_init();
 
+#ifdef __APPLE__
+  // BSD clock would be initialized in os::init() but we need to do that earlier
+  // as crac::prepare_restore() calls os::javaTimeNanos().
+  os::Bsd::clock_init();
+#endif
+  crac::crac_restore_data restore_data;
+  crac::prepare_restore(restore_data);
+
   // Preinitialize version info.
   VM_Version::early_initialize();
 
@@ -442,18 +450,6 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 
   // Initialize the output stream module
   ostream_init();
-
-#ifdef __APPLE__
-  // BSD clock would be initialized in os::init() but we need to do that earlier
-  // as crac::restore() calls os::javaTimeNanos().
-  os::Bsd::clock_init();
-#endif
-
-  // So that JDK version can be used as a discriminator when parsing arguments
-  JDK_Version_init();
-
-  // Output stream module should be already initialized for error reporting during restore.
-  if (check_for_restore(args) != JNI_OK) return JNI_ERR;
 
   // Process java launcher properties.
   Arguments::process_sun_java_launcher_properties(args);
@@ -469,6 +465,13 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 
   // Initialize system properties.
   Arguments::init_system_properties();
+
+  // So that JDK version can be used as a discriminator when parsing arguments
+  JDK_Version_init();
+
+  // Output stream module should be already initialized for error reporting during restore.
+  // JDK version should also be intialized for arguments parsing.
+  if (check_for_restore(args, restore_data) != JNI_OK) return JNI_ERR;
 
   // Update/Initialize System properties after JDK version number is known
   Arguments::init_version_specific_system_properties();

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -449,6 +449,9 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   os::Bsd::clock_init();
 #endif
 
+  // So that JDK version can be used as a discriminator when parsing arguments
+  JDK_Version_init();
+
   // Output stream module should be already initialized for error reporting during restore.
   if (check_for_restore(args) != JNI_OK) return JNI_ERR;
 
@@ -466,9 +469,6 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 
   // Initialize system properties.
   Arguments::init_system_properties();
-
-  // So that JDK version can be used as a discriminator when parsing arguments
-  JDK_Version_init();
 
   // Update/Initialize System properties after JDK version number is known
   Arguments::init_version_specific_system_properties();

--- a/src/hotspot/share/runtime/threads.hpp
+++ b/src/hotspot/share/runtime/threads.hpp
@@ -67,8 +67,6 @@ class Threads: AllStatic {
   static void threads_do(ThreadClosure* tc);
   static void possibly_parallel_threads_do(bool is_par, ThreadClosure* tc);
 
-  static jint check_for_restore(JavaVMInitArgs* args);
-
   // Initializes the vm and creates the vm thread
   static jint create_vm(JavaVMInitArgs* args, bool* canTryAgain);
   static void convert_vm_init_libraries_to_agents();

--- a/test/jdk/jdk/crac/ContextOrderTest.java
+++ b/test/jdk/jdk/crac/ContextOrderTest.java
@@ -43,11 +43,11 @@ import static jdk.test.lib.Asserts.*;
  * @modules java.base/jdk.internal.crac:+open
  * @modules java.base/jdk.internal.crac.mirror:+open
  * @modules java.base/jdk.internal.crac.mirror.impl:+open
- * @run main/othervm -ea -XX:CREngine=simengine -XX:CRaCCheckpointTo=ignored ContextOrderTest testOrder
- * @run main/othervm -ea -XX:CREngine=simengine -XX:CRaCCheckpointTo=ignored ContextOrderTest testRegisterBlocks
- * @run main/othervm -ea -XX:CREngine=simengine -XX:CRaCCheckpointTo=ignored ContextOrderTest testThrowing
- * @run main/othervm -ea -XX:CREngine=simengine -XX:CRaCCheckpointTo=ignored ContextOrderTest testRegisterToCompleted
- * @run main/othervm -ea -XX:CREngine=simengine -XX:CRaCCheckpointTo=ignored ContextOrderTest testRegisterFromOtherThread
+ * @run main/othervm -ea -XX:CRaCEngine=simengine -XX:CRaCCheckpointTo=ignored ContextOrderTest testOrder
+ * @run main/othervm -ea -XX:CRaCEngine=simengine -XX:CRaCCheckpointTo=ignored ContextOrderTest testRegisterBlocks
+ * @run main/othervm -ea -XX:CRaCEngine=simengine -XX:CRaCCheckpointTo=ignored ContextOrderTest testThrowing
+ * @run main/othervm -ea -XX:CRaCEngine=simengine -XX:CRaCCheckpointTo=ignored ContextOrderTest testRegisterToCompleted
+ * @run main/othervm -ea -XX:CRaCEngine=simengine -XX:CRaCCheckpointTo=ignored ContextOrderTest testRegisterFromOtherThread
  */
 public class ContextOrderTest {
     // prevents GC releasing the resources

--- a/test/jdk/jdk/crac/CracVersionTest.java
+++ b/test/jdk/jdk/crac/CracVersionTest.java
@@ -47,7 +47,7 @@
      public void test_fail() throws Exception {
          ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                  "-XX:CRaCCheckpointTo=cr",
-                 "-XX:CREngine=" + UNKNOWN_ENGINE,
+                 "-XX:CRaCEngine=" + UNKNOWN_ENGINE,
                  "-version");
          OutputAnalyzer out = new OutputAnalyzer(pb.start());
          out.shouldHaveExitValue(1);

--- a/test/jdk/jdk/crac/VMOptionsTest.java
+++ b/test/jdk/jdk/crac/VMOptionsTest.java
@@ -43,7 +43,7 @@ public class VMOptionsTest implements CracTest {
     @Override
     public void test() throws Exception {
         CracBuilder builder = new CracBuilder();
-        // this is here just to test passing CREngine params
+        // this is here just to test passing CRaCEngine params
         builder.engine(CracEngine.CRIU, "--verbosity=4", "--log-file=/dev/null");
         builder.vmOption("-XX:NativeMemoryTracking=off");
         builder.doCheckpoint();

--- a/test/jdk/jdk/crac/fileDescriptors/CheckpointWithOpenFdsTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/CheckpointWithOpenFdsTest.java
@@ -39,7 +39,7 @@ import static jdk.test.lib.Asserts.*;
  * This test includes two behaviours:
  * 1) inheriting open FD from parent process: this is achieved using EXTRA_FD_WRAPPER
  *    - any excess inherited FDs should be closed when JVM starts.
- * 2) open files on classpath: these files are ignored, handling is left to CREngine
+ * 2) open files on classpath: these files are ignored, handling is left to CRaCEngine
  *
  * @test
  * @library /test/lib

--- a/test/lib/jdk/test/lib/crac/CracBuilder.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilder.java
@@ -458,21 +458,21 @@ public class CracBuilder {
                     "," + Arrays.stream(engineArgs)
                             .map(str -> str.replace(",", "\\,"))
                             .collect(Collectors.joining(","));
-            cmd.add("-XX:CREngine=" + engine.engine + engArgs);
+            cmd.add("-XX:CRaCEngine=" + engine.engine + engArgs);
         }
         if (!isRestore) {
             cmd.add("-cp");
             cmd.add(getClassPath());
             if (printResources) {
                 cmd.add("-XX:+UnlockDiagnosticVMOptions");
-                cmd.add("-XX:+CRPrintResourcesOnCheckpoint");
+                cmd.add("-XX:+CRaCPrintResourcesOnCheckpoint");
             }
         }
         if (debug) {
             cmd.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0.0.0.0:5005");
             if (!isRestore) {
                 cmd.add("-XX:+UnlockExperimentalVMOptions");
-                cmd.add("-XX:-CRDoThrowCheckpointException");
+                cmd.add("-XX:-CRaCDoThrowCheckpointException");
             }
         }
         cmd.addAll(vmOptions);


### PR DESCRIPTION
Renames "CR*" CRaC options to "CRaC*", deprecates the olds names.

Restore call is moved later in the JVM initialization process since it now depends on JVM version to parse arguments (because of the deprecations).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8347551](https://bugs.openjdk.org/browse/JDK-8347551): [CRaC] CRaC-related VM options are not consistent (**Enhancement** - P5)


### Contributors
 * Timofei Pushkin `<tpushkin@openjdk.org>`
 * Radim Vansa `<rvansa@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/183/head:pull/183` \
`$ git checkout pull/183`

Update a local copy of the PR: \
`$ git checkout pull/183` \
`$ git pull https://git.openjdk.org/crac.git pull/183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 183`

View PR using the GUI difftool: \
`$ git pr show -t 183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/183.diff">https://git.openjdk.org/crac/pull/183.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/183#issuecomment-2586923638)
</details>
