### PR TITLE
JDK-8349560: [CRaC] Close EPoll FDs when FD policies close registered sockets

### DIFF
--- a/src/java.base/linux/classes/sun/nio/ch/EPollSelectorImpl.java
+++ b/src/java.base/linux/classes/sun/nio/ch/EPollSelectorImpl.java
@@ -32,19 +32,20 @@ import jdk.internal.access.JavaIOFileDescriptorAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.crac.Core;
 import jdk.internal.crac.JDKResource;
+import jdk.internal.crac.mirror.impl.CheckpointOpenResourceException;
+import jdk.internal.crac.mirror.impl.CheckpointOpenSocketException;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
-import java.nio.channels.IllegalSelectorException;
+import java.io.Serial;
+import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.spi.SelectorProvider;
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static sun.nio.ch.EPoll.EPOLLIN;
 import static sun.nio.ch.EPoll.EPOLL_CTL_ADD;
@@ -111,6 +112,7 @@ class EPollSelectorImpl extends SelectorImpl implements JDKResource {
     private boolean interruptTriggered;
 
     private volatile CheckpointRestoreState checkpointState = CheckpointRestoreState.NORMAL_OPERATION;;
+    private Set<SelectableChannel> currentChannels;
 
     private void initFDs() throws IOException {
         epfd = EPoll.create();
@@ -157,6 +159,7 @@ class EPollSelectorImpl extends SelectorImpl implements JDKResource {
                 thisState = CheckpointRestoreState.CHECKPOINTED;
             } else {
                 thisState = CheckpointRestoreState.CHECKPOINT_ERROR;
+                currentChannels = fdToKey.values().stream().map(SelectionKey::channel).collect(Collectors.toSet());
             }
 
             checkpointState = thisState;
@@ -425,9 +428,22 @@ class EPollSelectorImpl extends SelectorImpl implements JDKResource {
                 }
             }
             if (checkpointState == CheckpointRestoreState.CHECKPOINT_ERROR) {
-                throw new IllegalSelectorException();
+                JavaIOFileDescriptorAccess access = SharedSecrets.getJavaIOFileDescriptorAccess();
+                var ex = new BusySelectorException("Selector " + this + " has registered keys from channels: " + currentChannels, null);
+                ex.epollFds.add(claimFd(access, this.epfd, "EPoll FD "));
+                ex.epollFds.add(claimFd(access, this.eventfd.efd(), "EPoll Event FD "));
+                currentChannels = null;
+                throw ex;
             }
         }
+    }
+
+    private FileDescriptor claimFd(JavaIOFileDescriptorAccess access, int fdval, String type) {
+        FileDescriptor fd = new FileDescriptor();
+        access.set(fd, fdval);
+        Core.getClaimedFDs().claimFd(fd, this,
+                () -> new CheckpointOpenSocketException(type + fdval + " left open in " + this + " with registered keys.", null));
+        return fd;
     }
 
     @Override
@@ -445,6 +461,19 @@ class EPollSelectorImpl extends SelectorImpl implements JDKResource {
                 } catch (InterruptedException e) {
                 }
             }
+        }
+    }
+
+    private static class BusySelectorException extends CheckpointOpenResourceException {
+        @Serial
+        private static final long serialVersionUID = 5615481252774343456L;
+        // We need to keep the FileDescriptors around until the checkpoint completes
+        // as ClaimedFDs use WeakHashMap. Transient because exception is serializable
+        // and FileDescriptor is not.
+        transient List<FileDescriptor> epollFds = new ArrayList<>();
+
+        public BusySelectorException(String details, Throwable cause) {
+            super(details, cause);
         }
     }
 }

