### PR TITLE
8353064: [CRaC] ProblemList jdk/crac/LinkedCleanableRefTest

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -513,6 +513,12 @@ java/beans/XMLEncoder/Test6570354.java 8015593 macosx-all
 
 ############################################################################
 
+# jdk_crac
+
+jdk/crac/LinkedCleanableRefTest.java                            8353064 generic-all
+
+############################################################################
+
 # jdk_lang
 
 java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-all


### PR DESCRIPTION
Adds `jdk/crac/LinkedCleanableRefTest` into a ProblemList until it is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8353064](https://bugs.openjdk.org/browse/JDK-8353064): [CRaC] ProblemList jdk/crac/LinkedCleanableRefTest (**Bug** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/218/head:pull/218` \
`$ git checkout pull/218`

Update a local copy of the PR: \
`$ git checkout pull/218` \
`$ git pull https://git.openjdk.org/crac.git pull/218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 218`

View PR using the GUI difftool: \
`$ git pr show -t 218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/218.diff">https://git.openjdk.org/crac/pull/218.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/218#issuecomment-2758368019)
</details>
