### PR TITLE
8348925: [CRaC] Automatic CRaC support for LinuxWatchService

### DIFF
--- a/test/jdk/jdk/crac/fileDescriptors/FileWatcherAfterRestoreTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/FileWatcherAfterRestoreTest.java
@@ -26,13 +26,13 @@
  import jdk.test.lib.crac.CracBuilder;
  import jdk.test.lib.crac.CracTest;
  import jdk.test.lib.crac.CracTestArg;
- 
+
  import java.io.File;
  import java.io.IOException;
  import java.nio.file.*;
  import java.util.Objects;
  import java.util.concurrent.TimeUnit;
- 
+
 /**
  * @test
  * @library /test/lib
@@ -56,7 +56,7 @@ public class FileWatcherAfterRestoreTest implements CracTest {
                 f.delete();
             }
             Files.delete(checkPath);
-        } 
+        }
         builder.doRestore();
     }
 

--- a/test/jdk/jdk/crac/fileDescriptors/FileWatcherAfterRestoreTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/FileWatcherAfterRestoreTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ import jdk.crac.Core;
+ import jdk.test.lib.Asserts;
+ import jdk.test.lib.crac.CracBuilder;
+ import jdk.test.lib.crac.CracTest;
+ import jdk.test.lib.crac.CracTestArg;
+ 
+ import java.io.File;
+ import java.io.IOException;
+ import java.nio.file.*;
+ import java.util.Objects;
+ import java.util.concurrent.TimeUnit;
+ 
+/**
+ * @test
+ * @library /test/lib
+ * @build FileWatcherAfterRestoreTest
+ * @run driver jdk.test.lib.crac.CracTest true
+ * @run driver jdk.test.lib.crac.CracTest false
+ * @requires (os.family == "linux")
+ */
+public class FileWatcherAfterRestoreTest implements CracTest {
+
+    @CracTestArg(0)
+    boolean deleteFolder;
+
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder();
+        builder.doCheckpoint();
+        if (deleteFolder) {
+            Path checkPath = Paths.get(System.getProperty("user.dir"), "workdir");
+            for (File f : Objects.requireNonNull(checkPath.toFile().listFiles())) {
+                f.delete();
+            }
+            Files.delete(checkPath);
+        } 
+        builder.doRestore();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        WatchService watchService = FileSystems.getDefault().newWatchService();
+        Path directory;
+        directory = Paths.get(System.getProperty("user.dir"), "workdir");
+        directory.toFile().mkdir();
+        directory.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
+        Asserts.assertTrue(isMatchFound(watchService, directory));
+
+        Core.checkpointRestore();
+
+        if (deleteFolder) {
+            directory.toFile().mkdir();
+            Asserts.assertFalse(isMatchFound(watchService, directory));
+        } else {
+            Asserts.assertTrue(isMatchFound(watchService, directory));
+        }
+        watchService.close();
+    }
+
+    private boolean isMatchFound(WatchService watchService, Path directory) throws IOException, InterruptedException {
+        WatchKey key;
+        boolean matchFound;
+        Files.createTempFile(directory, "temp", ".txt");
+        matchFound = false;
+        while ((key = watchService.poll(1, TimeUnit.SECONDS)) != null) {
+            for (WatchEvent<?> event : key.pollEvents()) {
+                if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                    Object context = event.context();
+                    if (context instanceof Path filePath) {
+                        String fileName = filePath.getFileName().toString();
+                        if (fileName.matches("^temp\\d*\\.txt$")) {
+                            matchFound = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            key.reset();
+            if (matchFound) {
+                break;
+            }
+        }
+        return matchFound;
+    }
+}

--- a/test/jdk/jdk/crac/fileDescriptors/FileWatcherThreadTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/FileWatcherThreadTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+
+/**
+ * @test Checks the different state of WatchService keys at a checkpoint moment. 
+ * @library /test/lib
+ * @build FileWatcherThreadTest
+ * @run driver jdk.test.lib.crac.CracTest true
+ * @run driver jdk.test.lib.crac.CracTest false
+ * @requires (os.family == "linux")
+ */
+public class FileWatcherThreadTest implements CracTest {
+
+    @CracTestArg(0)
+    boolean checkpointWithoutKey;
+
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder().verbose(true);
+        builder.doCheckpointAndRestore();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Path directory = Paths.get(System.getProperty("user.dir"), "workdir");
+        directory.toFile().mkdir();
+
+        CompletableFuture<Boolean> caughtFirst = new CompletableFuture();
+        CompletableFuture<Boolean> caughtSecond = new CompletableFuture();
+        CyclicBarrier barrier = new CyclicBarrier(2); // Create a CyclicBarrier to sync between two threads
+
+        // Start the WatchService in a separate thread
+        Thread watchThread = new Thread(() -> {
+            try {
+                WatchService watchService = FileSystems.getDefault().newWatchService();
+                directory.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
+
+                if (checkpointWithoutKey) {
+                    barrier.await(); // Wait until the barrier is ready
+                }
+
+                while (true) {
+                    WatchKey key = watchService.take(); // Blocking call, waits for an event
+                    if (key == null) continue;
+
+                    for (WatchEvent<?> event : key.pollEvents()) {
+                        if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                            if (caughtFirst.isDone()) {
+                                caughtSecond.complete(true);
+                            } else {
+                                caughtFirst.complete(true);
+                            }
+                        }
+                    }
+                    key.reset();
+                }
+            } catch (Throwable e) {
+                if (caughtFirst.isDone()) {
+                    caughtSecond.completeExceptionally(e);
+                } else {
+                    caughtFirst.completeExceptionally(e);
+                }
+            }
+        });
+
+        watchThread.setDaemon(true);
+        watchThread.start();
+
+        if (checkpointWithoutKey) {
+            barrier.await(); // Wait for the WatchService to be ready
+            Core.checkpointRestore(); // Restore from checkpoint
+            Files.createTempFile(directory, "temp", ".txt");
+            Asserts.assertFalse(caughtSecond.isDone());
+        } else {
+            Files.createTempFile(directory, "temp", ".txt");
+            Asserts.assertTrue(caughtFirst.get());
+            Core.checkpointRestore();
+            Files.createTempFile(directory, "temp", ".txt");
+            Asserts.assertTrue(caughtSecond.get());
+        }
+    }
+}

--- a/test/jdk/jdk/crac/fileDescriptors/FileWatcherThreadTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/FileWatcherThreadTest.java
@@ -37,7 +37,7 @@ import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 
 /**
- * @test Checks the different state of WatchService keys at a checkpoint moment. 
+ * @test Checks the different state of WatchService keys at a checkpoint moment.
  * @library /test/lib
  * @build FileWatcherThreadTest
  * @run driver jdk.test.lib.crac.CracTest true


### PR DESCRIPTION
Updated version of the abandoned #71

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8348925](https://bugs.openjdk.org/browse/JDK-8348925): [CRaC] Automatic CRaC support for LinuxWatchService (**Enhancement** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * joeyleeeeeee97 `<joeylee1997.1997@gmail.com>`
 * Ilarion Nakonechnyy `<inakonechnyy@openjdk.org>`
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/195/head:pull/195` \
`$ git checkout pull/195`

Update a local copy of the PR: \
`$ git checkout pull/195` \
`$ git pull https://git.openjdk.org/crac.git pull/195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 195`

View PR using the GUI difftool: \
`$ git pr show -t 195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/195.diff">https://git.openjdk.org/crac/pull/195.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/195#issuecomment-2620890610)
</details>
