### PR TITLE
8349819: [CRaC] Support FD policy reopen on listening socket

### DIFF
--- a/src/java.base/linux/classes/sun/nio/ch/EPollPort.java
+++ b/src/java.base/linux/classes/sun/nio/ch/EPollPort.java
@@ -25,9 +25,15 @@
 
 package sun.nio.ch;
 
+import jdk.internal.crac.Core;
+import jdk.internal.crac.JDKResource;
+import jdk.internal.crac.mirror.Context;
+import jdk.internal.crac.mirror.Resource;
+
 import java.nio.channels.spi.AsynchronousChannelProvider;
 import java.io.IOException;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -51,7 +57,7 @@ final class EPollPort
     private static final int ENOENT     = 2;
 
     // epoll file descriptor
-    private final int epfd;
+    private int epfd;
 
     // address of the poll array passed to epoll_wait
     private final long address;
@@ -84,6 +90,74 @@ final class EPollPort
     private final ArrayBlockingQueue<Event> queue;
     private final Event NEED_TO_POLL = new Event(null, 0);
     private final Event EXECUTE_TASK_OR_SHUTDOWN = new Event(null, 0);
+    private final Event CHECKPOINT = new Event(null, 0);
+
+    private final CRaCResource resource = new CRaCResource();
+
+    private class CRaCResource implements JDKResource {
+        private volatile Phaser phaser;
+        private AtomicInteger counter;
+        private IOException restoreException;
+
+        @Override
+        public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+            int threads = threadCount();
+            if (threads == 0) {
+                throw new IllegalStateException();
+            }
+            phaser = new Phaser(threadCount() + 1);
+            counter = new AtomicInteger(threads);
+            for (int i = 0; i < threads; ++i) {
+                // cannot use executeOnHandlerTask as taskQueue is null in a non-fixed threadpool
+                queue.offer(CHECKPOINT);
+            }
+            // we call wakeup only once since there's only one thread actually polling
+            wakeup();
+            phaser.arriveAndAwaitAdvance();
+        }
+
+        private void processCheckpoint() {
+            boolean isLast = counter.decrementAndGet() == 0;
+            if (isLast) {
+                // This code is closing epfd even if there are FDs registered in that; the existence
+                // of these FDs will cause their own exceptions on checkpoint.
+                // If these are ignored by FD policies it's up to the user to deal with missed registrations.
+                try { FileDispatcherImpl.closeIntFD(epfd); } catch (IOException ioe) { }
+                try { FileDispatcherImpl.closeIntFD(sp[0]); } catch (IOException ioe) { }
+                try { FileDispatcherImpl.closeIntFD(sp[1]); } catch (IOException ioe) { }
+            }
+            phaser.arriveAndAwaitAdvance();
+            phaser.arriveAndAwaitAdvance();
+            if (isLast) {
+                try {
+                    epfd = EPoll.create();
+                    long fds = IOUtil.makePipe(true);
+                    sp[0] = (int) (fds >>> 32);
+                    sp[1] = (int) fds;
+                } catch (IOException e) {
+                    restoreException = e;
+                }
+            }
+            phaser.arriveAndAwaitAdvance();
+        }
+
+        @Override
+        public void afterRestore(Context<? extends Resource> context) throws Exception {
+            phaser.arriveAndAwaitAdvance();
+            phaser.arriveAndAwaitAdvance();
+            counter = null;
+            phaser = null;
+            if (restoreException != null) {
+                Exception e = restoreException;
+                restoreException = null;
+                throw e;
+            }
+        }
+
+        public boolean isCheckpoint() {
+            return phaser != null;
+        }
+    }
 
     EPollPort(AsynchronousChannelProvider provider, ThreadPool pool)
         throws IOException
@@ -110,6 +184,8 @@ final class EPollPort
         // threads polls
         this.queue = new ArrayBlockingQueue<>(MAX_EPOLL_EVENTS);
         this.queue.offer(NEED_TO_POLL);
