### PR TITLE
8348670: [CRaC] VirtualAllocCommitUncommitRecommit.java sometimes hangs

### DIFF
--- a/src/hotspot/os/posix/attachListener_posix.cpp
+++ b/src/hotspot/os/posix/attachListener_posix.cpp
@@ -393,7 +393,7 @@ void PosixAttachOperation::effectively_complete_raw(jint result, bufferedStream*
   // write operation result
   Thread* thread = Thread::current();
   if (thread->is_Java_thread()) {
-    ThreadBlockInVM((JavaThread* )thread);
+    ThreadBlockInVM tbivm(JavaThread::cast(thread));
     write_operation_result(result, st);
   } else {
     write_operation_result(result, st);


### PR DESCRIPTION
A `ThreadBlockInVM` guard had no effect because it had no name (it was destroyed immediately after creation) and that was causing a deadlock.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8348670](https://bugs.openjdk.org/browse/JDK-8348670): [CRaC] VirtualAllocCommitUncommitRecommit.java sometimes hangs (**Bug** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Roman Marchenko `<rmarchenko@openjdk.org>`
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/191/head:pull/191` \
`$ git checkout pull/191`

Update a local copy of the PR: \
`$ git checkout pull/191` \
`$ git pull https://git.openjdk.org/crac.git pull/191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 191`

View PR using the GUI difftool: \
`$ git pr show -t 191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/191.diff">https://git.openjdk.org/crac/pull/191.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/191#issuecomment-2615559724)
</details>
