### PR TITLE
8351701: [CRaC] CRaCEngineOptions=help cannot be used with CRaCRestoreFrom

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2261,6 +2261,11 @@ bool Arguments::parse_options_for_restore(const JavaVMInitArgs* args) {
 
   postcond(CRaCRestoreFrom != nullptr);
 
+  if (CRaCEngineOptions && strcmp(CRaCEngineOptions, "help") == 0) {
+    crac::print_engine_info_and_exit(); // Does not return on success
+    return false;
+  }
+
   return true;
 }
 

--- a/test/jdk/jdk/crac/CracEngineOptionsTest.java
+++ b/test/jdk/jdk/crac/CracEngineOptionsTest.java
@@ -157,13 +157,9 @@ public class CracEngineOptionsTest {
 
     @Test
     public void test_options_help() throws Exception {
-        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-                "-XX:CRaCEngineOptions=help");
-        OutputAnalyzer out = new OutputAnalyzer(pb.start());
-        out.shouldHaveExitValue(0);
-        out.stdoutShouldContain("Configuration options:");
-        out.stderrShouldBeEmpty();
-        out.shouldNotContain("CRaC engine option:");
+        testHelp();
+        testHelp("-XX:CRaCCheckpointTo=cr");
+        testHelp("-XX:CRaCRestoreFrom=cr");
     }
 
     private void test(String engine) throws Exception {
@@ -199,5 +195,18 @@ public class CracEngineOptionsTest {
         for (String text : notExpectedTexts) {
             out.shouldNotContain(text);
         }
+    }
+
+    private static void testHelp(String... opts) throws Exception {
+        List<String> optsList = new ArrayList(Arrays.asList(opts));
+        optsList.add("-XX:CRaCEngineOptions=help");
+        optsList.add("-Xlog:crac=debug");
+        // Limited to not get non-restore-settable flags with CRaCRestoreFrom
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(optsList);
+        OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        out.shouldHaveExitValue(0);
+        out.stdoutShouldContain("Configuration options:");
+        out.stderrShouldBeEmpty();
+        out.shouldNotContain("CRaC engine option:");
     }
 }

--- a/test/jdk/jdk/crac/CracEngineOptionsTest.java
+++ b/test/jdk/jdk/crac/CracEngineOptionsTest.java
@@ -120,6 +120,9 @@ public class CracEngineOptionsTest {
                 "CRaC engine failed to configure: '' = ''");
 
         if (Platform.isLinux()) {
+            test("criuengine", "help,keep_running=true", 1,
+                    "unknown configure option: help",
+                    "CRaC engine failed to configure: 'help' = ''");
             test("criuengine", "direct_map=not a bool", 1,
                     "CRaC engine failed to configure: 'direct_map' = 'not a bool'");
         }
@@ -153,6 +156,17 @@ public class CracEngineOptionsTest {
                     "CRaC engine failed to configure: '--arg3' = ''"
                 ),
                 Arrays.asList("specified multiple times"));
+
+        if (Platform.isLinux()) {
+            test("criuengine",
+                    Arrays.asList("help", "args=-v4"),
+                    1,
+                    Arrays.asList(
+                        "unknown configure option: help",
+                        "CRaC engine failed to configure: 'help' = ''"
+                    ),
+                    Collections.emptyList());
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes the issue and adds a regression test for it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8351701](https://bugs.openjdk.org/browse/JDK-8351701): [CRaC] CRaCEngineOptions=help cannot be used with CRaCRestoreFrom (**Bug** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/211/head:pull/211` \
`$ git checkout pull/211`

Update a local copy of the PR: \
`$ git checkout pull/211` \
`$ git pull https://git.openjdk.org/crac.git pull/211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 211`

View PR using the GUI difftool: \
`$ git pr show -t 211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/211.diff">https://git.openjdk.org/crac/pull/211.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/211#issuecomment-2715373622)
</details>
