### PR TITLE
8348934: [CRaC] Drop CRTrace VM option

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -566,6 +566,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "CRTraceStartupTime",           JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
   { "CRDoThrowCheckpointException", JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
   { "CRPauseOnCheckpointError",     JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRTrace",                      JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::undefined() },
 
   { nullptr, JDK_Version(0), JDK_Version(0) }
 };

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -73,23 +73,6 @@ jlong crac::uptime_since_restore() {
   return os::javaTimeNanos() - _restore_start_nanos;
 }
 
-void VM_Crac::trace_cr(const char* msg, ...) {
-  if (CRTrace) {
-    va_list ap;
-    va_start(ap, msg);
-    _ostream->print("CR: ");
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
-    _ostream->vprint_cr(msg, ap);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-    va_end(ap);
-  }
-}
-
 void VM_Crac::print_resources(const char* msg, ...) {
   if (CRaCPrintResourcesOnCheckpoint) {
     va_list ap;
@@ -352,9 +335,9 @@ void VM_Crac::doit() {
 
   int shmid = 0;
   if (CRaCAllowToSkipCheckpoint) {
-    trace_cr("Skip Checkpoint");
+    log_info(crac)("Skip Checkpoint");
   } else {
-    trace_cr("Checkpoint ...");
+    log_info(crac)("Checkpoint ...");
     report_ok_to_jcmd_if_any();
     int ret = checkpoint_restore(&shmid);
     if (ret == JVM_CHECKPOINT_ERROR) {
@@ -389,6 +372,9 @@ void VM_Crac::doit() {
 
 
 bool crac::prepare_checkpoint() {
+  // Automatically configure log level for 'crac' to Info
+  LogTagSetMapping<LOG_TAGS(crac)>::tagset().set_output_level(LogConfiguration::StdoutLog, LogLevelType::Info);
+
   struct stat st;
 
   if (0 == os::stat(CRaCCheckpointTo, &st)) {
@@ -455,7 +441,7 @@ Handle crac::checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong
       if (sc.after != SIZE_MAX) {
         const size_t delta = sc.after < sc.before ? (sc.before - sc.after) : (sc.after - sc.before);
         const char sign = sc.after < sc.before ? '-' : '+';
-        log_info(crac)("Trim native heap before checkpoint: " PROPERFMT "->" PROPERFMT " (%c" PROPERFMT ")",
+        log_debug(crac)("Trim native heap before checkpoint: " PROPERFMT "->" PROPERFMT " (%c" PROPERFMT ")",
                         PROPERFMTARGS(sc.before), PROPERFMTARGS(sc.after), sign, PROPERFMTARGS(delta));
       }
     }

--- a/src/hotspot/share/runtime/crac_structs.hpp
+++ b/src/hotspot/share/runtime/crac_structs.hpp
@@ -200,7 +200,6 @@ private:
   bool is_socket_from_jcmd(int sock_fd);
   void report_ok_to_jcmd_if_any();
   void print_resources(const char* msg, ...);
-  void trace_cr(const char* msg, ...);
   bool check_fds();
   bool memory_checkpoint();
   void memory_restore();

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1998,9 +1998,6 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, CRaCDoThrowCheckpointException, true, EXPERIMENTAL,         \
       "Throw CheckpointException if uncheckpointable resource handle found")\
                                                                             \
-  /* Not renaming to CRaCTrace, this should be obsoleted */                 \
-  product(bool, CRTrace, true, RESTORE_SETTABLE, "Minimal C/R tracing")     \
-                                                                            \
   product(bool, CRaCPauseOnCheckpointError, false, DIAGNOSTIC,              \
       "Pauses the checkpoint when a problem is found on VM level.")         \
                                                                             \

--- a/test/jdk/jdk/crac/jdwp/JdwpTransportTest.java
+++ b/test/jdk/jdk/crac/jdwp/JdwpTransportTest.java
@@ -66,7 +66,7 @@ public class JdwpTransportTest implements CracTest {
     private static String PORT = "5555";
     private static String DEBUGEE = "Listening for transport dt_socket at address: 5555";
     private static String STARTED = "APP: Started";
-    private static String CHECKPOINT = "CR: Checkpoint";
+    private static String CHECKPOINT = "[crac] Checkpoint";
 
     private VirtualMachine attachDebugger() throws Exception {
         AttachingConnector ac = Bootstrap.virtualMachineManager().attachingConnectors()


### PR DESCRIPTION
Obsoletes `CRTrace` VM option in favor of unified JVM logging.

Now it prints
```
[0.180s][info][crac] Checkpoint ...
```
rather than
```
CR: Checkpoint ...
```

Logging level for `crac` is programmatically set to `Info` (from the default `Warn`) and the level of a few other messages was reduced to `debug`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8348934](https://bugs.openjdk.org/browse/JDK-8348934): [CRaC] Drop CRTrace VM option (**Enhancement** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Radim Vansa `<rvansa@openjdk.org>`
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/198/head:pull/198` \
`$ git checkout pull/198`

Update a local copy of the PR: \
`$ git checkout pull/198` \
`$ git pull https://git.openjdk.org/crac.git pull/198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 198`

View PR using the GUI difftool: \
`$ git pr show -t 198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/198.diff">https://git.openjdk.org/crac/pull/198.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/198#issuecomment-2621005447)
</details>
