### PR TITLE
JDK-8352394: [CRaC] AOT class linking cannot archive jdk.internal.crac.Core$Priority

### DIFF
--- a/src/java.base/share/classes/jdk/internal/crac/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/Core.java
@@ -68,7 +68,7 @@ public class Core {
      *
      * Note: this is not a enum class to workaround CDS's inability to archive Reference objects,
      * reachable from some of these contexts, which leads to failures when CDS's AOTClassLinking is
-     * enabled (see JDK-XXXXXXX).
+     * enabled (see JDK-8352394).
      */
     public static class Priority {
         public static final Priority FILE_DESCRIPTORS = new Priority(new BlockingOrderedContext<>());

--- a/src/java.base/share/classes/jdk/internal/crac/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/Core.java
@@ -65,21 +65,25 @@ public class Core {
      * Resources of the same priority will be handled according the context supplied to the priority.
      *
      * Most resources should use priority NORMAL (the lowest priority).
+     *
+     * Note: this is not a enum class to workaround CDS's inability to archive Reference objects,
+     * reachable from some of these contexts, which leads to failures when CDS's AOTClassLinking is
+     * enabled (see JDK-XXXXXXX).
      */
-    public enum Priority {
-        FILE_DESCRIPTORS(new BlockingOrderedContext<>()),
-        PRE_FILE_DESCRIPTORS(new BlockingOrderedContext<>()),
+    public static class Priority {
+        public static final Priority FILE_DESCRIPTORS = new Priority(new BlockingOrderedContext<>());
+        public static final Priority PRE_FILE_DESCRIPTORS = new Priority(new BlockingOrderedContext<>());
         // We use OrderedContext to not cause failure when PlatformRecorder tries to
         // register itself when the recording is started from JfrResource.
-        JFR(new OrderedContext<>()),
-        CLEANERS(new BlockingOrderedContext<>()),
-        REFERENCE_HANDLER(new BlockingOrderedContext<>()),
-        SEEDER_HOLDER(new BlockingOrderedContext<>()),
-        SECURE_RANDOM(new BlockingOrderedContext<>()),
-        NATIVE_PRNG(new BlockingOrderedContext<>()),
-        EPOLLSELECTOR(new BlockingOrderedContext<>()),
-        SOCKETS(new BlockingOrderedContext<>()),
-        NORMAL(new BlockingOrderedContext<>());
+        public static final Priority JFR = new Priority(new OrderedContext<>());
+        public static final Priority CLEANERS = new Priority(new BlockingOrderedContext<>());
+        public static final Priority REFERENCE_HANDLER = new Priority(new BlockingOrderedContext<>());
+        public static final Priority SEEDER_HOLDER = new Priority(new BlockingOrderedContext<>());
+        public static final Priority SECURE_RANDOM = new Priority(new BlockingOrderedContext<>());
+        public static final Priority NATIVE_PRNG = new Priority(new BlockingOrderedContext<>());
+        public static final Priority EPOLLSELECTOR = new Priority(new BlockingOrderedContext<>());
+        public static final Priority SOCKETS = new Priority(new BlockingOrderedContext<>());
+        public static final Priority NORMAL = new Priority(new BlockingOrderedContext<>());
 
         private final Context<JDKResource> context;
         Priority(Context<JDKResource> context) {

--- a/src/java.base/share/classes/jdk/internal/jimage/BasicImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/BasicImageReader.java
@@ -176,18 +176,9 @@ public class BasicImageReader implements AutoCloseable {
             return;
         }
         try {
-            Object[] priorities = priorityClass.getEnumConstants();
-            if (priorities == null) {
-                return;
-            }
-            Object normalPriority = null;
-            for (int i = 0; i < priorities.length; ++i) {
-                if ("NORMAL".equals(priorities[i].toString())) {
-                    normalPriority = priorities[i];
-                }
-            }
+            Object normalPriority = priorityClass.getDeclaredField("NORMAL").get(null);
             if (normalPriority == null) {
-                throw new IllegalStateException();
+                throw new IllegalStateException("CRaC resource priority NORMAL is null");
             }
             Class<?> resourceClass = Class.forName("jdk.internal.crac.mirror.Resource");
             Method getContextMethod = priorityClass.getMethod("getContext");
@@ -198,7 +189,7 @@ public class BasicImageReader implements AutoCloseable {
         } catch (IllegalAccessException e) {
             // try to register via public API
             registerIfPublicCracPresent();
-        } catch (NoSuchMethodException | InvocationTargetException | ClassNotFoundException e) {
+        } catch (NoSuchFieldException | NoSuchMethodException | InvocationTargetException | ClassNotFoundException e) {
             throw new IllegalStateException(e);
         }
     }


### PR DESCRIPTION
Fixes (or rather works around) the incompatibility with AOT class linking by converting `jdk.internal.crac.Core$Priority` into a usual class. We can convert it back to enum when CDS either starts supporting archiving `Reference` objects or stops aborting the archiving when it stumbles upon an unsupported object.

An alternative approach would be to make CDS treat this particular enum class specially and don't archive it in initialized state but messing with CDS internals can lead to many conflicts later.

This is a draft because after implementing I noticed [JDK-8344140](https://github.com/openjdk/jdk/pull/22291) which restricted the set of AOT-initialized enums — maybe `jdk.internal.crac.Core$Priority` is not in the restricted set. We should get JDK-8344140 integrated as part of jdk 25+6 and see if the issue resolves itself.