### PR TITLE
8348929: [CRaC] Use /tmp for restore parameters storage

### DIFF
--- a/src/hotspot/os/posix/crac_posix.cpp
+++ b/src/hotspot/os/posix/crac_posix.cpp
@@ -29,18 +29,6 @@
 
 #include <sys/mman.h>
 
-int CracSHM::open(int mode) {
-  int shmfd = shm_open(_path, mode, 0600);
-  if (-1 == shmfd) {
-    perror("shm_open");
-  }
-  return shmfd;
-}
-
-void CracSHM::unlink() {
-  shm_unlink(_path);
-}
-
 void crac::reset_time_counters() {
   os::Posix::reset_time_counters();
 }

--- a/src/hotspot/os/windows/crac_windows.cpp
+++ b/src/hotspot/os/windows/crac_windows.cpp
@@ -43,13 +43,6 @@ bool VM_Crac::memory_checkpoint() {
 void VM_Crac::memory_restore() {
 }
 
-int CracSHM::open(int mode) {
-  return -1;
-}
-
-void CracSHM::unlink() {
-}
-
 bool crac::read_bootid(char *dest) {
   return true;
 }


### PR DESCRIPTION
`CracSHM` now uses a file in `os::get_temp_directory()` instead of `shm_open`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8348929](https://bugs.openjdk.org/browse/JDK-8348929): [CRaC] Use /tmp for restore parameters storage (**Bug** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Radim Vansa `<rvansa@openjdk.org>`
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/197/head:pull/197` \
`$ git checkout pull/197`

Update a local copy of the PR: \
`$ git checkout pull/197` \
`$ git pull https://git.openjdk.org/crac.git pull/197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 197`

View PR using the GUI difftool: \
`$ git pr show -t 197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/197.diff">https://git.openjdk.org/crac/pull/197.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/197#issuecomment-2620947774)
</details>
