### PR TITLE
8348674: [CRaC] Check whether CRaCRestoreFrom does exist

### DIFF
--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -527,6 +527,17 @@ void crac::prepare_restore(crac_restore_data& restore_data) {
 }
 
 void crac::restore(crac_restore_data& restore_data) {
+  struct stat statbuf;
+  if (os::stat(CRaCRestoreFrom, &statbuf) != 0) {
+    fprintf(stderr, "Cannot open restore directory of the -XX:CRaCRestoreFrom parameter: ");
+    perror(CRaCRestoreFrom);
+    return;
+  }
+  if ((statbuf.st_mode & S_IFMT) != S_IFDIR) {
+    fprintf(stderr, "-XX:CRaCRestoreFrom parameter is not a directory: %s\n", CRaCRestoreFrom);
+    return;
+  }
+
   compute_crengine();
 
   const int id = os::current_process_id();


### PR DESCRIPTION
Adds a check for `CRaCRestoreFrom` existence and type correctness into the JVM itself

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8348674](https://bugs.openjdk.org/browse/JDK-8348674): [CRaC] Check whether CRaCRestoreFrom does exist (**Enhancement** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Jan Kratochvil `<jkratochvil@openjdk.org>`
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/192/head:pull/192` \
`$ git checkout pull/192`

Update a local copy of the PR: \
`$ git checkout pull/192` \
`$ git pull https://git.openjdk.org/crac.git pull/192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 192`

View PR using the GUI difftool: \
`$ git pr show -t 192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/192.diff">https://git.openjdk.org/crac/pull/192.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/192#issuecomment-2615618531)
</details>
