### PR TITLE
8347991: [CRaC] ContainerPidAdjustmentTest takes too long to run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,10 +186,13 @@ jobs:
           JDK_IMAGE_DIR=${{ steps.bundles.outputs.jdk-path }}
           SYMBOLS_IMAGE_DIR=${{ steps.bundles.outputs.symbols-path }}
           TEST_IMAGE_DIR=${{ steps.bundles.outputs.tests-path }}
-          JTREG='JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash;VERBOSE=fail,error,time;KEYWORDS=!headful'
+          JTREG="JAVA_OPTIONS=$JAVA_OPTIONS;VERBOSE=fail,error,time;KEYWORDS=!headful"
           && bash ./.github/scripts/gen-test-summary.sh "$GITHUB_STEP_SUMMARY" "$GITHUB_OUTPUT"
         env:
           PATH: ${{ steps.path.outputs.value }}
+          JAVA_OPTIONS: >-
+            -XX:-CreateCoredumpOnCrash
+            ${{ matrix.test-name == 'jdk/crac' && '-Djdk.test.docker.retain.image=true -Djdk.test.crac.reuse.image=true' || '' }}
 
         # This is a separate step, since if the markdown from a step gets bigger than
         # 1024 kB it is skipped, but then the short summary above is still generated


### PR DESCRIPTION
CRaC tests that use Docker containers now can reuse a Docker image.

In GitHub Actions for `jdk/crac/ContainerPidAdjustmentTest` execution time of runs 2–14 dropped from 4–5s to 0.5–1s on each run, so this should save almost a minute for the whole test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8347991](https://bugs.openjdk.org/browse/JDK-8347991): [CRaC] ContainerPidAdjustmentTest takes too long to run (**Enhancement** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Roman Marchenko `<rmarchenko@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/186/head:pull/186` \
`$ git checkout pull/186`

Update a local copy of the PR: \
`$ git checkout pull/186` \
`$ git pull https://git.openjdk.org/crac.git pull/186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 186`

View PR using the GUI difftool: \
`$ git pr show -t 186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/186.diff">https://git.openjdk.org/crac/pull/186.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/186#issuecomment-2599065477)
</details>
