### PR TITLE
8350088: [CRaC] Stop & restart JFR recording on checkpoint

### DIFF
--- a/src/hotspot/share/jfr/jfr.cpp
+++ b/src/hotspot/share/jfr/jfr.cpp
@@ -176,8 +176,6 @@ void Jfr::after_restore() {
     // We cannot invoke this directly now as DCmdStart command would be blocked
     // trying to register new file descriptors. Instead we just record a request and
     // the recording will be started at the right moment from JDKResource.
-    JavaThread *const THREAD = JavaThread::current();
-    JfrUpcalls::request_start_after_restore(THREAD);
-    assert(!HAS_PENDING_EXCEPTION, "pending exception");
+    JfrUpcalls::request_start_after_restore();
   }
 }

--- a/src/hotspot/share/jfr/jfr.cpp
+++ b/src/hotspot/share/jfr/jfr.cpp
@@ -168,10 +168,9 @@ void Jfr::after_restore() {
     ResourceMark rm;
     char *buf = NEW_RESOURCE_ARRAY(char, buf_len);
     snprintf(buf, buf_len, "-XX:%s=%s", jfr_flag, flag->get_ccstr());
-    JavaVMOption option = {
-      .optionString = buf,
-      .extraInfo = nullptr,
-    };
+    JavaVMOption option;
+    option.optionString = buf;
+    option.extraInfo = nullptr;
     const JavaVMOption *option_ptr = &option;
     JfrOptionSet::parse_start_flight_recording_option(&option_ptr, buf + 4 + strlen(jfr_flag));
     // We cannot invoke this directly now as DCmdStart command would be blocked

--- a/src/hotspot/share/jfr/jfr.cpp
+++ b/src/hotspot/share/jfr/jfr.cpp
@@ -176,6 +176,8 @@ void Jfr::after_restore() {
     // We cannot invoke this directly now as DCmdStart command would be blocked
     // trying to register new file descriptors. Instead we just record a request and
     // the recording will be started at the right moment from JDKResource.
-    JfrUpcalls::request_start_after_restore(JavaThread::current());
+    JavaThread *const THREAD = JavaThread::current();
+    JfrUpcalls::request_start_after_restore(THREAD);
+    assert(!HAS_PENDING_EXCEPTION, "pending exception");
   }
 }

--- a/src/hotspot/share/jfr/jfr.cpp
+++ b/src/hotspot/share/jfr/jfr.cpp
@@ -25,15 +25,19 @@
 #include "precompiled.hpp"
 #include "jfr/jfr.hpp"
 #include "jfr/jni/jfrJavaSupport.hpp"
+#include "jfr/jni/jfrUpcalls.hpp"
 #include "jfr/leakprofiler/leakProfiler.hpp"
 #include "jfr/recorder/jfrRecorder.hpp"
 #include "jfr/recorder/checkpoint/jfrCheckpointManager.hpp"
+#include "jfr/periodic/jfrOSInterface.hpp"
 #include "jfr/recorder/repository/jfrEmergencyDump.hpp"
 #include "jfr/recorder/service/jfrOptionSet.hpp"
 #include "jfr/recorder/service/jfrOptionSet.hpp"
 #include "jfr/recorder/repository/jfrRepository.hpp"
 #include "jfr/support/jfrResolution.hpp"
 #include "jfr/support/jfrThreadLocal.hpp"
