### PR TITLE
8349131: [CRaC] Internal error on old glibc with pre-set GLIBC_TUNABLES and CPUFeatures restriction

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -930,9 +930,10 @@ const size_t VM_Version::glibc_prefix_len = strlen(glibc_prefix);
 
 bool VM_Version::glibc_env_set(char *disable_str) {
 #define TUNABLES_NAME "GLIBC_TUNABLES"
+#define REEXEC_NAME "HOTSPOT_GLIBC_TUNABLES_REEXEC"
   char *env_val = disable_str;
   const char *env = getenv(TUNABLES_NAME);
-  if (env && strcmp(env, env_val) == 0) {
+  if (env && (strcmp(env, env_val) == 0 || !INCLUDE_CPU_FEATURE_ACTIVE && getenv(REEXEC_NAME))) {
     if (!INCLUDE_CPU_FEATURE_ACTIVE) {
       if (ShowCPUFeatures) {
         tty->print_cr("Environment variable already set, glibc CPU_FEATURE_ACTIVE is unavailable - re-exec suppressed: " TUNABLES_NAME "=%s", env);
@@ -968,7 +969,6 @@ bool VM_Version::glibc_env_set(char *disable_str) {
   if (err)
     vm_exit_during_initialization(err_msg("setenv " TUNABLES_NAME " error: %m"));
 
-#define REEXEC_NAME "HOTSPOT_GLIBC_TUNABLES_REEXEC"
   if (getenv(REEXEC_NAME))
     vm_exit_during_initialization(err_msg("internal error: " TUNABLES_NAME "=%s failed and " REEXEC_NAME " is set", disable_str));
   if (setenv(REEXEC_NAME, "1", 1))

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -933,7 +933,7 @@ bool VM_Version::glibc_env_set(char *disable_str) {
 #define REEXEC_NAME "HOTSPOT_GLIBC_TUNABLES_REEXEC"
   char *env_val = disable_str;
   const char *env = getenv(TUNABLES_NAME);
-  if (env && (strcmp(env, env_val) == 0 || !INCLUDE_CPU_FEATURE_ACTIVE && getenv(REEXEC_NAME))) {
+  if (env && (strcmp(env, env_val) == 0 || (!INCLUDE_CPU_FEATURE_ACTIVE && getenv(REEXEC_NAME)))) {
     if (!INCLUDE_CPU_FEATURE_ACTIVE) {
       if (ShowCPUFeatures) {
         tty->print_cr("Environment variable already set, glibc CPU_FEATURE_ACTIVE is unavailable - re-exec suppressed: " TUNABLES_NAME "=%s", env);

--- a/test/jdk/jdk/crac/CPUFeatures/SimpleCPUFeatures.sh
+++ b/test/jdk/jdk/crac/CPUFeatures/SimpleCPUFeatures.sh
@@ -5,7 +5,7 @@
 # @run shell SimpleCPUFeatures.sh
 # @summary On old glibc (without INCLUDE_CPU_FEATURE_ACTIVE) one could get an internal error.
 # Error occurred during initialization of VM
-# internal error: GLIBC_TUNABLES=:glibc.cpu.hwcaps=,-AVX,-FMA,-AVX2,-BMI1,-BMI2,-ERMS,-LZCNT,-SSSE3,-POPCNT,-SSE4_1,-SSE4_2,-AVX512F,-AVX512CD,-AVX512BW,-AVX512DQ,-AVX512VL,-IBT,-MOVBE,-SHSTK,-XSAVE,-OSXSAVE,-HTT failed and HOTSPOT_GLIBC_TUNABLES_REEXEC is
+# internal error: GLIBC_TUNABLES=:glibc.cpu.hwcaps=,-AVX,-FMA,-AVX2,-BMI1,-BMI2,-ERMS,-LZCNT,-SSSE3,-POPCNT,-SSE4_1,-SSE4_2,-AVX512F,-AVX512CD,-AVX512BW,-AVX512DQ,-AVX512VL,-IBT,-MOVBE,-SHSTK,-XSAVE,-OSXSAVE,-HTT failed and HOTSPOT_GLIBC_TUNABLES_REEXEC is set
 
 set -ex
 

--- a/test/jdk/jdk/crac/CPUFeatures/SimpleCPUFeatures.sh
+++ b/test/jdk/jdk/crac/CPUFeatures/SimpleCPUFeatures.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+# @test
+# @requires os.family == "linux"
+# @requires os.arch=="amd64" | os.arch=="x86_64"
+# @run shell SimpleCPUFeatures.sh
+# @summary On old glibc (without INCLUDE_CPU_FEATURE_ACTIVE) one could get an internal error.
+# Error occurred during initialization of VM
+# internal error: GLIBC_TUNABLES=:glibc.cpu.hwcaps=,-AVX,-FMA,-AVX2,-BMI1,-BMI2,-ERMS,-LZCNT,-SSSE3,-POPCNT,-SSE4_1,-SSE4_2,-AVX512F,-AVX512CD,-AVX512BW,-AVX512DQ,-AVX512VL,-IBT,-MOVBE,-SHSTK,-XSAVE,-OSXSAVE,-HTT failed and HOTSPOT_GLIBC_TUNABLES_REEXEC is
+
+set -ex
+
+export JAVA_HOME=$TESTJAVA
+export GLIBC_TUNABLES=glibc.pthread.rseq=0
+$JAVA_HOME/bin/java -XX:CPUFeatures=generic -XX:+ShowCPUFeatures -version 2>&1 | tee /proc/self/fd/2 | grep -q 'openjdk version'
+
+exit 0


### PR DESCRIPTION
Besides fixing the issue adds a corresponding test case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8349131](https://bugs.openjdk.org/browse/JDK-8349131): [CRaC] Internal error on old glibc with pre-set GLIBC_TUNABLES and CPUFeatures restriction (**Bug** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Jan Kratochvil `<jkratochvil@openjdk.org>`
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/200/head:pull/200` \
`$ git checkout pull/200`

Update a local copy of the PR: \
`$ git checkout pull/200` \
`$ git pull https://git.openjdk.org/crac.git pull/200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 200`

View PR using the GUI difftool: \
`$ git pr show -t 200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/200.diff">https://git.openjdk.org/crac/pull/200.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/200#issuecomment-2626670996)
</details>
