### PR TITLE
8348869: [CRaC] Restore args are split by whitespaces incorrectly

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -90,6 +90,7 @@ char** Arguments::_jvm_args_array               = nullptr;
 int    Arguments::_num_jvm_args                 = 0;
 unsigned int Arguments::_addmods_count          = 0;
 char*  Arguments::_java_command                 = nullptr;
+char*  Arguments::_java_command_crac            = nullptr;
 SystemProperty* Arguments::_system_properties   = nullptr;
 size_t Arguments::_conservative_max_heap_alignment = 0;
 Arguments::Mode Arguments::_mode                = _mixed;
@@ -2204,9 +2205,9 @@ bool Arguments::parse_options_for_restore(const JavaVMInitArgs* args) {
 
       get_key_value(tail, &key, &value);
 
-      if (strcmp(key, "sun.java.command") == 0) {
-        char *old_java_command = _java_command;
-        _java_command = os::strdup_check_oom(value, mtArguments);
+      if (strcmp(key, "sun.java.crac_command") == 0) {
+        char *old_java_command = _java_command_crac;
+        _java_command_crac = os::strdup_check_oom(value, mtArguments);
         if (old_java_command != NULL) {
           os::free(old_java_command);
         }
@@ -2249,6 +2250,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
 
     if (!match_option(option, "-Djava.class.path", &tail) &&
         !match_option(option, "-Dsun.java.command", &tail) &&
+        !match_option(option, "-Dsun.java.crac_command", &tail) &&
         !match_option(option, "-Dsun.java.launcher", &tail)) {
 
         // add all jvm options to the jvm_args string. This string

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -196,6 +196,7 @@ class Arguments : AllStatic {
   static int    _num_jvm_args;
   // string containing all java command (class/jarfile name and app args)
   static char* _java_command;
+  static char* _java_command_crac;
   // number of unique modules specified in the --add-modules option
   static unsigned int _addmods_count;
 
@@ -399,6 +400,7 @@ class Arguments : AllStatic {
   static int num_jvm_args()                { return _num_jvm_args; }
   // return the arguments passed to the Java application
   static const char* java_command()        { return _java_command; }
+  static const char* java_command_crac()        { return _java_command_crac; }
 
   // print jvm_flags, jvm_args and java_command
   static void print_on(outputStream* st);

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -551,7 +551,7 @@ void crac::restore(crac_restore_data& restore_data) {
           shmfd,
           Arguments::jvm_flags_array(), Arguments::num_jvm_flags(),
           Arguments::system_properties(),
-          Arguments::java_command() ? Arguments::java_command() : "",
+          Arguments::java_command_crac() ? Arguments::java_command_crac() : "",
           restore_data.restore_time,
           restore_data.restore_nanos)) {
       char strid[32];

--- a/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
@@ -240,22 +240,20 @@ public class Core {
             // Parse arguments into array, unescape spaces
             final char escChar = '\\';
             final char sepChar = ' ';
-            ArrayList<String> argList = new ArrayList<String>();
-            argList.add("");
+            final var argList = new ArrayList<String>();
+            final var curArgBuilder = new StringBuilder();
             for (int i = 0; i < newArguments.length(); ++i) {
                 final char curChar = newArguments.charAt(i);
-                final int lastIdx = argList.size() - 1;
                 switch (curChar) {
-                    case sepChar:
-                        argList.add("");
-                        break;
-                    case escChar:
-                        argList.set(lastIdx, argList.get(lastIdx) + newArguments.charAt(++i));
-                        break;
-                    default:
-                        argList.set(lastIdx, argList.get(lastIdx) + curChar);
+                    case sepChar -> {
+                        argList.add(curArgBuilder.toString());
+                        curArgBuilder.setLength(0);
+                    }
+                    case escChar -> curArgBuilder.append(newArguments.charAt(++i));
+                    default -> curArgBuilder.append(curChar);
                 }
             }
+            argList.add(curArgBuilder.toString());
 
             final String[] args = argList.toArray(new String[argList.size()]);
             if (args.length > 0) {

--- a/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
@@ -41,6 +41,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
@@ -236,7 +237,27 @@ public class Core {
         }
 
         if (newArguments != null && newArguments.length() > 0) {
-            String[] args = newArguments.split(" ");
+            // Parse arguments into array, unescape spaces
+            final char escChar = '\\';
+            final char sepChar = ' ';
+            ArrayList<String> argList = new ArrayList<String>();
+            argList.add("");
+            for (int i = 0; i < newArguments.length(); ++i) {
+                final char curChar = newArguments.charAt(i);
+                final int lastIdx = argList.size() - 1;
+                switch (curChar) {
+                    case sepChar:
+                        argList.add("");
+                        break;
+                    case escChar:
+                        argList.set(lastIdx, argList.get(lastIdx) + newArguments.charAt(++i));
+                        break;
+                    default:
+                        argList.set(lastIdx, argList.get(lastIdx) + curChar);
+                }
+            }
+
+            final String[] args = argList.toArray(new String[argList.size()]);
             if (args.length > 0) {
                 try {
                     Method newMain = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {

--- a/src/java.base/share/native/libjli/java.h
+++ b/src/java.base/share/native/libjli/java.h
@@ -151,6 +151,8 @@ int CallJavaMainInNewThread(jlong stack_size, void* args);
 /* sun.java.launcher.* platform properties. */
 void SetJavaCommandLineProp(char* what, int argc, char** argv);
 
+void SetJavaCommandLinePropCrac(char *what, int argc, char **argv);
+
 /*
  * Functions defined in java.c and used in java_md.c.
  */

--- a/test/jdk/jdk/crac/RestoreNewArgsTest.java
+++ b/test/jdk/jdk/crac/RestoreNewArgsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Azul Systems, 385 Moffett Park Drive, Suite 115, Sunnyvale
+ * CA 94089 USA or visit www.azul.com if you need additional information or
+ * have any questions.
+ */
+
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/*
+ * @test RestoreNewArgsTest
+ * @summary the test checks new args are propagated into a restored process.
+ * @library /test/lib
+ * @build RestoreNewArgsTest
+ * @run driver/timeout=120 jdk.test.lib.crac.CracTest
+ * @requires (os.family == "linux")
+ */
+public class RestoreNewArgsTest implements CracTest {
+
+    @Override
+    public void test() throws Exception {
+        final String MAIN_CLASS = "RestoreNewArgsTest$InternalMain";
+        final String ARG0 = "test arg";
+        final String ARG1 = "\\ another\\ \"test\\\\arg ";
+        final String ARG2 = "  ano\007ther  'yet  arg  \\";
+        CracBuilder builder = new CracBuilder().captureOutput(true);
+        builder.doCheckpoint();
+        builder.startRestoreWithArgs(null, Arrays.asList(MAIN_CLASS, ARG0, ARG1, ARG2))
+            .waitForSuccess().outputAnalyzer()
+            .shouldContain("RESTORED")
+            .shouldContain("Arg 0: " + ARG0 + ".")
+            .shouldContain("Arg 1: " + ARG1 + ".")
+            .shouldContain("Arg 2: " + ARG2 + ".");
+    }
+
+    @Override
+    public void exec() throws Exception {
+        jdk.crac.Core.checkpointRestore();
+        System.out.println("RESTORED");
+    }
+
+    public class InternalMain {
+        public static void main(String args[]) throws Exception {
+            int i = 0;
+            for (var arg : args) {
+                System.out.println("Arg " + i++ + ": " + arg + ".");
+            }
+        }
+    }
+}
+

--- a/test/lib/jdk/test/lib/crac/CracBuilder.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilder.java
@@ -410,11 +410,18 @@ public class CracBuilder {
     }
 
     public CracProcess startRestore(List<String> javaPrefix) throws Exception {
+        return startRestoreWithArgs(javaPrefix, null);
+    }
+
+    public CracProcess startRestoreWithArgs(List<String> javaPrefix, List<String> args) throws Exception {
         if (!runContainerDirectly) {
             ensureContainerStarted();
         }
         List<String> cmd = prepareCommand(javaPrefix, true);
         cmd.add("-XX:CRaCRestoreFrom=" + imageDir);
+        if (null != args) {
+            cmd.addAll(args);
+        }
         log("Starting restored process:");
         log(String.join(" ", cmd));
         return new CracProcess(this, cmd);


### PR DESCRIPTION
Fixes the issue by creating a new property `sun.java.crac_command` with spaces escaped. On restore, JVM parses this string de-escaping symbols.

Replaces abandoned #101.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8348869](https://bugs.openjdk.org/browse/JDK-8348869): [CRaC] Restore args are split by whitespaces incorrectly (**Bug** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Roman Marchenko `<rmarchenko@openjdk.org>`
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/193/head:pull/193` \
`$ git checkout pull/193`

Update a local copy of the PR: \
`$ git checkout pull/193` \
`$ git pull https://git.openjdk.org/crac.git pull/193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 193`

View PR using the GUI difftool: \
`$ git pr show -t 193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/193.diff">https://git.openjdk.org/crac/pull/193.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/193#issuecomment-2619287610)
</details>
