### PR TITLE
8347993: [CRaC] Assertion error in os::cleanup_memory()

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2227,8 +2227,10 @@ bool os::release_memory(char* addr, size_t bytes) {
 void os::cleanup_memory(char* addr, size_t bytes) {
   char* start = (char*)align_up(addr, os::vm_page_size());
   char* end = (char*)align_down(addr + bytes, os::vm_page_size());
-  os::uncommit_memory(start, end - start);
-  os::commit_memory(start, end - start, false);
+  if (start < end) {
+    os::uncommit_memory(start, end - start);
+    os::commit_memory(start, end - start, false);
+  }
 }
 
 // Prints all mappings


### PR DESCRIPTION
Fixes an assertion error introduced with CRaC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8347993](https://bugs.openjdk.org/browse/JDK-8347993): [CRaC] Assertion error in os::cleanup_memory() (**Bug** - P3)


### Contributors
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/185/head:pull/185` \
`$ git checkout pull/185`

Update a local copy of the PR: \
`$ git checkout pull/185` \
`$ git pull https://git.openjdk.org/crac.git pull/185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 185`

View PR using the GUI difftool: \
`$ git pr show -t 185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/185.diff">https://git.openjdk.org/crac/pull/185.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/185#issuecomment-2598551442)
</details>
