### PR TITLE
8348650: [CRaC] Limit heap size before checkpoint

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1324,6 +1324,10 @@ public:
 
   // Used to print information about locations in the hs_err file.
   bool print_location(outputStream* st, void* addr) const override;
+
+  void after_restore(void) override {
+    _hrm.after_restore();
+  }
 };
 
 // Scoped object that performs common pre- and post-gc heap printing operations.

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
@@ -121,6 +121,7 @@ class G1HeapRegionManager: public CHeapObj<mtGC> {
   void clear_auxiliary_data_structures(uint start, uint num_regions);
 
   G1HeapRegionTable _regions;
+  uint _max_available_regions;
   G1RegionToSpaceMapper* _heap_mapper;
   G1RegionToSpaceMapper* _bitmap_mapper;
   G1FreeRegionList _free_list;
@@ -145,7 +146,7 @@ class G1HeapRegionManager: public CHeapObj<mtGC> {
   G1HeapRegion* allocate_humongous_allow_expand(uint num_regions);
 
   // Expand helper for cases when the regions to expand are well defined.
-  void expand_exact(uint start, uint num_regions, WorkerThreads* pretouch_workers);
+  bool expand_exact(uint start, uint num_regions, WorkerThreads* pretouch_workers);
   // Expand helper activating inactive regions rather than committing new ones.
   uint expand_inactive(uint num_regions);
   // Expand helper finding new regions to commit.
@@ -230,7 +231,7 @@ public:
   }
 
   // Return the number of regions available (uncommitted) regions.
-  uint available() const { return max_length() - length(); }
+  uint available() const { return _max_available_regions - length(); }
 
   // Return the number of regions currently active and available for use.
   uint length() const { return _committed_map.num_active(); }
@@ -287,6 +288,8 @@ public:
 
   // Do some sanity checking.
   void verify_optional() PRODUCT_RETURN;
+
+  void after_restore(void);
 };
 
 // The G1HeapRegionClaimer is used during parallel iteration over heap regions,

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -526,6 +526,8 @@ protected:
   void reset_promotion_should_fail(volatile size_t* count);
   void reset_promotion_should_fail();
 #endif  // #ifndef PRODUCT
+
+  virtual void after_restore(void) {}
 };
 
 // Class to set and reset the GC cause for a CollectedHeap.

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -473,6 +473,8 @@ Handle crac::checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong
     VMThread::execute(&cr);
   }
 
+  Universe::heap()->after_restore();
+
   LogConfiguration::reopen();
   if (aio_writer) {
     aio_writer->resume();

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2004,6 +2004,9 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, CRaCPauseOnCheckpointError, false, DIAGNOSTIC,              \
       "Pauses the checkpoint when a problem is found on VM level.")         \
                                                                             \