--- a/src/java.base/share/classes/jdk/internal/crac/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/Core.java
@@ -65,6 +65,7 @@ public class Core {
         SECURE_RANDOM(new BlockingOrderedContext<>()),
         NATIVE_PRNG(new BlockingOrderedContext<>()),
         EPOLLSELECTOR(new BlockingOrderedContext<>()),
+        SOCKETS(new BlockingOrderedContext<>()),
         NORMAL(new BlockingOrderedContext<>());
 
         private final Context<JDKResource> context;

--- a/src/java.base/share/classes/jdk/internal/crac/JDKFdResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKFdResource.java
@@ -27,8 +27,12 @@ public abstract class JDKFdResource implements JDKResource {
     static volatile boolean stacktraceHintPrinted = false;
     static volatile boolean warningSuppressionHintPrinted = false;
 
-    @SuppressWarnings("this-escape")
     public JDKFdResource() {
+        this(Core.Priority.FILE_DESCRIPTORS);
+    }
+
+    @SuppressWarnings("this-escape")
+    public JDKFdResource(Core.Priority priority) {
         stackTraceHolder = COLLECT_FD_STACKTRACES ?
             // About the timestamp: we cannot format it nicely since this
             // exception is sometimes created too early in the VM lifecycle
@@ -37,7 +41,7 @@ public abstract class JDKFdResource implements JDKResource {
                 + " at epoch:" + System.currentTimeMillis() + " here") :
             null;
 
-        Core.Priority.FILE_DESCRIPTORS.getContext().register(this);
+        priority.getContext().register(this);
         OpenResourcePolicies.ensureRegistered();
     }
 

--- a/src/java.base/share/classes/jdk/internal/crac/JDKSocketResourceBase.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKSocketResourceBase.java
@@ -18,6 +18,7 @@ public abstract class JDKSocketResourceBase extends JDKFdResource {
     private boolean error;
 
     public JDKSocketResourceBase(Object owner) {
+        super(Core.Priority.SOCKETS);
         this.owner = owner;
     }
 

--- a/test/jdk/jdk/crac/fileDescriptors/SocketWithSelectorTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/SocketWithSelectorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.CheckpointException;
+import jdk.crac.Core;
+import jdk.internal.crac.OpenResourcePolicies;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracProcess;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static jdk.test.lib.Asserts.assertEquals;
+
+/**
+ * @test
+ * @library /test/lib
+ * @modules java.base/jdk.internal.crac:+open
+ * @requires (os.family == "linux")
+ * @build FDPolicyTestBase
+ * @build SocketWithSelectorTest
+ * @run driver jdk.test.lib.crac.CracTest true
+ * @run driver jdk.test.lib.crac.CracTest false
+ */
+public class SocketWithSelectorTest extends FDPolicyTestBase implements CracTest {
+    @CracTestArg
+    boolean closeSocket;
+
+    @Override
+    public void test() throws Exception {
+        String loopback = InetAddress.getLoopbackAddress().getHostAddress();
+        Path config = writeConfig("""
+                type: SOCKET
+                family: ip
+                localAddress: $loopback
+                action: close
+                """.replace("$loopback", loopback));
+        try {
+            CracBuilder builder = new CracBuilder();
+            if (closeSocket) {
+                builder.javaOption(OpenResourcePolicies.PROPERTY, config.toString());
+            }
+            CracProcess checkpointed = builder.startCheckpoint();
+            if (closeSocket) {
+                checkpointed.waitForCheckpointed();
+                builder.doRestore();
+            } else {
+                // the checkpoint is supposed to fail
+                checkpointed.waitForSuccess();
+            }
+        } finally {
+            Files.deleteIfExists(config);
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Selector selector = Selector.open();
+        ServerSocketChannel serverChannel = ServerSocketChannel.open()
+                .bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+        serverChannel.configureBlocking(false);
+        serverChannel.register(selector, SelectionKey.OP_ACCEPT);
+        try {
+            Core.checkpointRestore();
+        } catch (CheckpointException e) {
+            assertEquals(1L, Arrays.stream(e.getSuppressed()).filter(e2 -> e2.getMessage().contains("has registered keys from channels")).count());
+            assertEquals(2L, Arrays.stream(e.getSuppressed()).filter(e2 -> e2.getMessage().contains("with registered keys")).count());
+            assertEquals(1L, Arrays.stream(e.getSuppressed()).filter(e2 -> e2.getClass().getSimpleName().equals("CheckpointOpenSocketException"))
+                    .filter(e2 -> e2.getMessage().contains("ServerSocketChannelImpl")).count());
+        }
+    }
+}


### PR DESCRIPTION
FD policies are applied as the last set of JDK resources. When these are meant to close server sockets, it’s rather too late: open EPoll FDs won’t be closed automatically as these have the socket still registered when the automatic close is performed.

We can apply FD policies on sockets and close these if requested before EPoll FD handling. The downside is that we would not handle sockets opened during checkpoint, but generally the application should not do that. 

Besides changing the order of closing this PR also improves the way EPoll FDs are reported: the Selector throws BusySelectorException listing channels registered on that selector, and EPoll FD and Event Epoll FD are claimed through Java code with message referencing the selector (this suppresses native open FD detection that wouldn't provide much info).