+#include "memory/resourceArea.hpp"
+#include "runtime/flags/jvmFlag.hpp"
 #include "runtime/java.hpp"
 
 bool Jfr::is_enabled() {
@@ -148,4 +152,31 @@ bool Jfr::on_flight_recorder_option(const JavaVMOption** option, char* delimiter
 
 bool Jfr::on_start_flight_recording_option(const JavaVMOption** option, char* delimiter) {
   return JfrOptionSet::parse_start_flight_recording_option(option, delimiter);
+}
+
+void Jfr::before_checkpoint() {
+  JfrOSInterface::before_checkpoint();
+}
+
+void Jfr::after_restore() {
+  const char *jfr_flag = "StartFlightRecording";
+  JVMFlag *flag = JVMFlag::find_flag(jfr_flag);
+  if (flag->get_origin() == JVMFlagOrigin::CRAC_RESTORE) {
+    // -XX:StartFlightRecording passed on restore
+    assert(JfrOptionSet::start_flight_recording_options() == nullptr, "should have been released");
+    size_t buf_len = 4 + strlen(jfr_flag) + 1 + strlen(flag->get_ccstr()) + 1;
+    ResourceMark rm;
+    char *buf = NEW_RESOURCE_ARRAY(char, buf_len);
+    snprintf(buf, buf_len, "-XX:%s=%s", jfr_flag, flag->get_ccstr());
+    JavaVMOption option = {
+      .optionString = buf,
+      .extraInfo = nullptr,
+    };
+    const JavaVMOption *option_ptr = &option;
+    JfrOptionSet::parse_start_flight_recording_option(&option_ptr, buf + 4 + strlen(jfr_flag));
+    // We cannot invoke this directly now as DCmdStart command would be blocked
+    // trying to register new file descriptors. Instead we just record a request and
+    // the recording will be started at the right moment from JDKResource.
+    JfrUpcalls::request_start_after_restore(JavaThread::current());
+  }
 }

--- a/src/hotspot/share/jfr/jfr.hpp
+++ b/src/hotspot/share/jfr/jfr.hpp
@@ -72,6 +72,8 @@ class Jfr : AllStatic {
   static bool on_start_flight_recording_option(const JavaVMOption** option, char* delimiter);
   static void on_backpatching(const Method* callee_method, JavaThread* jt);
   static void initialize_main_thread(JavaThread* jt);
+  static void before_checkpoint();
+  static void after_restore();
 };
 
 #endif // SHARE_JFR_JFR_HPP

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -430,3 +430,7 @@ JVM_END
 NO_TRANSITION(jlong, jfr_nanos_now(JNIEnv* env, jclass jvm))
   return JfrChunk::nanos_now();
 NO_TRANSITION_END
+
+JVM_ENTRY_NO_ENV(void, jfr_start_after_restore(JNIEnv* env, jclass jvm))
+  return JfrRecorder::start_after_restore();
+JVM_END

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
@@ -167,6 +167,8 @@ void JNICALL jfr_unregister_stack_filter(JNIEnv* env, jclass jvm, jlong id);
 
 jlong JNICALL jfr_nanos_now(JNIEnv* env, jclass jvm);
 
+void JNICALL jfr_start_after_restore(JNIEnv* env, jclass jvm);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
@@ -101,7 +101,8 @@ JfrJniMethodRegistration::JfrJniMethodRegistration(JNIEnv* env) {
       (char*)"emitDataLoss", (char*)"(J)V", (void*)jfr_emit_data_loss,
       (char*)"registerStackFilter", (char*)"([Ljava/lang/String;[Ljava/lang/String;)J", (void*)jfr_register_stack_filter,
       (char*)"unregisterStackFilter", (char*)"(J)V", (void*)jfr_unregister_stack_filter,
-      (char*)"nanosNow", (char*)"()J", (void*)jfr_nanos_now
+      (char*)"nanosNow", (char*)"()J", (void*)jfr_nanos_now,
+      (char*)"startFlightRecorderAfterRestore", (char*)"()V", (void*)jfr_start_after_restore,
     };
 
     const size_t method_array_length = sizeof(method) / sizeof(JNINativeMethod);

--- a/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
+++ b/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
@@ -48,6 +48,8 @@ static Symbol* bytes_for_eager_instrumentation_sym = nullptr;
 static Symbol* bytes_for_eager_instrumentation_sig_sym = nullptr;
 static Symbol* unhide_internal_types_sym = nullptr;
 static Symbol* unhide_internal_types_sig_sym = nullptr;
+static Symbol* request_start_after_restore_sym = nullptr;
+static Symbol* request_start_after_restore_sig_sym = nullptr;
 
 static bool initialize(TRAPS) {
   static bool initialized = false;
@@ -60,6 +62,8 @@ static bool initialize(TRAPS) {
     bytes_for_eager_instrumentation_sig_sym = SymbolTable::new_permanent_symbol("(JZZLjava/lang/Class;[B)[B");
     unhide_internal_types_sym = SymbolTable::new_permanent_symbol("unhideInternalTypes");
     unhide_internal_types_sig_sym = SymbolTable::new_permanent_symbol("()V");
+    request_start_after_restore_sym = SymbolTable::new_permanent_symbol("requestStartAfterRestore");
+    request_start_after_restore_sig_sym = SymbolTable::new_permanent_symbol("()V");
     initialized = unhide_internal_types_sig_sym != nullptr;
   }
   return initialized;
@@ -207,4 +211,23 @@ bool JfrUpcalls::unhide_internal_types(TRAPS) {
     return false;
   }
   return true;
+}
+
+void JfrUpcalls::request_start_after_restore(TRAPS) {
+  DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(THREAD));
+  if (!initialize(THREAD)) {
+    log_error(jfr, system)("JfrUpcall could not be initialized.");
+    return;
+  }
+  JavaValue result(T_VOID);
+  const Klass* klass = SystemDictionary::resolve_or_fail(jvm_upcalls_class_sym, true, CHECK);
+  assert(klass != nullptr, "invariant");
+  JfrJavaArguments args(&result, klass, request_start_after_restore_sym, request_start_after_restore_sig_sym);
+  JfrJavaSupport::call_static(&args, THREAD);
+  if (HAS_PENDING_EXCEPTION) {
+    CLEAR_PENDING_EXCEPTION;
+    ResourceMark rm(THREAD);
+    log_error(jfr, system)("JfrUpcall failed for %s", unhide_internal_types_sym->as_C_string());
+    return;
+  }
 }

--- a/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
+++ b/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
@@ -213,7 +213,8 @@ bool JfrUpcalls::unhide_internal_types(TRAPS) {
   return true;
 }
 
-void JfrUpcalls::request_start_after_restore(TRAPS) {
+void JfrUpcalls::request_start_after_restore() {
+  JavaThread * const THREAD = JavaThread::current();
   DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(THREAD));
   if (!initialize(THREAD)) {
     log_error(jfr, system)("JfrUpcall could not be initialized.");

--- a/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
+++ b/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
@@ -227,7 +227,6 @@ void JfrUpcalls::request_start_after_restore(TRAPS) {
   if (HAS_PENDING_EXCEPTION) {
     CLEAR_PENDING_EXCEPTION;
     ResourceMark rm(THREAD);
-    log_error(jfr, system)("JfrUpcall failed for %s", unhide_internal_types_sym->as_C_string());
-    return;
+    log_error(jfr, system)("JfrUpcall failed for %s", request_start_after_restore_sym->as_C_string());
   }
 }

--- a/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
+++ b/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
@@ -220,7 +220,14 @@ void JfrUpcalls::request_start_after_restore(TRAPS) {
     return;
   }
   JavaValue result(T_VOID);
-  const Klass* klass = SystemDictionary::resolve_or_fail(jvm_upcalls_class_sym, true, CHECK);
+  const Klass* klass = SystemDictionary::resolve_or_fail(jvm_upcalls_class_sym, true, THREAD);
+  if (HAS_PENDING_EXCEPTION) {
+    CLEAR_PENDING_EXCEPTION;
+    ResourceMark rm(THREAD);
+    log_error(jfr, system)("JfrUpcall cannot resolve class %s, flight recording won't be started",
+      jvm_upcalls_class_sym->as_C_string());
+    return;
+  }
   assert(klass != nullptr, "invariant");
   JfrJavaArguments args(&result, klass, request_start_after_restore_sym, request_start_after_restore_sig_sym);
   JfrJavaSupport::call_static(&args, THREAD);

--- a/src/hotspot/share/jfr/jni/jfrUpcalls.hpp
+++ b/src/hotspot/share/jfr/jni/jfrUpcalls.hpp
@@ -56,7 +56,7 @@ class JfrUpcalls : AllStatic {
                              TRAPS);
 
   static bool unhide_internal_types(TRAPS);
-  static void request_start_after_restore(TRAPS);
+  static void request_start_after_restore();
 };
 
 #endif // SHARE_JFR_JNI_JFRUPCALLS_HPP

--- a/src/hotspot/share/jfr/jni/jfrUpcalls.hpp
+++ b/src/hotspot/share/jfr/jni/jfrUpcalls.hpp
@@ -56,6 +56,7 @@ class JfrUpcalls : AllStatic {
                              TRAPS);
 
   static bool unhide_internal_types(TRAPS);
+  static void request_start_after_restore(TRAPS);
 };
 
 #endif // SHARE_JFR_JNI_JFRUPCALLS_HPP

--- a/src/hotspot/share/jfr/periodic/jfrOSInterface.hpp
+++ b/src/hotspot/share/jfr/periodic/jfrOSInterface.hpp
@@ -56,6 +56,8 @@ class JfrOSInterface: public JfrCHeapObj {
   static int generate_initial_environment_variable_events();
   static int system_processes(SystemProcess** system_processes, int* no_of_sys_processes);
   static int network_utilization(NetworkInterface** network_interfaces);
+
+  static void before_checkpoint();
 };
 
 #endif // SHARE_JFR_PERIODIC_JFROSINTERFACE_HPP

--- a/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
+++ b/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
@@ -465,7 +465,8 @@ void JfrRecorder::stop_recording() {
 }
 
 void JfrRecorder::start_after_restore() {
-  JavaThread* const thread = JavaThread::current();
-  validate_recording_options(thread);
-  launch_command_line_recordings(thread);
+  JavaThread* const THREAD = JavaThread::current();
+  validate_recording_options(THREAD);
+  launch_command_line_recordings(THREAD);
+  assert(!HAS_PENDING_EXCEPTION, "pending exception");
 }

--- a/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
+++ b/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
@@ -463,3 +463,9 @@ bool JfrRecorder::is_recording() {
 void JfrRecorder::stop_recording() {
   _post_box->post(MSG_STOP);
 }
+
+void JfrRecorder::start_after_restore() {
+  JavaThread* const thread = JavaThread::current();
+  validate_recording_options(thread);
+  launch_command_line_recordings(thread);
+}

--- a/src/hotspot/share/jfr/recorder/jfrRecorder.hpp
+++ b/src/hotspot/share/jfr/recorder/jfrRecorder.hpp
@@ -69,6 +69,8 @@ class JfrRecorder : public JfrCHeapObj {
   static void start_recording();
   static bool is_recording();
   static void stop_recording();
+
+  static void start_after_restore();
 };
 
 #endif // SHARE_JFR_RECORDER_JFRRECORDER_HPP

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 
 #include "classfile/classLoader.hpp"
+#include "jfr/jfr.hpp"
 #include "jvm.h"
 #include "logging/logAsyncWriter.hpp"
 #include "logging/logConfiguration.hpp"
@@ -311,6 +312,7 @@ void VM_Crac::doit() {
   DefaultStreamHandler defStreamHandler;
 
   Decoder::before_checkpoint();
+  JFR_ONLY(Jfr::before_checkpoint();)
   if (!check_fds()) {
     ok = false;
   }
@@ -469,6 +471,9 @@ Handle crac::checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong
   if (aio_writer) {
     aio_writer->resume();
   }
+
+  // after_restore should run outside VM thread
+  JFR_ONLY(Jfr::after_restore();)
 
 #if INCLUDE_JVMTI
   JvmtiExport::post_crac_after_restore();

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -312,7 +312,6 @@ void VM_Crac::doit() {
   DefaultStreamHandler defStreamHandler;
 
   Decoder::before_checkpoint();
-  JFR_ONLY(Jfr::before_checkpoint();)
   if (!check_fds()) {
     ok = false;
   }
@@ -453,6 +452,8 @@ Handle crac::checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong
     }
   }
 
+  JFR_ONLY(Jfr::before_checkpoint();)
+
   AsyncLogWriter* aio_writer = AsyncLogWriter::instance();
   if (aio_writer) {
     aio_writer->stop();
@@ -472,7 +473,6 @@ Handle crac::checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong
     aio_writer->resume();
   }
 
-  // after_restore should run outside VM thread
   JFR_ONLY(Jfr::after_restore();)
 
 #if INCLUDE_JVMTI

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1932,7 +1932,7 @@ const int ObjectAlignmentInBytes = 8;
   JFR_ONLY(product(ccstr, FlightRecorderOptions, nullptr,                   \
           "Flight Recorder options"))                                       \
                                                                             \
-  JFR_ONLY(product(ccstr, StartFlightRecording, nullptr,                    \
+  JFR_ONLY(product(ccstr, StartFlightRecording, nullptr, RESTORE_SETTABLE,  \
           "Start flight recording with options"))                           \
                                                                             \
   product(bool, UseFastUnorderedTimeStamps, false, EXPERIMENTAL,            \

--- a/src/java.base/share/classes/jdk/internal/crac/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/Core.java
@@ -28,9 +28,11 @@ package jdk.internal.crac;
 
 import jdk.internal.crac.mirror.Context;
 import jdk.internal.crac.mirror.impl.BlockingOrderedContext;
+import jdk.internal.crac.mirror.impl.OrderedContext;
 
 public class Core {
     private static ClaimedFDs claimedFDs;
+    private static JfrResource jfrResource = new JfrResource();
 
     /**
      * Called by JDK FD resources
@@ -48,6 +50,14 @@ public class Core {
     }
 
     /**
+     * Called by jdk.jfr.internal.JVMUpcalls when native code requests to start flight recording
+     * @param runnable
+     */
+    public static void setStartFlightRecorder(Runnable runnable) {
+        jfrResource.setStartFlightRecorder(runnable);
+    }
+
+    /**
      * Priorities are defined in the order of registration to the global context.
      * Checkpoint notification will be processed in the order from the bottom to the top of the list.
      * Restore will be done in reverse order: from the top to the bottom.
@@ -59,6 +69,9 @@ public class Core {
     public enum Priority {
         FILE_DESCRIPTORS(new BlockingOrderedContext<>()),
         PRE_FILE_DESCRIPTORS(new BlockingOrderedContext<>()),
+        // We use OrderedContext to not cause failure when PlatformRecorder tries to
+        // register itself when the recording is started from JfrResource.
+        JFR(new OrderedContext<>()),
         CLEANERS(new BlockingOrderedContext<>()),
         REFERENCE_HANDLER(new BlockingOrderedContext<>()),
         SEEDER_HOLDER(new BlockingOrderedContext<>()),

--- a/src/java.base/share/classes/jdk/internal/crac/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/Core.java
@@ -32,7 +32,7 @@ import jdk.internal.crac.mirror.impl.OrderedContext;
 
 public class Core {
     private static ClaimedFDs claimedFDs;
-    private static JfrResource jfrResource = new JfrResource();
+    private static final JfrResource jfrResource = new JfrResource();
 
     /**
      * Called by JDK FD resources

--- a/src/java.base/share/classes/jdk/internal/crac/JfrResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JfrResource.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package jdk.internal.crac;
 
 import jdk.internal.crac.mirror.Context;
@@ -22,6 +46,6 @@ class JfrResource implements JDKResource {
     }
 
     public void setStartFlightRecorder(Runnable runnable) {
-        this.startRecording = runnable;
+        startRecording = runnable;
     }
 }

--- a/src/java.base/share/classes/jdk/internal/crac/JfrResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JfrResource.java
@@ -1,0 +1,27 @@
+package jdk.internal.crac;
+
+import jdk.internal.crac.mirror.Context;
+import jdk.internal.crac.mirror.Resource;
+
+class JfrResource implements JDKResource {
+    private Runnable startRecording;
+
+    JfrResource() {
+        Core.Priority.JFR.getContext().register(this);
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) {
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) {
+        if (startRecording != null) {
+            startRecording.run();
+        }
+    }
+
+    public void setStartFlightRecorder(Runnable runnable) {
+        this.startRecording = runnable;
+    }
+}

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -177,6 +177,7 @@ module java.base {
         jdk.crypto.cryptoki;
     exports jdk.internal.crac to
         java.rmi,
+        jdk.jfr.internal,
         jdk.management.agent,
         jdk.sctp;
     exports jdk.internal.classfile.components to
@@ -420,6 +421,7 @@ module java.base {
     exports jdk.internal.crac.mirror to
         java.rmi,
         jdk.crac,
+        jdk.jfr.internal,
         jdk.management.agent;
 
     exports jdk.internal.crac.mirror.impl to

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -177,7 +177,7 @@ module java.base {
         jdk.crypto.cryptoki;
     exports jdk.internal.crac to
         java.rmi,
-        jdk.jfr.internal,
+        jdk.jfr,
         jdk.management.agent,
         jdk.sctp;
     exports jdk.internal.classfile.components to
@@ -421,7 +421,7 @@ module java.base {
     exports jdk.internal.crac.mirror to
         java.rmi,
         jdk.crac,
-        jdk.jfr.internal,
+        jdk.jfr,
         jdk.management.agent;
 
     exports jdk.internal.crac.mirror.impl to

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
@@ -675,4 +675,9 @@ public final class JVM {
      * @param value
      */
     public static native void setMiscellaneous(long eventTypeId, long value);
+
+    /**
+     * Starts recording based on -XX:StartFlightRecorder passed on restore.
+     */
+    public static native void startFlightRecorderAfterRestore();
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVMUpcalls.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVMUpcalls.java
@@ -26,6 +26,7 @@ package jdk.jfr.internal;
 
 import java.lang.reflect.Modifier;
 
+import jdk.internal.crac.Core;
 import jdk.jfr.internal.event.EventConfiguration;
 import jdk.jfr.internal.util.Bytecode;
 import jdk.jfr.internal.util.Utils;
@@ -156,5 +157,12 @@ final class JVMUpcalls {
      */
     static Thread createRecorderThread(ThreadGroup systemThreadGroup, ClassLoader contextClassLoader) {
         return SecuritySupport.createRecorderThread(systemThreadGroup, contextClassLoader);
+    }
+
+    /**
+     * Called by the JVM when it is restored with a new -XX:StartFlightRecorder
+     */
+    static void requestStartAfterRestore() {
+        Core.setStartFlightRecorder(JVM::startFlightRecorderAfterRestore);
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
@@ -854,6 +854,10 @@ public final class PlatformRecording implements AutoCloseable {
         return result;
     }
 
+    SafePath getDumpDirectory() {
+        return dumpDirectory;
+    }
+
     /**
      * Sets the dump directory.
      * <p>

--- a/test/jdk/jdk/crac/jfr/FlightRecorderCmdlineTest.java
+++ b/test/jdk/jdk/crac/jfr/FlightRecorderCmdlineTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+
+import java.io.File;
+
+import static jdk.test.lib.Asserts.assertTrue;
+
+/**
+ * @test FlightRecorderCmdlineTest
+ * @library /test/lib
+ * @requires (os.family == "linux")
+ * @build FlightRecorderTestBase
+ * @build FlightRecorderCmdlineTest
+ * @run driver jdk.test.lib.crac.CracTest true false
+ * @run driver jdk.test.lib.crac.CracTest false true
+ * @run driver jdk.test.lib.crac.CracTest true true
+ *
+ */
+public class FlightRecorderCmdlineTest extends FlightRecorderTestBase implements CracTest {
+    @CracTestArg(0)
+    boolean beforeCheckpoint;
+
+    @CracTestArg(1)
+    boolean afterRestore;
+
+    @Override
+    public void test() throws Exception {
+        File jfrOne = File.createTempFile("one", ".jfr");
+        File jfrTwo = File.createTempFile("two", ".jfr");
+        assertTrue(jfrOne.delete());
+        assertTrue(jfrTwo.delete());
+        CracBuilder cpBuilder = new CracBuilder();
+        cpBuilder.vmOption("-Xlog:jfr=debug");
+        if (beforeCheckpoint) {
+            cpBuilder.vmOption("-XX:StartFlightRecording=dumponexit=true,filename=" + jfrOne);
+        }
+        cpBuilder.doCheckpoint();
+        if (beforeCheckpoint) {
+            assertRecording(jfrOne);
+        }
+        CracBuilder rsBuilder = new CracBuilder();
+        if (afterRestore) {
+            rsBuilder.vmOption("-XX:StartFlightRecording=dumponexit=true,filename=" + jfrTwo);
+        }
+        rsBuilder.doRestore();
+        if (beforeCheckpoint) {
+            assertRecording(jfrOne);
+        }
+        if (afterRestore) {
+            assertRecording(jfrTwo);
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Core.checkpointRestore();
+    }
+}

--- a/test/jdk/jdk/crac/jfr/FlightRecorderJcmdTest.java
+++ b/test/jdk/jdk/crac/jfr/FlightRecorderJcmdTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import jdk.crac.Core;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracProcess;
+import jdk.test.lib.crac.CracTest;
+
+import java.io.File;
+
+import static jdk.test.lib.Asserts.assertTrue;
+
+/**
+ * @test FlightRecorderJcmdTest
+ * @library /test/lib
+ * @requires (os.family == "linux")
+ * @build FlightRecorderTestBase
+ * @build FlightRecorderJcmdTest
+ * @run driver jdk.test.lib.crac.CracTest
+ *
+ */
+public class FlightRecorderJcmdTest extends FlightRecorderTestBase implements CracTest {
+    protected static final String TEST_STARTED = "TEST STARTED";
+
+    @Override
+    public void test() throws Exception {
+        File jfr = File.createTempFile("flight", ".jfr");
+        assertTrue(jfr.delete());
+        CracBuilder builder = new CracBuilder().captureOutput(true);
+        CracProcess first = builder.startCheckpoint();
+        first.waitForStdout(TEST_STARTED);
+        builder.runJcmd(String.valueOf(first.pid()), "JFR.start", "name=xxx", "dumponexit=true", "filename=" + jfr)
+                .shouldHaveExitValue(0)
+                .shouldContain("Started recording");
+        first.input().write('\n');
+        first.input().flush();
+        first.waitForCheckpointed();
+        assertRecording(jfr);
+        CracProcess second = new CracBuilder().captureOutput(true).startRestore();
+        second.waitForStdout(RESTORED_MESSAGE, false);
+
+        File jfrOther = File.createTempFile("other", ".jfr");
+        assertTrue(jfrOther.delete());
+        // CRIU restored with the same PID
+        String restoredPid = String.valueOf(first.pid());
+        builder.runJcmd(restoredPid, "JFR.dump", "name=xxx", "filename=" + jfrOther)
+                .shouldHaveExitValue(0)
+                .shouldContain("Dumped recording \"xxx\"");
+        assertRecording(jfrOther);
+        second.input().write('\n');
+        second.input().flush();
+        second.waitForSuccess();
+        assertRecording(jfr);
+    }
+
+    @Override
+    public void exec() throws Exception {
+        System.out.println(TEST_STARTED);
+        System.in.read();
+        Core.checkpointRestore();
+        System.out.println(RESTORED_MESSAGE);
+        System.in.read();
+    }
+}

--- a/test/jdk/jdk/crac/jfr/FlightRecorderTestBase.java
+++ b/test/jdk/jdk/crac/jfr/FlightRecorderTestBase.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.jfr.consumer.RecordingFile;
+import jdk.test.lib.crac.CracTest;
+
+import java.io.File;
+import java.io.IOException;
+
+import static jdk.test.lib.Asserts.assertTrue;
+import static jdk.test.lib.Asserts.fail;
+
+abstract class FlightRecorderTestBase implements CracTest {
+    protected static void assertRecording(File jfr) {
+        assertTrue(jfr.exists());
+        assertTrue(jfr.length() > 0);
+        try (RecordingFile recordingFile = new RecordingFile(jfr.toPath())) {
+            while (recordingFile.hasMoreEvents()) {
+                recordingFile.readEvent();
+            }
+        } catch (IOException e) {
+            fail("Cannot read JFR file", e);
+        }
+        assertTrue(jfr.delete());
+    }
+}


### PR DESCRIPTION
All JFR recordings are closed during checkpoint. After restore JDK starts new recordings with the same parameters as those running before checkpoint.
The recordings dumped before checkpoint are moved to a different path (`xxx.jfr` -> `xxx.<N>.jfr`, `xxx` -> `xxx.<N>` with `<N>` between 0 and 20 by default). 
If `-XX:StartFlightRecorder=...` is passed on restore a new recording is started.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8350088](https://bugs.openjdk.org/browse/JDK-8350088): [CRaC] Stop &amp; restart JFR recording on checkpoint (**Bug** - P4)


### Reviewers
 * [Timofei Pushkin](https://openjdk.org/census#tpushkin) (@TimPushkin - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/203/head:pull/203` \
`$ git checkout pull/203`

Update a local copy of the PR: \
`$ git checkout pull/203` \
`$ git pull https://git.openjdk.org/crac.git pull/203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 203`

View PR using the GUI difftool: \
`$ git pr show -t 203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/203.diff">https://git.openjdk.org/crac/pull/203.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/203#issuecomment-2659786605)
</details>
