### PR TITLE
8349365: [CRaC] Handle javaagent adding jars to boostrap/system classpath

### DIFF
--- a/src/hotspot/os/linux/crac_linux.cpp
+++ b/src/hotspot/os/linux/crac_linux.cpp
@@ -302,6 +302,7 @@ bool VM_Crac::check_fds() {
 
   bool ok = true;
 
+  ResourceMark rm;
   GrowableArray<int> boot_classpath_fds = ClassLoader::get_classpath_entry_fds();
 
   for (int i = 0; i < fds.len(); ++i) {

--- a/src/hotspot/os/linux/crac_linux.cpp
+++ b/src/hotspot/os/linux/crac_linux.cpp
@@ -302,6 +302,8 @@ bool VM_Crac::check_fds() {
 
   bool ok = true;
 
+  GrowableArray<int> boot_classpath_fds = ClassLoader::get_classpath_entry_fds();
+
   for (int i = 0; i < fds.len(); ++i) {
     if (fds.get_state(i) == FdsInfo::CLOSED) {
       continue;
@@ -338,6 +340,11 @@ bool VM_Crac::check_fds() {
         print_resources("OK: jcmd socket\n");
         continue;
       }
+    }
+
+    if (boot_classpath_fds.contains(fd)) {
+      print_resources("OK: claimed by classloader\n");
+      continue;
     }
 
     if (CRaCAllowedOpenFilePrefixes != nullptr) {

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -820,7 +820,6 @@ void ClassLoader::add_to_boot_append_entries(ClassPathEntry *new_entry) {
 }
 
 GrowableArray<int> ClassLoader::get_classpath_entry_fds() {
-  log_info(crac)("Listing classpath FDS");
   GrowableArray<int> fds;
   assert(Thread::current()->is_VM_thread(), "should be called from VM op");
   // we don't use mutexes here because it is called from VM op

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -99,6 +99,7 @@ class ClassPathZipEntry: public ClassPathEntry {
   virtual ~ClassPathZipEntry();
   u1* open_entry(JavaThread* current, const char* name, jint* filesize, bool nul_terminate);
   ClassFileStream* open_stream(JavaThread* current, const char* name);
+  int get_fd() const { return ZipLibrary::get_fd(_zip); }
 };
 
 
@@ -411,6 +412,9 @@ class ClassLoader: AllStatic {
 
   // adds a class path to the boot append entries
   static void add_to_boot_append_entries(ClassPathEntry* new_entry);
+
+  // returns list of file descriptors used for both boot and app classpath entries
+  static GrowableArray<int> get_classpath_entry_fds();
 
   // creates a class path zip entry (returns null if JAR file cannot be opened)
   static ClassPathZipEntry* create_class_path_zip_entry(const char *apath, bool is_boot_append);

--- a/src/hotspot/share/utilities/zipLibrary.cpp
+++ b/src/hotspot/share/utilities/zipLibrary.cpp
@@ -39,6 +39,7 @@ typedef jboolean(*ZIP_ReadEntry_t)(jzfile* zip, jzentry* entry, unsigned char* b
 typedef jint(*ZIP_CRC32_t)(jint crc, const jbyte* buf, jint len);
 typedef const char* (*ZIP_GZip_InitParams_t)(size_t, size_t*, size_t*, int);
 typedef size_t(*ZIP_GZip_Fully_t)(char*, size_t, char*, size_t, char*, size_t, int, char*, char const**);
+typedef int(*ZIP_GetFD_t)(jzfile *zip);
 
 static ZIP_Open_t ZIP_Open = nullptr;
 static ZIP_Close_t ZIP_Close = nullptr;
@@ -47,6 +48,7 @@ static ZIP_ReadEntry_t ZIP_ReadEntry = nullptr;
 static ZIP_CRC32_t ZIP_CRC32 = nullptr;
 static ZIP_GZip_InitParams_t ZIP_GZip_InitParams = nullptr;
 static ZIP_GZip_Fully_t ZIP_GZip_Fully = nullptr;
+static ZIP_GetFD_t ZIP_GetFD = nullptr;
 
 static void* _zip_handle = nullptr;
 static bool _loaded = false;
@@ -82,6 +84,7 @@ static void store_function_pointers(const char* path, bool vm_exit_on_failure) {
   // and if possible, streamline setting all entry points consistently.
   ZIP_GZip_InitParams = CAST_TO_FN_PTR(ZIP_GZip_InitParams_t, dll_lookup("ZIP_GZip_InitParams", path, false));
   ZIP_GZip_Fully = CAST_TO_FN_PTR(ZIP_GZip_Fully_t, dll_lookup("ZIP_GZip_Fully", path, false));
+  ZIP_GetFD = CAST_TO_FN_PTR(ZIP_GetFD_t, dll_lookup("ZIP_GetFD", path, false));
 }
 
 static void load_zip_library(bool vm_exit_on_failure) {
@@ -194,4 +197,8 @@ void* ZipLibrary::handle() {
   assert(is_loaded(), "invariant");
   assert(_zip_handle != nullptr, "invariant");
   return _zip_handle;
+}
+
+int ZipLibrary::get_fd(jzfile *zip) {
+  return ZIP_GetFD ? ZIP_GetFD(zip) : -1;
 }

--- a/src/hotspot/share/utilities/zipLibrary.hpp
+++ b/src/hotspot/share/utilities/zipLibrary.hpp
@@ -50,6 +50,7 @@ class ZipLibrary : AllStatic {
   static const char* init_params(size_t block_size, size_t* needed_out_size, size_t* needed_tmp_size, int level);
   static size_t compress(char* in, size_t in_size, char* out, size_t out_size, char* tmp, size_t tmp_size, int level, char* buf, const char** pmsg);
   static void* handle();
+  static int get_fd(jzfile *zip);
 };
 
 #endif // SHARE_UTILITIES_ZIPLIBRARY_HPP

--- a/src/java.base/share/native/libzip/zip_util.c
+++ b/src/java.base/share/native/libzip/zip_util.c
@@ -1692,3 +1692,13 @@ ZIP_GZip_Fully(char* inBuf, size_t inLen, char* outBuf, size_t outLen, char* tmp
 
   return result;
 }
+
+JNIEXPORT int
+ZIP_GetFD(jzfile *zip) {
+#ifdef WIN32
+    // File descriptors not applicable on Windows
+    return -1;
+#else
+    return (int) zip->zfd;
+#endif // !WIN32
+}

--- a/src/java.base/share/native/libzip/zip_util.h
+++ b/src/java.base/share/native/libzip/zip_util.h
@@ -281,6 +281,9 @@ ZIP_FreeEntry(jzfile *zip, jzentry *ze);
 jlong ZIP_GetEntryDataOffset(jzfile *zip, jzentry *entry);
 jzentry * ZIP_GetEntry2(jzfile *zip, char *name, jint ulen, jboolean addSlash);
 
+JNIEXPORT int
+ZIP_GetFD(jzfile *zip);
+
 JNIEXPORT jboolean
 ZIP_InflateFully(void *inBuf, jlong inLen, void *outBuf, jlong outLen, char **pmsg);
 

--- a/test/jdk/jdk/crac/AddBootEntryTest.java
+++ b/test/jdk/jdk/crac/AddBootEntryTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.test.lib.Utils;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.instrument.Instrumentation;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.jar.JarFile;
+
+/**
+ * @test AddBootEntryTest
+ * @requires (os.family == "linux")
+ * @library /test/lib
+ * @modules java.instrument
+ *          jdk.jartool/sun.tools.jar
+ * @build AddBootEntryTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class AddBootEntryTest implements CracTest {
+    @Override
+    public void test() throws Exception {
+        File agentJar = File.createTempFile("agent", ".jar");
+        agentJar.deleteOnExit();
+
+        File manifest = File.createTempFile("manifest", ".mf");
+        manifest.deleteOnExit();
+        Files.writeString(manifest.toPath(), """
+            Manifest-Version: 1.0
+            Premain-Class: AddBootEntryTest$Agent
+            Can-Redefine-Classes: true
+            """);
+
+        File testJar = File.createTempFile("test", ".jar");
+        testJar.deleteOnExit();
+
+        String[] agentJarArgs = { "--create", "--file", agentJar.getPath(),
+                "--manifest", manifest.getAbsolutePath(),
+                Utils.TEST_CLASSES + File.separator + "AddBootEntryTest$Agent.class" };
+        sun.tools.jar.Main jarTool = new sun.tools.jar.Main(System.out, System.err, "jar");
+        if (!jarTool.run(agentJarArgs)) {
+            throw new Exception("jar failed: args=" + Arrays.toString(agentJarArgs));
+        }
+        String[] testJarArgs = {"--create", "--file", testJar.getPath(),
+                Utils.TEST_CLASSES + File.separator + "AddBootEntryTest$Agent.class"};
+        if (!jarTool.run(testJarArgs)) {
+            throw new Exception("jar failed: args=" + Arrays.toString(testJarArgs));
+        }
+
+        new CracBuilder()
+                .vmOption("-javaagent:" + agentJar.getPath() + "=" + testJar.getPath())
+                .printResources(true)
+                .doCheckpoint();
+        new CracBuilder().doRestore();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Core.checkpointRestore();
+    }
+
+    public static class Agent {
+        public static void premain(String args, Instrumentation inst) throws IOException {
+            inst.appendToBootstrapClassLoaderSearch(new JarFile(args));
+        }
+    }
+
+    public static class Dummy {}
+}


### PR DESCRIPTION
File descriptors owned by `ClassPathEntry` in `ClassLoader` are ignored during checkpoint.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8349365](https://bugs.openjdk.org/browse/JDK-8349365): [CRaC] Handle javaagent adding jars to boostrap/system classpath (**Bug** - P4)


### Reviewers
 * [Timofei Pushkin](https://openjdk.org/census#tpushkin) (@TimPushkin - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/201/head:pull/201` \
`$ git checkout pull/201`

Update a local copy of the PR: \
`$ git checkout pull/201` \
`$ git pull https://git.openjdk.org/crac.git pull/201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 201`

View PR using the GUI difftool: \
`$ git pr show -t 201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/201.diff">https://git.openjdk.org/crac/pull/201.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/201#issuecomment-2636503793)
</details>
