### PR TITLE
8352408: [CRaC] Minor CRE API improvements

### DIFF
--- a/src/hotspot/share/include/crlib/crlib.h
+++ b/src/hotspot/share/include/crlib/crlib.h
@@ -51,7 +51,7 @@ typedef const struct crlib_extension crlib_extension_t;
 // configuration storage if it needs to keep it.
 struct crlib_api {
   // Initializes a configuration structure.
-  crlib_conf_t *(*create_conf)();
+  crlib_conf_t *(*create_conf)(void);
   // Destroys a configuration structure. The argument can be null.
   void (*destroy_conf)(crlib_conf_t *);
 

--- a/src/hotspot/share/include/crlib/crlib_restore_data.h
+++ b/src/hotspot/share/include/crlib/crlib_restore_data.h
@@ -37,13 +37,14 @@ extern "C" {
 struct crlib_restore_data {
   crlib_extension_t header;
 
-  // Called by the restoring application to pass data to the restored application.
-  // 'data' must not be null, size must be greater than 0.
-  // The engine may impose limits on the data size and return false if it is not accepted.
+  // Called by the restoring application to pass data to the restored application, returns true on
+  // success.
+  // If 'size' is positive 'data' must reference 'size' bytes of data. If 'size' is 0 any previously
+  // recorded restore data is cleared.
   bool (*set_restore_data)(crlib_conf_t *, const void *data, size_t size);
 
   // Called by the restored application to retrieve the data passed by the restoring application.
-  // Copies up to 'size' > 0 bytes of the data into 'buf' != null.
+  // Copies up to 'size' bytes of the data into 'buf' of appropriate size.
   // Returns the size of the data the engine has, in bytes — it can be more, equal to or less than
   // 'size'. Returned value of 0 represents an error.
   size_t (*get_restore_data)(crlib_conf_t *, void *buf, size_t size);

--- a/src/java.base/share/native/libcrexec/crexec.cpp
+++ b/src/java.base/share/native/libcrexec/crexec.cpp
@@ -231,23 +231,27 @@ public:
   void set_argv_action(const char *action) { _argv[ARGV_ACTION] = action; }
 
   bool set_restore_data(const void *data, size_t size) {
-    if (size != sizeof(_restore_data)) {
-      fprintf(stderr, CREXEC "unsupported size of restore data: %zu - only %zu is supported\n",
-              size, sizeof(_restore_data));
+    constexpr const size_t supported_size = sizeof(_restore_data);
+    if (size > 0 && size != supported_size) {
+      fprintf(stderr,
+              CREXEC "unsupported size of restore data: %zu was requested but only %zu is supported\n",
+              size, supported_size);
       return false;
     }
-    _restore_data = *static_cast<const int *>(data);
+    if (size > 0) {
+      memcpy(&_restore_data, data, size);
+    } else {
+      _restore_data = 0;
+    }
     return true;
   }
 
   size_t get_restore_data(void *buf, size_t size) {
-    if (size < sizeof(_restore_data)) {
-      fprintf(stderr, CREXEC "can only provide >= %zu bytes of restore data but %zu was requested\n",
-              sizeof(_restore_data), size);
-      return 0;
+    constexpr const size_t available_size = sizeof(_restore_data);
+    if (size > 0) {
+      memcpy(buf, &_restore_data, size < available_size ? size : available_size);
     }
-    *static_cast<int *>(buf) = _restore_data;
-    return sizeof(_restore_data);
+    return available_size;
   }
 
 private:


### PR DESCRIPTION
Minor fixups for CRE API:

`crexec` is also adopted to conform to the restore data API docs change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8352408](https://bugs.openjdk.org/browse/JDK-8352408): [CRaC] Minor CRE API improvements (**Bug** - P2)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/214/head:pull/214` \
`$ git checkout pull/214`

Update a local copy of the PR: \
`$ git checkout pull/214` \
`$ git pull https://git.openjdk.org/crac.git pull/214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 214`

View PR using the GUI difftool: \
`$ git pr show -t 214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/214.diff">https://git.openjdk.org/crac/pull/214.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/214#issuecomment-2736349885)
</details>
