### PR TITLE
8350569: [CRaC] Log level of 'crac' cannot be changed on checkpoint

### DIFF
--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -120,6 +120,10 @@ void LogConfiguration::initialize(jlong vm_start_time) {
   for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     ts->set_output_level(StdoutLog, LogLevel::Default);
   }
+
+  // Default log level for 'crac' is Info
+  precond(!log_is_enabled(Info, crac)); // If this fails, the below can be removed
+  LogTagSetMapping<LOG_TAGS(crac)>::tagset().set_output_level(StdoutLog, LogLevel::Info);
 }
 
 void LogConfiguration::finalize() {

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -377,9 +377,6 @@ void VM_Crac::doit() {
 
 
 bool crac::prepare_checkpoint() {
-  // Automatically configure log level for 'crac' to Info
-  LogTagSetMapping<LOG_TAGS(crac)>::tagset().set_output_level(LogConfiguration::StdoutLog, LogLevelType::Info);
-
   struct stat st;
 
   if (0 == os::stat(CRaCCheckpointTo, &st)) {

--- a/test/jdk/jdk/crac/CracLogTest.java
+++ b/test/jdk/jdk/crac/CracLogTest.java
@@ -36,9 +36,7 @@ import jdk.test.lib.crac.CracTestArg;
  * @run driver jdk.test.lib.crac.CracTest not-set
  * @run driver jdk.test.lib.crac.CracTest off
  * @run driver jdk.test.lib.crac.CracTest error
- * @run driver jdk.test.lib.crac.CracTest warning
  * @run driver jdk.test.lib.crac.CracTest info
- * @run driver jdk.test.lib.crac.CracTest debug
  * @run driver jdk.test.lib.crac.CracTest trace
  */
 public class CracLogTest implements CracTest {

--- a/test/jdk/jdk/crac/CracLogTest.java
+++ b/test/jdk/jdk/crac/CracLogTest.java
@@ -58,9 +58,9 @@ public class CracLogTest implements CracTest {
         }
         final var out = builder.startCheckpoint().waitForSuccess().outputAnalyzer();
 
-        final var checkpointLogMsgLevel = logLevelStrToInt(CHECKPOINT_LOG_LEVEL);
+        final var checkpointLogLevel = logLevelStrToInt(CHECKPOINT_LOG_LEVEL);
         final var selectedLogLevel = logLevelStrToInt(logLevelStr);
-        if (checkpointLogMsgLevel <= selectedLogLevel) {
+        if (checkpointLogLevel <= selectedLogLevel) {
             out.shouldContain(CHECKPOINT_LOG_MSG);
         } else {
             out.shouldNotContain(CHECKPOINT_LOG_MSG);

--- a/test/jdk/jdk/crac/CracLogTest.java
+++ b/test/jdk/jdk/crac/CracLogTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Core;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracEngine;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+
+/**
+ * @test
+ * @bug 8350569
+ * @summary Checks that log set 'crac' can be manipulated via VM options.
+ * @library /test/lib
+ * @build CracLogTest
+ * @run driver jdk.test.lib.crac.CracTest not-set
+ * @run driver jdk.test.lib.crac.CracTest off
+ * @run driver jdk.test.lib.crac.CracTest error
+ * @run driver jdk.test.lib.crac.CracTest warning
+ * @run driver jdk.test.lib.crac.CracTest info
+ * @run driver jdk.test.lib.crac.CracTest debug
+ * @run driver jdk.test.lib.crac.CracTest trace
+ */
+public class CracLogTest implements CracTest {
+    private static final String CHECKPOINT_LOG_LEVEL = "info";
+    private static final String CHECKPOINT_LOG_MSG = "Checkpoint ...";
+
+    @CracTestArg(0)
+    String logLevelStr;
+
+    @Override
+    public void test() throws Exception {
+        var builder = new CracBuilder()
+                .engine(CracEngine.SIMULATE)
+                .captureOutput(true);
+        if (!logLevelStr.equals("not-set")) {
+            builder = builder.vmOption("-Xlog:crac=" + logLevelStr);
+        }
+        final var out = builder.startCheckpoint().waitForSuccess().outputAnalyzer();
+
+        final var checkpointLogMsgLevel = logLevelStrToInt(CHECKPOINT_LOG_LEVEL);
+        final var selectedLogLevel = logLevelStrToInt(logLevelStr);
+        if (checkpointLogMsgLevel <= selectedLogLevel) {
+            out.shouldContain(CHECKPOINT_LOG_MSG);
+        } else {
+            out.shouldNotContain(CHECKPOINT_LOG_MSG);
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Core.checkpointRestore();
+    }
+
+    private static int logLevelStrToInt(String str) {
+        return switch (str) {
+            case "not-set" -> logLevelStrToInt(CHECKPOINT_LOG_LEVEL);
+            case "off" -> 0;
+            case "error" -> 1;
+            case "warning" -> 2;
+            case "info" -> 3;
+            case "debug" -> 4;
+            case "trace" -> 5;
+            default -> throw new IllegalArgumentException("Not a log level: " + str);
+        };
+    }
+}


### PR DESCRIPTION
Fixes the issue by moving the change of the default 'crac' log set level before CLI arguments are parsed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8350569](https://bugs.openjdk.org/browse/JDK-8350569): [CRaC] Log level of 'crac' cannot be changed on checkpoint (**Bug** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer) ⚠️ Review applies to [5bdc9f87](https://git.openjdk.org/crac/pull/205/files/5bdc9f87b8ef30087aff5738cf93865b8382bfe5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/205/head:pull/205` \
`$ git checkout pull/205`

Update a local copy of the PR: \
`$ git checkout pull/205` \
`$ git pull https://git.openjdk.org/crac.git pull/205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 205`

View PR using the GUI difftool: \
`$ git pr show -t 205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/205.diff">https://git.openjdk.org/crac/pull/205.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/205#issuecomment-2678345437)
</details>
