### PR TITLE
8353243: [CRaC] Show all options in engine help

### DIFF
--- a/src/hotspot/share/include/crlib/crlib_description.h
+++ b/src/hotspot/share/include/crlib/crlib_description.h
@@ -50,13 +50,10 @@ struct crlib_description {
   // Returns a valid C-string with a formatted list of configuration keys supported by the engine
   // with their descriptions, or null on error.
   //
-  // Some keys can be excluded if they are not supposed to be set by a user but rather by the
-  // application the engine is linked to.
-  //
   // Example:
   // "
   // * do_stuff=<true/false> (default: true) — whether to do stuff.\n
-  // * args=<string> (default: \"\") — other arguments.
+  // * args=<string> (default: \"\") — other arguments.\n
   // "
   const char *(*configuration_doc)(crlib_conf_t *);
 

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -327,12 +327,14 @@ void crac::print_engine_info_and_exit() {
 
   const GrowableArrayCHeap<const char *, MemTag::mtInternal> *controlled_opts = engine.vm_controlled_options();
   assert(controlled_opts != nullptr, "must be");
-  if (!controlled_opts->is_empty()) {
+  if (controlled_opts->is_nonempty()) {
     tty->cr();
-    tty->print_raw("Configuration options controlled by the JVM:");
-    for (const char *opt : *controlled_opts) {
-      tty->print_raw(" ");
-      tty->print_raw(opt);
+    tty->print_raw("Configuration options controlled by the JVM: ");
+    for (int i = 0; i < controlled_opts->length(); i++) {
+      tty->print_raw(controlled_opts->at(i));
+      if (i != controlled_opts->length() - 1) {
+        tty->print_raw(", ");
+      }
     }
     tty->cr();
   }

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -31,6 +31,7 @@
 #include "logging/logConfiguration.hpp"
 #include "memory/allocation.hpp"
 #include "memory/oopFactory.hpp"
+#include "nmt/memTag.hpp"
 #include "oops/typeArrayOop.inline.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "runtime/crac_engine.hpp"
@@ -50,6 +51,7 @@
 #include "os.inline.hpp"
 #include "utilities/defaultStream.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/growableArray.hpp"
 #include "utilities/ostream.hpp"
 
 static jlong _restore_start_time;
@@ -322,6 +324,19 @@ void crac::print_engine_info_and_exit() {
   tty->cr();
   tty->print_raw_cr("Configuration options:");
   tty->print_raw(conf_doc); // Doc string ends with CR by convention
+
+  const GrowableArrayCHeap<const char *, MemTag::mtInternal> *controlled_opts = engine.vm_controlled_options();
+  assert(controlled_opts != nullptr, "must be");
+  if (!controlled_opts->is_empty()) {
+    tty->cr();
+    tty->print_raw("Configuration options controlled by the JVM:");
+    for (const char *opt : *controlled_opts) {
+      tty->print_raw(" ");
+      tty->print_raw(opt);
+    }
+    tty->cr();
+  }
+  delete controlled_opts;
 
   vm_exit(0);
   ShouldNotReachHere();

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -325,20 +325,16 @@ void crac::print_engine_info_and_exit() {
   tty->print_raw_cr("Configuration options:");
   tty->print_raw(conf_doc); // Doc string ends with CR by convention
 
-  const GrowableArrayCHeap<const char *, MemTag::mtInternal> *controlled_opts = engine.vm_controlled_options();
-  assert(controlled_opts != nullptr, "must be");
-  if (controlled_opts->is_nonempty()) {
-    tty->cr();
-    tty->print_raw("Configuration options controlled by the JVM: ");
-    for (int i = 0; i < controlled_opts->length(); i++) {
-      tty->print_raw(controlled_opts->at(i));
-      if (i != controlled_opts->length() - 1) {
-        tty->print_raw(", ");
-      }
+  const char * const *controlled_opts = CracEngine::vm_controlled_options();
+  tty->cr();
+  tty->print_raw("Configuration options controlled by the JVM: ");
+  for (const auto *opt = controlled_opts; *opt != nullptr; opt++) {
+    tty->print_raw(*opt);
+    if (*(opt + 1) != nullptr) {
+      tty->print_raw(", ");
     }
-    tty->cr();
   }
-  delete controlled_opts;
+  tty->cr();
 
   vm_exit(0);
   ShouldNotReachHere();

--- a/src/hotspot/share/runtime/crac_engine.cpp
+++ b/src/hotspot/share/runtime/crac_engine.cpp
@@ -32,19 +32,26 @@
 #include "runtime/globals.hpp"
 #include "runtime/os.hpp"
 #include "utilities/debug.hpp"
-#include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/resourceHash.hpp"
 
 #include <cstddef>
 #include <cstring>
 
-// CRaC engine configuration options that JVM sets directly.
-// If an option is controlled exctusively by JVM (i.e. the user is not allowed
-// to pass the option through CRaCEngineOptions) it should be listed in
-// CracEngine::vm_controlled_options().
-#define ENGINE_OPT_IMAGE_LOCATION "image_location"
-#define ENGINE_OPT_EXEC_LOCATION "exec_location"
+// CRaC engine configuration options JVM sets directly instead of relaying from the user
+#define VM_CONTROLLED_ENGINE_OPTS(OPT) \
+  OPT(image_location) \
+  OPT(exec_location) \
+
+#define ARRAY_ELEM(opt) #opt,
+static constexpr const char * const vm_controlled_engine_opts[] = {
+  VM_CONTROLLED_ENGINE_OPTS(ARRAY_ELEM) nullptr
+};
+#undef ARRAY_ELEM
+
+#define DEFINE_OPT_VAR(opt) static constexpr const char engine_opt_##opt[] = #opt;
+VM_CONTROLLED_ENGINE_OPTS(DEFINE_OPT_VAR)
+#undef DEFINE_OPT_VAR
 
 #ifdef _WINDOWS
 static char *strsep(char **strp, const char *delim) {
@@ -62,6 +69,10 @@ static char *strsep(char **strp, const char *delim) {
   return str;
 }
 #endif // _WINDOWS
+
+const char * const *CracEngine::vm_controlled_options() {
+  return vm_controlled_engine_opts;
+}
 
 static bool find_engine(const char *dll_dir, char *path, size_t path_size, bool *is_library) {
   // Try to interpret as a file path
@@ -139,8 +150,8 @@ static bool find_engine(const char *dll_dir, char *path, size_t path_size, bool 
 
 static bool configure_image_location(const crlib_api_t &api, crlib_conf_t *conf, const char *image_location) {
   precond(image_location != nullptr && image_location[0] != '\0');
-  if (!api.configure(conf, ENGINE_OPT_IMAGE_LOCATION, image_location)) {
-    log_error(crac)("CRaC engine failed to configure: '" ENGINE_OPT_IMAGE_LOCATION "' = '%s'", image_location);
+  if (!api.configure(conf, engine_opt_image_location, image_location)) {
+    log_error(crac)("CRaC engine failed to configure: '%s' = '%s'", engine_opt_image_location, image_location);
     return false;
   }
   return true;
@@ -184,10 +195,10 @@ static crlib_conf_t *create_conf(const crlib_api_t &api, const char *image_locat
   }
 
   if (exec_location != nullptr) { // Only passed when using crexec
-    guarantee(api.can_configure(conf, ENGINE_OPT_EXEC_LOCATION),
-              "crexec does not support expected option: " ENGINE_OPT_EXEC_LOCATION);
-    if (!api.configure(conf, ENGINE_OPT_EXEC_LOCATION, exec_location)) {
-      log_error(crac)("crexec failed to configure: '" ENGINE_OPT_EXEC_LOCATION "' = '%s'", exec_location);
+    guarantee(api.can_configure(conf, engine_opt_exec_location),
+              "crexec does not support expected option: %s", engine_opt_exec_location);
+    if (!api.configure(conf, engine_opt_exec_location, exec_location)) {
+      log_error(crac)("crexec failed to configure: '%s' = '%s'", engine_opt_exec_location, exec_location);
       api.destroy_conf(conf);
       return nullptr;
     }
@@ -197,6 +208,11 @@ static crlib_conf_t *create_conf(const crlib_api_t &api, const char *image_locat
     return conf;
   }
 
+  CStringSet vm_controlled_keys;
+#define PUT_CONTROLLED_KEY(opt) vm_controlled_keys.put_when_absent(engine_opt_##opt, false);
+  VM_CONTROLLED_ENGINE_OPTS(PUT_CONTROLLED_KEY)
+#undef PUT_CONTROLLED_KEY
+
   char *engine_options = os::strdup_check_oom(CRaCEngineOptions, mtInternal);
   char *const engine_options_start = engine_options;
   CStringSet keys;
@@ -205,9 +221,8 @@ static crlib_conf_t *create_conf(const crlib_api_t &api, const char *image_locat
     const char *key = strsep(&key_value, "=");
     const char *value = key_value != nullptr ? key_value : "";
     assert(key != nullptr, "Should have terminated before");
-    if (strcmp(key, ENGINE_OPT_IMAGE_LOCATION) == 0 ||
-        (exec_location != nullptr && strcmp(key, ENGINE_OPT_EXEC_LOCATION) == 0)) {
-      log_warning(crac)("Internal CRaC engine option provided, skipping: %s", key);
+    if (vm_controlled_keys.contains(key)) {
+      log_warning(crac)("VM-controlled CRaC engine option provided, skipping: %s", key);
       continue;
     }
     {
@@ -393,30 +408,4 @@ const char *CracEngine::description() const {
 const char *CracEngine::configuration_doc() const {
   precond(_description_api != nullptr);
   return _description_api->configuration_doc(_conf);
-}
-
-GrowableArrayCHeap<const char *, MemTag::mtInternal> *CracEngine::vm_controlled_options() const {
-  precond(_description_api != nullptr);
-
-  auto * const opts = new GrowableArrayCHeap<const char *, MemTag::mtInternal>();
-
-  // We expect all engines to support this but the error is to be shown when configuring checkpoint
-  if (_api->can_configure(_conf, ENGINE_OPT_IMAGE_LOCATION)) {
-    opts->append(ENGINE_OPT_IMAGE_LOCATION);
-  }
-
-  // ID-based checks are not fully robust as engines are free to use any ID (e.g. external engines
-  // can try to "impersonate" themselves as crexec) but in reality engines are expected to use
-  // destinct IDs so this shouldn't cause problems
-  const char *id = _description_api->identity(_conf);
-  if (id == nullptr) {
-    log_debug(crac)("CRaC engine failed to identify itself");
-    return opts;
-  }
-
-  if (strcmp(id, "crexec") == 0 && _api->can_configure(_conf, ENGINE_OPT_EXEC_LOCATION)) {
-    opts->append(ENGINE_OPT_EXEC_LOCATION);
-  }
-
-  return opts;
 }

--- a/src/hotspot/share/runtime/crac_engine.cpp
+++ b/src/hotspot/share/runtime/crac_engine.cpp
@@ -400,24 +400,22 @@ GrowableArrayCHeap<const char *, MemTag::mtInternal> *CracEngine::vm_controlled_
 
   auto * const opts = new GrowableArrayCHeap<const char *, MemTag::mtInternal>();
 
+  // We expect all engines to support this but the error is to be shown when configuring checkpoint
   if (_api->can_configure(_conf, ENGINE_OPT_IMAGE_LOCATION)) {
     opts->append(ENGINE_OPT_IMAGE_LOCATION);
-  } else {
-    log_debug(crac)("CRaC engine does not support expected option: " ENGINE_OPT_IMAGE_LOCATION);
   }
 
+  // ID-based checks are not fully robust as engines are free to use any ID (e.g. external engines
+  // can try to "impersonate" themselves as crexec) but in reality engines are expected to use
+  // destinct IDs so this shouldn't cause problems
   const char *id = _description_api->identity(_conf);
   if (id == nullptr) {
     log_debug(crac)("CRaC engine failed to identify itself");
     return opts;
   }
 
-  if (strcmp(id, "crexec") == 0) {
-    if (_api->can_configure(_conf, ENGINE_OPT_EXEC_LOCATION)) {
-      opts->append(ENGINE_OPT_EXEC_LOCATION);
-    } else {
-      log_debug(crac)("CRaC engine does not support expected option: " ENGINE_OPT_EXEC_LOCATION);
-    }
+  if (strcmp(id, "crexec") == 0 && _api->can_configure(_conf, ENGINE_OPT_EXEC_LOCATION)) {
+    opts->append(ENGINE_OPT_EXEC_LOCATION);
   }
 
   return opts;

--- a/src/hotspot/share/runtime/crac_engine.hpp
+++ b/src/hotspot/share/runtime/crac_engine.hpp
@@ -29,7 +29,6 @@
 #include "crlib/crlib_restore_data.h"
 #include "memory/allocation.hpp"
 #include "nmt/memTag.hpp"
-#include "utilities/growableArray.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -37,6 +36,8 @@
 // CRaC engine library wrapper.
 class CracEngine : public CHeapObj<mtInternal> {
 public:
+  static const char * const *vm_controlled_options();
+
   explicit CracEngine(const char *image_location = nullptr);
   ~CracEngine();
 
@@ -63,7 +64,6 @@ public:
   ApiStatus prepare_description_api();
   const char *description() const;
   const char *configuration_doc() const;
-  GrowableArrayCHeap<const char *, MemTag::mtInternal> *vm_controlled_options() const;
 
 private:
   void *_lib = nullptr;

--- a/src/hotspot/share/runtime/crac_engine.hpp
+++ b/src/hotspot/share/runtime/crac_engine.hpp
@@ -29,6 +29,7 @@
 #include "crlib/crlib_restore_data.h"
 #include "memory/allocation.hpp"
 #include "nmt/memTag.hpp"
+#include "utilities/growableArray.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -62,6 +63,7 @@ public:
   ApiStatus prepare_description_api();
   const char *description() const;
   const char *configuration_doc() const;
+  GrowableArrayCHeap<const char *, MemTag::mtInternal> *vm_controlled_options() const;
 
 private:
   void *_lib = nullptr;

--- a/src/java.base/share/native/libcrexec/crexec.cpp
+++ b/src/java.base/share/native/libcrexec/crexec.cpp
@@ -362,18 +362,16 @@ static const char *description(crlib_conf_t *conf) {
 }
 
 static const char *configuration_doc(crlib_conf_t *conf) {
-  // Internal options which are expected to be set by the program crexec is linked to are omitted
-  // since users are not supposed to pass them directly:
-  // * image_location=<path> (no default) - path to a directory with checkpoint/restore files.
-  // * exec_location=<path> (no default) - path to the engine executable.
   return
+    "* image_location=<path> (no default) - path to a directory with checkpoint/restore files.\n"
+    "* exec_location=<path> (no default) - path to the engine executable.\n"
     "* keep_running=<true/false> (default: false) - keep the process running after the checkpoint "
     "or kill it.\n"
     "* direct_map=<true/false> (default: true) - on restore, map process data directly from saved "
     "files. This may speedup the restore but the resulting process will not be the same as before "
     "the checkpoint.\n"
     "* args=<string> (default: \"\") - free space-separated arguments passed directly to the "
-    "engine executable, e.g. \"--arg1 --arg2 --arg3\".";
+    "engine executable, e.g. \"--arg1 --arg2 --arg3\".\n";
 }
 
 static const char * const *configurable_keys(crlib_conf_t *conf) {

--- a/test/jdk/jdk/crac/engineOptions/ParsingTest.java
+++ b/test/jdk/jdk/crac/engineOptions/ParsingTest.java
@@ -81,7 +81,7 @@ public class ParsingTest {
     public void test_options() throws Exception {
         test("simengine", "");
         test("simengine", "image_location=cr", 0,
-                "Internal CRaC engine option provided, skipping: image_location");
+                "VM-controlled CRaC engine option provided, skipping: image_location");
         if (Platform.isLinux()) {
             test("criuengine", Arrays.asList("keep_running=true,args=-v -v -v -v"), 0,
                     Arrays.asList(


### PR DESCRIPTION
C/R engines are now advised to list all options in `configuration_doc`. If JVM does not let users to control some options it states that in the engine help message.

crexec now documents internal options, such as `image_location` and `exec_location`, in its doc message.

This is how crexec's help looks with this change:
```
$ java -XX:CRaCEngineOptions=help
crexec - pseudo-CRaC-engine used to relay data from JVM to a "real" engine implemented as an executable (instead of a library). The engine executable is expected to have CRaC-CRIU-like CLI. Support of the configuration options also depends on the engine executable.

Configuration options:
* image_location=<path> (no default) - path to a directory with checkpoint/restore files.
* exec_location=<path> (no default) - path to the engine executable.
* keep_running=<true/false> (default: false) - keep the process running after the checkpoint or kill it.
* direct_map=<true/false> (default: true) - on restore, map process data directly from saved files. This may speedup the restore but the resulting process will not be the same as before the checkpoint.
* args=<string> (default: "") - free space-separated arguments passed directly to the engine executable, e.g. "--arg1 --arg2 --arg3".

Configuration options controlled by the JVM: image_location, exec_location
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8353243](https://bugs.openjdk.org/browse/JDK-8353243): [CRaC] Show all options in engine help (**Enhancement** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/220/head:pull/220` \
`$ git checkout pull/220`

Update a local copy of the PR: \
`$ git checkout pull/220` \
`$ git pull https://git.openjdk.org/crac.git pull/220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 220`

View PR using the GUI difftool: \
`$ git pr show -t 220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/220.diff">https://git.openjdk.org/crac/pull/220.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/220#issuecomment-2765606173)
</details>
