### PR TITLE
8349071: [CRaC] Disable rseq in libc on checkpoint and restore

### DIFF
--- a/src/java.base/share/native/launcher/main.c
+++ b/src/java.base/share/native/launcher/main.c
@@ -62,27 +62,33 @@ WinMain(HINSTANCE inst, HINSTANCE previnst, LPSTR cmdline, int cmdshow)
 #else /* JAVAW */
 
 #ifndef _WIN32
+#include <stdbool.h>
 #include <sys/wait.h>
 
-static int is_checkpoint = 0;
+static bool is_checkpoint = false;
+static bool is_restore = false;
 static const int crac_min_pid_default = 128;
 static int crac_min_pid = 0;
-static int is_min_pid_set = 0;
+static bool is_min_pid_set = false;
 
-static void parse_checkpoint(const char *arg) {
-    if (!is_checkpoint) {
-        const char *checkpoint_arg = "-XX:CRaCCheckpointTo";
-        const int len = strlen(checkpoint_arg);
-        if (0 == strncmp(arg, checkpoint_arg, len)) {
-            is_checkpoint = 1;
-        }
+static inline const char *find_option(const char *arg, const char *vmoption) {
+    const int len = strlen(vmoption);
+    if (0 == strncmp(arg, vmoption, len)) {
+        return arg + len;
     }
-    if (!is_min_pid_set) {
-        const char *checkpoint_arg = "-XX:CRaCMinPid=";
-        const int len = strlen(checkpoint_arg);
-        if (0 == strncmp(arg, checkpoint_arg, len)) {
-            crac_min_pid = atoi(arg + len);
-            is_min_pid_set = 1;
+    return NULL;
+}
+
+static void parse_crac(const char *arg) {
+    if (!is_checkpoint && find_option(arg, "-XX:CRaCCheckpointTo")) {
+        is_checkpoint = true;
+    } else if (!is_restore && find_option(arg, "-XX:CRaCRestoreFrom")) {
+        is_restore = true;
+    } else if (!is_min_pid_set) {
+        const char *value = find_option(arg, "-XX:CRaCMinPid=");
+        if (value != NULL) {
+            crac_min_pid = atoi(value);
+            is_min_pid_set = true;
         }
     }
 }
@@ -311,7 +317,7 @@ main(int argc, char **argv)
         }
         // Iterate the rest of command line
         for (i = 1; i < argc; i++) {
-            parse_checkpoint(argv[i]);
+            parse_crac(argv[i]);
             JLI_List argsInFile = JLI_PreprocessArg(argv[i], JNI_TRUE);
             if (NULL == argsInFile) {
                 JLI_List_add(args, JLI_StringDup(argv[i]));
@@ -373,7 +379,7 @@ main(int argc, char **argv)
     }
 #ifdef LINUX
     // /proc filesystem is only on LINUX/*NIX - rseq is not relevant elsewhere anyway
-    if (is_checkpoint) {
+    if (is_checkpoint || is_restore) {
         const char *GLIBC_TUNABLES = "GLIBC_TUNABLES";
         const char *tunables = getenv(GLIBC_TUNABLES);
         // do not try overwrite an existing tunable setting


### PR DESCRIPTION
An extended version of what was initially suggested in #31. Besides disabling rseq on checkpoint disables it on restore because it became known to also cause errors otherwise.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8349071](https://bugs.openjdk.org/browse/JDK-8349071): [CRaC] Disable rseq in libc on checkpoint and restore (**Bug** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Contributors
 * Anton Kozlov `<akozlov@openjdk.org>`
 * Radim Vansa `<rvansa@openjdk.org>`
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/199/head:pull/199` \
`$ git checkout pull/199`

Update a local copy of the PR: \
`$ git checkout pull/199` \
`$ git pull https://git.openjdk.org/crac.git pull/199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 199`

View PR using the GUI difftool: \
`$ git pr show -t 199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/199.diff">https://git.openjdk.org/crac/pull/199.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/199#issuecomment-2624660696)
</details>