+  product(size_t, CRaCMaxHeapSizeBeforeCheckpoint, 0, "Maximum size "       \
+      "of heap before checkpoint. By default equals to -Xmx.")              \
+                                                                            \
   product(int, LockingMode, LM_LIGHTWEIGHT,                                 \
           "(Deprecated) Select locking mode: "                              \
           "0: (Deprecated) monitors only (LM_MONITOR), "                    \

--- a/test/hotspot/jtreg/gc/TestSmallHeap.java
+++ b/test/hotspot/jtreg/gc/TestSmallHeap.java
@@ -104,7 +104,7 @@ public class TestSmallHeap {
         analyzer.shouldHaveExitValue(0);
 
         expectedMaxHeap = Math.max(expectedMaxHeap, minMaxHeap);
-        long maxHeapSize = Long.parseLong(analyzer.firstMatch("MaxHeapSize.+=\\s+(\\d+)",1));
+        long maxHeapSize = Long.parseLong(analyzer.firstMatch("\\bMaxHeapSize\\b.+=\\s+(\\d+)",1));
         long actualHeapSize = Long.parseLong(analyzer.firstMatch(VerifyHeapSize.actualMsg + "(\\d+)",1));
         Asserts.assertEQ(maxHeapSize, expectedMaxHeap);
         Asserts.assertLessThanOrEqual(actualHeapSize, maxHeapSize);

--- a/test/jdk/jdk/crac/ContainerOOMETest.java
+++ b/test/jdk/jdk/crac/ContainerOOMETest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Azul Systems, 385 Moffett Park Drive, Suite 115, Sunnyvale
+ * CA 94089 USA or visit www.azul.com if you need additional information or
+ * have any questions.
+ */
+
+import jdk.crac.Core;
+import jdk.test.lib.containers.docker.Common;
+import jdk.test.lib.containers.docker.DockerTestUtils;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+
+import java.util.HashMap;
+
+import static jdk.test.lib.Asserts.*;
+
+/*
+ * @test ContainerOOMETest
+ * @requires (os.family == "linux")
+ * @requires container.support
+ * @library /test/lib
+ * @build ContainerOOMETest
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest
+ */
+public class ContainerOOMETest implements CracTest {
+    private static final String AFTER_OOME = "AFTER OOME";
+
+    @Override
+    public void test() throws Exception {
+        if (!DockerTestUtils.canTestDocker()) {
+            return;
+        }
+        final String imageName = Common.imageName("oome-test");
+        CracBuilder builder = new CracBuilder()
+                .captureOutput(true)
+                .inDockerImage(imageName)
+                .dockerOptions("-m", "256M")
+                .runContainerDirectly(true)
+                // Without specific request for G1 we would get Serial on 256M
+                .vmOption("-XX:+UseG1GC")
+                .vmOption("-Xmx4G")
+                .vmOption("-XX:CRaCMaxHeapSizeBeforeCheckpoint=128M");
+        try {
+            builder.startCheckpoint().outputAnalyzer()
+                    .shouldHaveExitValue(137) // checkpoint
+                    .stderrShouldContain(AFTER_OOME);
+            builder.clearDockerOptions().clearVmOptions().captureOutput(false);
+            builder.doRestore();
+        } finally {
+            builder.ensureContainerKilled();
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        try {
+            lotOfAllocations();
+            fail("Should have OOMEd");
+        } catch (OutOfMemoryError error) {
+            // ignore the error
+        }
+        System.err.println(AFTER_OOME);
+        Core.checkpointRestore();
+        lotOfAllocations();
+    }
+
+    private static void lotOfAllocations() {
+        HashMap<String, String> map = new HashMap<>();
+        for (int i = 0; i < 10000000; ++i) {
+            String str = String.valueOf(i);
+            map.put(str, str);
+            if (i % 1000000 == 0) {
+                System.err.println(i + ": " + Runtime.getRuntime().totalMemory());
+            }
+        }
+    }
+}

--- a/test/lib/jdk/test/lib/crac/CracBuilder.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilder.java
@@ -162,8 +162,9 @@ public class CracBuilder {
         return this;
     }
 
-    public void clearVmOptions() {
+    public CracBuilder clearVmOptions() {
         vmOptions.clear();
+        return this;
     }
 
     public CracBuilder printResources(boolean print) {
@@ -223,6 +224,12 @@ public class CracBuilder {
     public CracBuilder dockerOptions(String... options) {
         assertNull(dockerOptions);
         this.dockerOptions = options;
+        return this;
+    }
+
+    public CracBuilder clearDockerOptions() {
+        assertNotNull(dockerOptions);;
+        this.dockerOptions = null;
         return this;
     }
 
@@ -403,7 +410,9 @@ public class CracBuilder {
     }
 
     public CracProcess startRestore(List<String> javaPrefix) throws Exception {
-        ensureContainerStarted();
+        if (!runContainerDirectly) {
+            ensureContainerStarted();
+        }
         List<String> cmd = prepareCommand(javaPrefix, true);
         cmd.add("-XX:CRaCRestoreFrom=" + imageDir);
         log("Starting restored process:");


### PR DESCRIPTION
Adds `CRaCMaxHeapSizeBeforeCheckpoint` to allow limiting heap size before checkpoint and adds its support into G1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8348650](https://bugs.openjdk.org/browse/JDK-8348650): [CRaC] Limit heap size before checkpoint (**Enhancement** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Timofei Pushkin `<tpushkin@openjdk.org>`
 * Radim Vansa `<rvansa@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/189/head:pull/189` \
`$ git checkout pull/189`

Update a local copy of the PR: \
`$ git checkout pull/189` \
`$ git pull https://git.openjdk.org/crac.git pull/189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 189`

View PR using the GUI difftool: \
`$ git pr show -t 189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/189.diff">https://git.openjdk.org/crac/pull/189.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/189#issuecomment-2615277256)
</details>