+
+        Core.Priority.EPOLLSELECTOR.getContext().register(resource);
     }
 
     EPollPort start() {
@@ -289,6 +365,11 @@ final class EPollPort
 
                     // handle wakeup to execute task or shutdown
                     if (ev == EXECUTE_TASK_OR_SHUTDOWN) {
+                        if (resource.isCheckpoint()) {
+                            // the wakeup was caused by checkpoint, but there might not be any taskQueue
+                            // and no task. It is not a shutdown, though.
+                            continue;
+                        }
                         Runnable task = pollTask();
                         if (task == null) {
                             // shutdown request
@@ -297,6 +378,9 @@ final class EPollPort
                         // run task (may throw error/exception)
                         replaceMe = true;
                         task.run();
+                        continue;
+                    } else if (ev == CHECKPOINT) {
+                        resource.processCheckpoint();
                         continue;
                     }
 

--- a/src/java.base/share/classes/java/net/DatagramSocketImpl.java
+++ b/src/java.base/share/classes/java/net/DatagramSocketImpl.java
@@ -76,6 +76,11 @@ public abstract class DatagramSocketImpl implements SocketOptions {
         }
 
         @Override
+        protected boolean isListening() {
+            return false;
+        }
+
+        @Override
         protected void closeBeforeCheckpoint() {
             disconnect();
         }

--- a/src/java.base/share/classes/java/net/SocketImpl.java
+++ b/src/java.base/share/classes/java/net/SocketImpl.java
@@ -75,7 +75,7 @@ public abstract class SocketImpl implements SocketOptions {
     protected int localport;
 
     @SuppressWarnings("unused")
-    private final JDKSocketResource resource = new JDKSocketResource(this) {
+    private final JDKSocketResource resource = new JDKSocketResource(SocketImpl.this) {
         @Override
         protected FileDescriptor getFD() {
             return fd;
@@ -91,11 +91,39 @@ public abstract class SocketImpl implements SocketOptions {
             return new InetSocketAddress(address, port);
         }
 
+        // We cannot override this in subclass because SocketImpl is public and resource factory method
+        // would expose JDKSocketResource outside JDK.
+        @Override
+        protected boolean isListening() {
+            return SocketImpl.this.isListening();
+        }
+
         @Override
         protected void closeBeforeCheckpoint() throws IOException {
             close();
         }
+
+        @Override
+        protected void reopenAfterRestore() throws IOException {
+            SocketImpl.this.reopenAfterRestore();
+        }
     };
+
+    /**
+     * Is this socket listening (server)?
+     * @return True if listening
+     */
+    protected boolean isListening() {
+        return false;
+    }
+
+    /**
+     * Used only by CRaC
+     * @throws IOException When cannot be reopened
+     */
+    protected void reopenAfterRestore() throws IOException {
+        throw new UnsupportedOperationException("Reopen not implemented");
+    }
 
     /**
      * Initialize a new instance of this class

--- a/src/java.base/share/classes/java/net/SocketImpl.java
+++ b/src/java.base/share/classes/java/net/SocketImpl.java
@@ -75,7 +75,7 @@ public abstract class SocketImpl implements SocketOptions {
     protected int localport;
 
     @SuppressWarnings("unused")
-    private final JDKSocketResource resource = new JDKSocketResource(SocketImpl.this) {
+    private final JDKSocketResource resource = new JDKSocketResource(this) {
         @Override
         protected FileDescriptor getFD() {
             return fd;

--- a/src/java.base/share/classes/java/nio/channels/spi/AbstractInterruptibleChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/AbstractInterruptibleChannel.java
@@ -131,6 +131,16 @@ public abstract class AbstractInterruptibleChannel
     }
 
     /**
+     * Used only internally by CRaC
+     */
+    protected final void setReopened() {
+        synchronized (closeLock) {
+            assert closed;
+            closed = false;
+        }
+    }
+
+    /**
      * Closes this channel.
      *
      * <p> This method is invoked by the {@link #close close} method in order

--- a/src/java.base/share/classes/jdk/internal/crac/JDKSocketResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKSocketResource.java
@@ -38,10 +38,7 @@ public abstract class JDKSocketResource extends JDKSocketResourceBase {
         var remoteMatcher = getMatcher(remote, "remoteAddress", "remotePort", "remotePath");
         Predicate<Map<String, String>> listenMatcher = params -> {
             String cfgListening = params.get("listening");
-            if (cfgListening == null || "*".equals(cfgListening)) {
-                return true;
-            }
-            return Boolean.parseBoolean(cfgListening) == isListening();
+            return cfgListening == null || Boolean.parseBoolean(cfgListening) == isListening();
         };
         return OpenResourcePolicies.find(isRestore, OpenResourcePolicies.SOCKET,
                 params -> localMatcher.test(params) && remoteMatcher.test(params) && listenMatcher.test(params));

--- a/src/java.base/share/classes/jdk/internal/crac/JDKSocketResourceBase.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKSocketResourceBase.java
@@ -139,9 +139,8 @@ public abstract class JDKSocketResourceBase extends JDKFdResource {
             OpenResourcePolicies.Policy policy = findPolicy(true);
             String action = policy == null ? "error" : policy.action;
             try {
-                // FIXME: implement
                 if (action.equals("reopen")) {
-                    throw new UnsupportedOperationException("Policy " + policy.type + " not implemented");
+                    reopenAfterRestore();
                 }
             } finally {
                 reset();
@@ -150,4 +149,8 @@ public abstract class JDKSocketResourceBase extends JDKFdResource {
     }
 
     protected abstract void reset();
+
+    protected void reopenAfterRestore() throws IOException {
+        throw new UnsupportedOperationException("Reopen not implemented on sockets");
+    }
 }

--- a/src/java.base/share/classes/jdk/internal/crac/OpenResourcePolicies.java
+++ b/src/java.base/share/classes/jdk/internal/crac/OpenResourcePolicies.java
@@ -75,7 +75,7 @@ public class OpenResourcePolicies {
         try {
             for (String line : Files.readAllLines(f.toPath())) {
                 line = line.trim();
-                if (line.startsWith("#")) {
+                if (line.startsWith("#") || line.isEmpty()) {
                     continue;
                 } else if ("---".equals(line)) {
                     if (type == null && action == null && params.isEmpty()) {

--- a/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
@@ -64,11 +64,14 @@ public class Core {
     private static native Object[] checkpointRestore0(int[] fdArr, Object[] objArr, boolean dryRun, long jcmdStream);
     private static final Object checkpointRestoreLock = new Object();
     private static boolean checkpointInProgress = false;
+    private static int dryRunsCounter = -1;
 
     private static class FlagsHolder {
         private FlagsHolder() {}
         public static final boolean TRACE_STARTUP_TIME =
             Boolean.getBoolean("jdk.crac.trace-startup-time");
+        public static final boolean DRY_RUNS_INTERRUPTED = Boolean.getBoolean("jdk.crac.dry-runs.interrupted");
+        public static final int DRY_RUNS = Integer.getInteger("jdk.crac.dry-runs", 0);
     }
 
     private static final Context<Resource> globalContext = GlobalContext.createGlobalContextImpl();
@@ -149,6 +152,31 @@ public class Core {
         // - FileDescriptors for resources (sun.util.calendar.ZoneInfoFile)
         LoggerContainer.info("Starting checkpoint");
         LoggerContainer.debug("at epoch:{0}", System.currentTimeMillis());
+
+        if (dryRunsCounter < 0) {
+            dryRunsCounter = FlagsHolder.DRY_RUNS;
+        }
+        while (dryRunsCounter > 0) {
+            jdk.internal.crac.Core.setClaimedFDs(new ClaimedFDs());
+            try {
+                globalContext.beforeCheckpoint(null);
+            } catch (CheckpointException ce) {
+                checkpointException.handle(ce);
+            }
+            jdk.internal.crac.Core.setClaimedFDs(null);
+            try {
+                globalContext.afterRestore(null);
+            } catch (RestoreException re) {
+                checkpointException.resuppress(re);
+            }
+            dryRunsCounter--;
+            if (FlagsHolder.DRY_RUNS_INTERRUPTED) {
+                checkpointException.get().addSuppressed(new RuntimeException("Dry-run executed, not continuing with checkpoint"));
+            }
+            // We use only checkpoint exception type because effectively even afterRestore() runs
+            // before checkpoint. The exact source is clear from stack trace
+            checkpointException.throwIfAny();
+        }
 
         ClaimedFDs claimedFDs = new ClaimedFDs();
 

--- a/src/java.base/share/classes/sun/nio/ch/AsynchronousServerSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/AsynchronousServerSocketChannelImpl.java
@@ -169,8 +169,7 @@ abstract class AsynchronousServerSocketChannelImpl
         implReopen();
     }
 
-    protected void implReopen() throws IOException {
-    }
+    protected abstract void implReopen() throws IOException;
 
     /**
      * Invoked by accept to accept connection

--- a/src/java.base/share/classes/sun/nio/ch/AsynchronousServerSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/AsynchronousServerSocketChannelImpl.java
@@ -70,6 +70,9 @@ abstract class AsynchronousServerSocketChannelImpl
     // set true when exclusive binding is on and SO_REUSEADDR is emulated
     private boolean isReuseAddress;
 
+    // last backlog used for bind(...)
+    private int backlog;
+
     AsynchronousServerSocketChannelImpl(AsynchronousChannelGroupImpl group) {
         super(group.provider());
         this.fd = Net.serverSocket(true);
@@ -90,8 +93,27 @@ abstract class AsynchronousServerSocketChannelImpl
             }
 
             @Override
+            protected boolean isListening() {
+                return true;
+            }
+
+            @Override
             protected void closeBeforeCheckpoint() throws IOException {
                 close();
+            }
+
+            @Override
+            protected void reopenAfterRestore() throws IOException {
+                FileDescriptor newfd = Net.serverSocket(true);
+                IOUtil.setfdVal(fd, IOUtil.fdVal(newfd));
+                reopen();
+                synchronized (stateLock) {
+                    SocketAddress local = localAddress;
+                    if (local != null) {
+                        localAddress = null;
+                        bind(local, backlog);
+                    }
+                }
             }
         };
     }
@@ -134,6 +156,20 @@ abstract class AsynchronousServerSocketChannelImpl
             closeLock.writeLock().unlock();
         }
         implClose();
+    }
+
+    private void reopen() {
+        closeLock.writeLock().lock();
+        try {
+            assert(closed);
+            closed = false;
+        } finally {
+            closeLock.writeLock().unlock();
+        }
+        implReopen();
+    }
+
+    protected void implReopen() {
     }
 
     /**
@@ -182,7 +218,8 @@ abstract class AsynchronousServerSocketChannelImpl
                     throw new AlreadyBoundException();
                 NetHooks.beforeTcpBind(fd, isa.getAddress(), isa.getPort());
                 Net.bind(fd, isa.getAddress(), isa.getPort());
-                Net.listen(fd, backlog < 1 ? 50 : backlog);
+                this.backlog = backlog < 1 ? 50 : backlog;
+                Net.listen(fd, this.backlog);
                 localAddress = Net.localAddress(fd);
             }
         } finally {

--- a/src/java.base/share/classes/sun/nio/ch/AsynchronousServerSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/AsynchronousServerSocketChannelImpl.java
@@ -158,7 +158,7 @@ abstract class AsynchronousServerSocketChannelImpl
         implClose();
     }
 
-    private void reopen() {
+    private void reopen() throws IOException {
         closeLock.writeLock().lock();
         try {
             assert(closed);
@@ -169,7 +169,7 @@ abstract class AsynchronousServerSocketChannelImpl
         implReopen();
     }
 
-    protected void implReopen() {
+    protected void implReopen() throws IOException {
     }
 
     /**

--- a/src/java.base/share/classes/sun/nio/ch/AsynchronousSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/AsynchronousSocketChannelImpl.java
@@ -623,6 +623,11 @@ abstract class AsynchronousSocketChannelImpl
         }
 
         @Override
+        protected boolean isListening() {
+            return false;
+        }
+
+        @Override
         protected void closeBeforeCheckpoint() throws IOException {
             close();
         }

--- a/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
@@ -1985,6 +1985,11 @@ class DatagramChannelImpl
         }
 
         @Override
+        protected boolean isListening() {
+            return false;
+        }
+
+        @Override
         protected void closeBeforeCheckpoint() throws IOException {
             close();
         }

--- a/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
@@ -1636,6 +1636,11 @@ class SocketChannelImpl
         }
 
         @Override
+        protected boolean isListening() {
+            return false;
+        }
+
+        @Override
         protected void closeBeforeCheckpoint() throws IOException {
             close();
         }

--- a/src/java.base/unix/classes/sun/nio/ch/UnixAsynchronousServerSocketChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/UnixAsynchronousServerSocketChannelImpl.java
@@ -43,7 +43,7 @@ class UnixAsynchronousServerSocketChannelImpl
     private static final NativeDispatcher nd = new SocketDispatcher();
 
     private final Port port;
-    private final int fdVal;
+    private int fdVal;
 
     // flag to indicate an accept is outstanding
     private final AtomicBoolean accepting = new AtomicBoolean();
@@ -110,6 +110,12 @@ class UnixAsynchronousServerSocketChannelImpl
             // invoke by submitting task rather than directly
             Invoker.invokeIndirectly(this, handler, att, null, x);
         }
+    }
+
+    @Override
+    protected void implReopen() {
+        fdVal = IOUtil.fdVal(fd);
+        port.register(fdVal, this);
     }
 
     @Override

--- a/test/jdk/jdk/crac/fileDescriptors/ReopenListeningAsynchronousSocketChannelTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/ReopenListeningAsynchronousSocketChannelTest.java
@@ -35,7 +35,6 @@ import java.util.concurrent.Future;
  * @test
  * @library /test/lib
  * @modules java.base/jdk.internal.crac:+open
- * @requires (os.family == "linux")
  * @build FDPolicyTestBase
  * @build ReopenListeningTestBase
  * @build ReopenListeningAsynchronousSocketChannelTest

--- a/test/jdk/jdk/crac/fileDescriptors/ReopenListeningAsynchronousSocketChannelTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/ReopenListeningAsynchronousSocketChannelTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.crac.CracTest;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.channels.AsynchronousServerSocketChannel;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+
+/**
+ * @test
+ * @library /test/lib
+ * @modules java.base/jdk.internal.crac:+open
+ * @requires (os.family == "linux")
+ * @build FDPolicyTestBase
+ * @build ReopenListeningTestBase
+ * @build ReopenListeningAsynchronousSocketChannelTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class ReopenListeningAsynchronousSocketChannelTest extends ReopenListeningTestBase<AsynchronousServerSocketChannel> implements CracTest {
+    @Override
+    protected AsynchronousServerSocketChannel createServer() throws IOException {
+        return AsynchronousServerSocketChannel.open().bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+    }
+
+    @Override
+    protected void testConnection(AsynchronousServerSocketChannel serverSocket) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        Thread serverThread = new Thread(() -> {
+            try {
+                Future<AsynchronousSocketChannel> socket = serverSocket.accept();
+                socket.get();
+                latch.countDown();
+                // the socket leaks in here but for some reason it does not leave the FD open
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        serverThread.setDaemon(true);
+        serverThread.start();
+        AsynchronousSocketChannel clientSocket = AsynchronousSocketChannel.open();
+        Future<Void> connectFuture = clientSocket.connect(serverSocket.getLocalAddress());
+        connectFuture.get();
+        latch.await();
+    }
+}

--- a/test/jdk/jdk/crac/fileDescriptors/ReopenListeningSocketChannelTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/ReopenListeningSocketChannelTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.crac.CracTest;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * @test
+ * @library /test/lib
+ * @modules java.base/jdk.internal.crac:+open
+ * @requires (os.family == "linux")
+ * @build FDPolicyTestBase
+ * @build ReopenListeningTestBase
+ * @build ReopenListeningSocketChannelTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class ReopenListeningSocketChannelTest extends ReopenListeningTestBase<ServerSocketChannel> implements CracTest {
+    @Override
+    protected ServerSocketChannel createServer() throws IOException {
+        return ServerSocketChannel.open().bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+    }
+
+    @Override
+    protected void testConnection(ServerSocketChannel serverSocket) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        Thread serverThread = new Thread(() -> {
+            try {
+                SocketChannel socket = serverSocket.accept();
+                latch.countDown();
+                // the socket leaks in here but for some reason it does not leave the FD open
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        });
+        serverThread.setDaemon(true);
+        serverThread.start();
+        SocketChannel clientSocket = SocketChannel.open(serverSocket.getLocalAddress());
+        Asserts.assertTrue(clientSocket.isConnected());
+        latch.await();
+    }
+}

--- a/test/jdk/jdk/crac/fileDescriptors/ReopenListeningSocketChannelTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/ReopenListeningSocketChannelTest.java
@@ -35,7 +35,6 @@ import java.util.concurrent.CountDownLatch;
  * @test
  * @library /test/lib
  * @modules java.base/jdk.internal.crac:+open
- * @requires (os.family == "linux")
  * @build FDPolicyTestBase
  * @build ReopenListeningTestBase
  * @build ReopenListeningSocketChannelTest

--- a/test/jdk/jdk/crac/fileDescriptors/ReopenListeningSocketTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/ReopenListeningSocketTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.crac.CracTest;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * @test
+ * @library /test/lib
+ * @modules java.base/jdk.internal.crac:+open
+ * @requires (os.family == "linux")
+ * @build FDPolicyTestBase
+ * @build ReopenListeningTestBase
+ * @build ReopenListeningSocketTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class ReopenListeningSocketTest extends ReopenListeningTestBase<ServerSocket> implements CracTest {
+    @Override
+    protected ServerSocket createServer() throws IOException {
+        return new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+    }
+
+    @Override
+    protected void testConnection(ServerSocket serverSocket) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        Thread serverThread = new Thread(() -> {
+            try {
+                Socket socket = serverSocket.accept();
+                latch.countDown();
+                // the socket leaks in here but for some reason it does not leave the FD open
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        });
+        serverThread.setDaemon(true);
+        serverThread.start();
+        Socket clientSocket = new Socket(InetAddress.getLoopbackAddress(), serverSocket.getLocalPort());
+        Asserts.assertTrue(clientSocket.isConnected());
+        latch.await();
+    }
+
+}

--- a/test/jdk/jdk/crac/fileDescriptors/ReopenListeningSocketTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/ReopenListeningSocketTest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.CountDownLatch;
  * @test
  * @library /test/lib
  * @modules java.base/jdk.internal.crac:+open
- * @requires (os.family == "linux")
  * @build FDPolicyTestBase
  * @build ReopenListeningTestBase
  * @build ReopenListeningSocketTest

--- a/test/jdk/jdk/crac/fileDescriptors/ReopenListeningTestBase.java
+++ b/test/jdk/jdk/crac/fileDescriptors/ReopenListeningTestBase.java
@@ -24,6 +24,7 @@
 import jdk.crac.Core;
 import jdk.internal.crac.OpenResourcePolicies;
 import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracEngine;
 import jdk.test.lib.crac.CracTest;
 
 import java.io.IOException;
@@ -34,7 +35,6 @@ import java.nio.file.Path;
 public abstract class ReopenListeningTestBase<ServerType> extends FDPolicyTestBase implements CracTest {
     @Override
     public void test() throws Exception {
-        String loopback = InetAddress.getLoopbackAddress().getHostAddress();
         Path config = writeConfig("""
                 type: SOCKET
                 family: ip
@@ -44,12 +44,13 @@ public abstract class ReopenListeningTestBase<ServerType> extends FDPolicyTestBa
                 type: SOCKET
                 family: ip
                 action: close
-                """.replace("$loopback", loopback));
+                """);
         try {
             new CracBuilder()
+                    .engine(CracEngine.SIMULATE)
                     .javaOption(OpenResourcePolicies.PROPERTY, config.toString())
                     .javaOption("jdk.crac.collect-fd-stacktraces", "true")
-                    .doCheckpointAndRestore();
+                    .startCheckpoint().waitForSuccess();
         } finally {
             Files.deleteIfExists(config);
         }

--- a/test/jdk/jdk/crac/fileDescriptors/ReopenListeningTestBase.java
+++ b/test/jdk/jdk/crac/fileDescriptors/ReopenListeningTestBase.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.internal.crac.OpenResourcePolicies;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public abstract class ReopenListeningTestBase<ServerType> extends FDPolicyTestBase implements CracTest {
+    @Override
+    public void test() throws Exception {
+        String loopback = InetAddress.getLoopbackAddress().getHostAddress();
+        Path config = writeConfig("""
+                type: SOCKET
+                family: ip
+                listening: true
+                action: reopen
+                ---
+                type: SOCKET
+                family: ip
+                action: close
+                """.replace("$loopback", loopback));
+        try {
+            new CracBuilder()
+                    .javaOption(OpenResourcePolicies.PROPERTY, config.toString())
+                    .javaOption("jdk.crac.collect-fd-stacktraces", "true")
+                    .doCheckpointAndRestore();
+        } finally {
+            Files.deleteIfExists(config);
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        ServerType serverSocket = createServer();
+        testConnection(serverSocket);
+        Core.checkpointRestore();
+        testConnection(serverSocket);
+    }
+
+    protected abstract ServerType createServer() throws IOException;
+
+    protected abstract void testConnection(ServerType serverSocket) throws Exception;
+}


### PR DESCRIPTION
Adds additional filtering option for `type: SOCKET` in OpenResourcePolicies: `listening: true` which is true for common server sockets. 
With `action: reopen` these implement automatic close on checkpoint and reopening on restore, using the same local address (this obviously won't work well if the restore happens on a machine that does not have the IP used before checkpoint).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8349819](https://bugs.openjdk.org/browse/JDK-8349819): [CRaC] Support FD policy reopen on listening socket (**Enhancement** - P4)


### Reviewers
 * [Timofei Pushkin](https://openjdk.org/census#tpushkin) (@TimPushkin - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/204/head:pull/204` \
`$ git checkout pull/204`

Update a local copy of the PR: \
`$ git checkout pull/204` \
`$ git pull https://git.openjdk.org/crac.git pull/204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 204`

View PR using the GUI difftool: \
`$ git pr show -t 204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/204.diff">https://git.openjdk.org/crac/pull/204.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/204#issuecomment-2659843922)
</details>
