### PR TITLE
8352413: [CRaC] crexec fails to pass some options when CRAC_CRIU_OPTS is already used

### DIFF
--- a/src/java.base/share/native/libcrexec/crexec.cpp
+++ b/src/java.base/share/native/libcrexec/crexec.cpp
@@ -490,7 +490,8 @@ public:
     bool opts_found = false;
     size_t opts_index = 0;
     for (; _env[opts_index] != nullptr; opts_index++) {
-      if (strcmp(_env[opts_index], CRAC_CRIU_OPTS) == 0 && _env[opts_index][CRAC_CRIU_OPTS_LEN] == '=') {
+      if (strncmp(_env[opts_index], CRAC_CRIU_OPTS, CRAC_CRIU_OPTS_LEN) == 0 &&
+          _env[opts_index][CRAC_CRIU_OPTS_LEN] == '=') {
         opts_found = true;
         break;
       }
@@ -540,7 +541,7 @@ static int checkpoint(crlib_conf_t *conf) {
 
   {
     Environment env;
-    if (!env.is_initialized()||
+    if (!env.is_initialized() ||
         (conf->keep_running().value && !env.append("CRAC_CRIU_LEAVE_RUNNING", ""))) {
       return -1;
     }

--- a/test/jdk/jdk/crac/VMOptionsTest.java
+++ b/test/jdk/jdk/crac/VMOptionsTest.java
@@ -42,8 +42,6 @@ import static jdk.test.lib.Asserts.*;
  * @requires (os.family == "linux")
  */
 public class VMOptionsTest implements CracTest {
-    private static final String LOG_FILE_NAME = "custom-log-file.log";
-
     @Override
     public void test() throws Exception {
         final String enginePath = Path.of(Utils.TEST_JDK, "lib", "criuengine").toString();
@@ -51,13 +49,9 @@ public class VMOptionsTest implements CracTest {
         CracBuilder builder = new CracBuilder();
 
         builder.vmOption("-XX:CRaCEngine=criuengine");
-        builder.vmOption("-XX:CRaCEngineOptions=args=-o " + LOG_FILE_NAME);
+        builder.vmOption("-XX:CRaCEngineOptions=args=-v1");
         builder.vmOption("-XX:NativeMemoryTracking=off");
         builder.doCheckpoint();
-
-        // Checking whether CRaCEngineOptions had an effect
-        final Path logFilePath = Path.of("cr", LOG_FILE_NAME);
-        assertTrue(logFilePath.toFile().exists(), logFilePath.toAbsolutePath() + " must exist");
 
         builder.clearVmOptions();
         builder.vmOption("-XX:CRaCEngine=" + enginePath);
@@ -81,7 +75,7 @@ public class VMOptionsTest implements CracTest {
             assertEquals(VMOption.Origin.VM_CREATION, engine1.getOrigin());
 
             VMOption engineOptions1 = bean.getVMOption("CRaCEngineOptions");
-            assertEquals("args=-o " + LOG_FILE_NAME, engineOptions1.getValue());
+            assertEquals("args=-v1", engineOptions1.getValue());
             assertEquals(VMOption.Origin.VM_CREATION, engineOptions1.getOrigin());
 
             VMOption checkpointTo1 = bean.getVMOption("CRaCCheckpointTo");
@@ -109,7 +103,7 @@ public class VMOptionsTest implements CracTest {
             assertEquals(VMOption.Origin.VM_CREATION, engine2.getOrigin());
 
             VMOption engineOptions2 = bean.getVMOption("CRaCEngineOptions");
-            assertEquals("args=-o " + LOG_FILE_NAME, engineOptions2.getValue());
+            assertEquals("args=-v1", engineOptions2.getValue());
             assertEquals(VMOption.Origin.VM_CREATION, engineOptions2.getOrigin());
 
             // Should change

--- a/test/jdk/jdk/crac/engineOptions/CracCriuOptsTest.java
+++ b/test/jdk/jdk/crac/engineOptions/CracCriuOptsTest.java
@@ -90,9 +90,10 @@ public class CracCriuOptsTest implements CracTest {
             s.matches("\\(\\d+.\\d+\\) pie: \\d+: Preadv 0x\\p{XDigit}+:\\d+\\.\\.\\. \\(\\d+ iovs\\) \\(mmap [01]\\)")
         ).toList();
         assertFalse(lines.isEmpty(), "At least one log line must match the expected pattern");
+
+        final var end = "(mmap " + (directMap ? "1" : "0") + ")";
         for (var s : lines) {
             // If this fails it means that direct_map is on when it should be off or vise-versa
-            final var end = "(mmap " + (directMap ? "1" : "0") + ")";
             assertTrue(s.endsWith(end), "Log line \"" + s + "\" must end with \"" + end + "\"");
         }
     }

--- a/test/jdk/jdk/crac/engineOptions/CracCriuOptsTest.java
+++ b/test/jdk/jdk/crac/engineOptions/CracCriuOptsTest.java
@@ -65,7 +65,7 @@ public class CracCriuOptsTest implements CracTest {
         // "direct_map=false" engine option is expected to add "--no-mmap-page-image" to
         // CRAC_CRIU_OPTS — this is what we'll check.
         // PREREQ_CHECK checks that the test's pre-requisite has not changed: when neither
-        // direct_map=true nor --no-mmap-page-image is specified direct mapping IS performed.
+        // direct_map=false nor --no-mmap-page-image is specified direct mapping IS performed.
         final boolean disableDirectMap = variant != Variant.PREREQ_CHECK;
         if (variant == Variant.ENVVAR_USED) {
             builder.env(CRAC_CRIU_OPTS, "-v");

--- a/test/jdk/jdk/crac/engineOptions/CracCriuOptsTest.java
+++ b/test/jdk/jdk/crac/engineOptions/CracCriuOptsTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import jdk.crac.*;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+
+import static jdk.test.lib.Asserts.*;
+
+/**
+ * @test Testing CracEngineOptions influenced by CRAC_CRIU_OPTS env variable.
+ * @requires (os.family == "linux")
+ * @library /test/lib
+ * @build CracCriuOptsTest
+ * @run driver jdk.test.lib.crac.CracTest PREREQ_CHECK
+ * @run driver jdk.test.lib.crac.CracTest NOT_SET
+ * @run driver jdk.test.lib.crac.CracTest ENVVAR_USED
+ * @run driver jdk.test.lib.crac.CracTest ALREADY_SET
+ */
+
+public class CracCriuOptsTest implements CracTest {
+    private static final String CRAC_CRIU_OPTS = "CRAC_CRIU_OPTS";
+    private static final Path LOG_FILE_PATH = Path.of("restore.log");
+
+    public enum Variant {
+        PREREQ_CHECK,
+        NOT_SET,
+        ENVVAR_USED,
+        ALREADY_SET
+    }
+
+    @CracTestArg
+    Variant variant;
+
+    @Override
+    public void test() throws Exception {
+        final CracBuilder builder = new CracBuilder();
+        builder.doCheckpoint();
+
+        // "direct_map=false" engine option is expected to add "--no-mmap-page-image" to
+        // CRAC_CRIU_OPTS — this is what we'll check.
+        // PREREQ_CHECK checks that the test's pre-requisite has not changed: when neither
+        // direct_map=true nor --no-mmap-page-image is specified direct mapping IS performed.
+        final boolean disableDirectMap = variant != Variant.PREREQ_CHECK;
+        if (variant == Variant.ENVVAR_USED) {
+            builder.env(CRAC_CRIU_OPTS, "-v");
+        } else if (variant == Variant.ALREADY_SET) {
+            builder.env(CRAC_CRIU_OPTS, "-v --no-mmap-page-image");
+        }
+        // Using log file instead of stderr because output capturing takes too long for some reason.
+        // If we let CRIU create the file we may not get reading permissions, so we create it by
+        // ourselves and also truncate it if it exists from previous runs (CRIU should truncate
+        // automatically but just to be safe).
+        Files.write(LOG_FILE_PATH, new byte[0]); // Creates if not exists, truncates otherwise
+        builder.engineOptions("args=-v4 -o " + LOG_FILE_PATH + (disableDirectMap ? ",direct_map=false" : ""));
+
+        builder.doRestore();
+        checkLogFile(!disableDirectMap);
+    }
+
+    private static void checkLogFile(boolean directMap) throws IOException {
+        // CRIU prints debug lines "Preadv %lx:%d... (%d iovs) (mmap %d)" where the last %d is
+        // either 0 or 1 depending on whether direct mapping is performed
+        final var lines = Files.lines(LOG_FILE_PATH).filter(s ->
+            s.matches("\\(\\d+.\\d+\\) pie: \\d+: Preadv 0x\\p{XDigit}+:\\d+\\.\\.\\. \\(\\d+ iovs\\) \\(mmap [01]\\)")
+        ).toList();
+        assertFalse(lines.isEmpty(), "At least one log line must match the expected pattern");
+        for (var s : lines) {
+            // If this fails it means that direct_map is on when it should be off or vise-versa
+            final var end = "(mmap " + (directMap ? "1" : "0") + ")";
+            assertTrue(s.endsWith(end), "Log line \"" + s + "\" must end with \"" + end + "\"");
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Core.checkpointRestore();
+    }
+}

--- a/test/jdk/jdk/crac/engineOptions/HelpTest.java
+++ b/test/jdk/jdk/crac/engineOptions/HelpTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.*;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+/*
+* @test
+* @summary Testing -XX:CRaCEngineOptions=help.
+* @library /test/lib
+*/
+public class HelpTest {
+    public static void main(String[] args) throws Exception {
+        test();
+        test("-XX:CRaCCheckpointTo=cr");
+        test("-XX:CRaCRestoreFrom=cr");
+    }
+
+    private static void test(String... opts) throws Exception {
+        List<String> optsList = new ArrayList(Arrays.asList(opts));
+        optsList.add("-XX:CRaCEngineOptions=help");
+        optsList.add("-Xlog:crac=debug");
+        // Limited to not get non-restore-settable flags with CRaCRestoreFrom
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(optsList);
+        OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        out.shouldHaveExitValue(0);
+        out.stdoutShouldContain("Configuration options:");
+        out.stderrShouldBeEmpty();
+        out.shouldNotContain("CRaC engine option:");
+    }
+}

--- a/test/jdk/jdk/crac/engineOptions/ParsingTest.java
+++ b/test/jdk/jdk/crac/engineOptions/ParsingTest.java
@@ -35,12 +35,11 @@ import java.util.*;
 
 /*
 * @test
-* @summary Testing CRaCEngine and CRaCEngineOptions VM options.
+* @summary Testing parsing of CRaCEngine and CRaCEngineOptions VM options.
 * @library /test/lib
-* @build CracEngineOptionsTest
-* @run junit/othervm CracEngineOptionsTest
+* @run junit/othervm ParsingTest
 */
-public class CracEngineOptionsTest {
+public class ParsingTest {
     @BeforeClass
     public static void checkCriu() {
         final boolean hasCriu = Path.of(Utils.TEST_JDK, "lib", "criuengine").toFile().exists();
@@ -169,13 +168,6 @@ public class CracEngineOptionsTest {
         }
     }
 
-    @Test
-    public void test_options_help() throws Exception {
-        testHelp();
-        testHelp("-XX:CRaCCheckpointTo=cr");
-        testHelp("-XX:CRaCRestoreFrom=cr");
-    }
-
     private void test(String engine) throws Exception {
         test(engine, Collections.emptyList(), 0, Collections.emptyList(), Collections.emptyList());
     }
@@ -209,18 +201,5 @@ public class CracEngineOptionsTest {
         for (String text : notExpectedTexts) {
             out.shouldNotContain(text);
         }
-    }
-
-    private static void testHelp(String... opts) throws Exception {
-        List<String> optsList = new ArrayList(Arrays.asList(opts));
-        optsList.add("-XX:CRaCEngineOptions=help");
-        optsList.add("-Xlog:crac=debug");
-        // Limited to not get non-restore-settable flags with CRaCRestoreFrom
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(optsList);
-        OutputAnalyzer out = new OutputAnalyzer(pb.start());
-        out.shouldHaveExitValue(0);
-        out.stdoutShouldContain("Configuration options:");
-        out.stderrShouldBeEmpty();
-        out.shouldNotContain("CRaC engine option:");
     }
 }


### PR DESCRIPTION
~~This contains the change from #216 so that should be merged first.~~ UPD: rebased.

The fix itself is small but coming up with a way to test it was not trivial:
1. I've split `jdk/crac/CracEngineOptionsTest.java` onto `jdk/crac/engineOptions/ParsingTest.java` and `jdk/crac/engineOptions/HelpTest.java` because it was getting too large (nothing added/removed, just split).
2. Added `jdk/crac/engineOptions/CracCriuOptsTest.java` to regression-test the main fix of this PR (this test depends on #216).
3. Removed a part that tested that `args` are actually applied by `crexec` from `jdk/crac/VMOptionsTest.java` because (2) is now effectively tests this (`VMOptionsTest` wasn't a proper place for this to begin with, it just was convenient).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8352413](https://bugs.openjdk.org/browse/JDK-8352413): [CRaC] crexec fails to pass some options when CRAC_CRIU_OPTS is already used (**Bug** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/217/head:pull/217` \
`$ git checkout pull/217`

Update a local copy of the PR: \
`$ git checkout pull/217` \
`$ git pull https://git.openjdk.org/crac.git pull/217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 217`

View PR using the GUI difftool: \
`$ git pr show -t 217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/217.diff">https://git.openjdk.org/crac/pull/217.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/217#issuecomment-2736407989)
</details>
