### PR TITLE
8354432: [CRaC] Timed waiting finishes early w.r.t. wall clock time

### DIFF
--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -58,14 +58,11 @@ static jlong _restore_start_time;
 static jlong _restore_start_nanos;
 
 CracEngine *crac::_engine = nullptr;
-// Timestamps recorded before checkpoint
-jlong crac::checkpoint_wallclock_seconds; // Wall clock time, full seconds
-jlong crac::checkpoint_wallclock_nanos;   // Wall clock time, nanoseconds remainder [0, 999999999]
-jlong crac::checkpoint_monotonic_nanos;   // Monotonic time
-char crac::checkpoint_bootid[UUID_LENGTH];
-// Value based on wall clock time difference that will guarantee monotonic
-// System.nanoTime() close to actual wall-clock time difference.
-jlong crac::javaTimeNanos_offset = 0;
+char crac::_checkpoint_bootid[UUID_LENGTH];
+jlong crac::_checkpoint_wallclock_seconds;
+jlong crac::_checkpoint_wallclock_nanos;
+jlong crac::_checkpoint_monotonic_nanos;
+jlong crac::_javaTimeNanos_offset;
 
 jlong crac::restore_start_time() {
   if (!_restore_start_time) {
@@ -631,10 +628,10 @@ bool CracRestoreParameters::read_from(int fd) {
 }
 
 void crac::record_time_before_checkpoint() {
-  os::javaTimeSystemUTC(checkpoint_wallclock_seconds, checkpoint_wallclock_nanos);
-  checkpoint_monotonic_nanos = os::javaTimeNanos();
-  memset(checkpoint_bootid, 0, UUID_LENGTH);
-  read_bootid(checkpoint_bootid);
+  os::javaTimeSystemUTC(_checkpoint_wallclock_seconds, _checkpoint_wallclock_nanos);
+  _checkpoint_monotonic_nanos = os::javaTimeNanos();
+  memset(_checkpoint_bootid, 0, UUID_LENGTH);
+  read_bootid(_checkpoint_bootid);
 }
 
 void crac::update_javaTimeNanos_offset() {
@@ -646,14 +643,14 @@ void crac::update_javaTimeNanos_offset() {
   // only guarantee that the nanotime does not go backwards in that case but
   // won't offset the time based on wall-clock time as this change in monotonic
   // time is likely intentional.
-  if (!read_bootid(buf) || memcmp(buf, checkpoint_bootid, UUID_LENGTH) != 0) {
+  if (!read_bootid(buf) || memcmp(buf, _checkpoint_bootid, UUID_LENGTH) != 0) {
     jlong current_wallclock_seconds;
     jlong current_wallclock_nanos;
     os::javaTimeSystemUTC(current_wallclock_seconds, current_wallclock_nanos);
 
     jlong diff_wallclock =
-      (current_wallclock_seconds - checkpoint_wallclock_seconds) * NANOSECS_PER_SEC +
-      current_wallclock_nanos - checkpoint_wallclock_nanos;
+      (current_wallclock_seconds - _checkpoint_wallclock_seconds) * NANOSECS_PER_SEC +
+      current_wallclock_nanos - _checkpoint_wallclock_nanos;
     // If the wall clock has gone backwards we won't add it to the offset
     if (diff_wallclock < 0) {
       diff_wallclock = 0;
@@ -661,13 +658,13 @@ void crac::update_javaTimeNanos_offset() {
 
     // javaTimeNanos() call on the second line below uses the *_offset, so we will zero
     // it to make the call return true monotonic time rather than the adjusted value.
-    javaTimeNanos_offset = 0;
-    javaTimeNanos_offset = checkpoint_monotonic_nanos - os::javaTimeNanos() + diff_wallclock;
+    _javaTimeNanos_offset = 0;
+    _javaTimeNanos_offset = _checkpoint_monotonic_nanos - os::javaTimeNanos() + diff_wallclock;
   } else {
     // ensure monotonicity even if this looks like the same boot
-    jlong diff = os::javaTimeNanos() - checkpoint_monotonic_nanos;
+    jlong diff = os::javaTimeNanos() - _checkpoint_monotonic_nanos;
     if (diff < 0) {
-      javaTimeNanos_offset -= diff;
+      _javaTimeNanos_offset -= diff;
     }
   }
 }

--- a/src/hotspot/share/runtime/crac.hpp
+++ b/src/hotspot/share/runtime/crac.hpp
@@ -58,8 +58,9 @@ public:
   static void reset_time_counters();
 
 private:
-  static jlong checkpoint_millis;
-  static jlong checkpoint_nanos;
+  static jlong checkpoint_wallclock_seconds;
+  static jlong checkpoint_wallclock_nanos;
+  static jlong checkpoint_monotonic_nanos;
   static char checkpoint_bootid[UUID_LENGTH];
   static jlong javaTimeNanos_offset;
 

--- a/src/hotspot/share/runtime/crac.hpp
+++ b/src/hotspot/share/runtime/crac.hpp
@@ -52,19 +52,22 @@ public:
   static jlong uptime_since_restore();
 
   static jlong monotonic_time_offset() {
-    return javaTimeNanos_offset;
+    return _javaTimeNanos_offset;
   }
 
   static void reset_time_counters();
 
 private:
-  static jlong checkpoint_wallclock_seconds;
-  static jlong checkpoint_wallclock_nanos;
-  static jlong checkpoint_monotonic_nanos;
-  static char checkpoint_bootid[UUID_LENGTH];
-  static jlong javaTimeNanos_offset;
-
   static CracEngine *_engine;
+
+  static char _checkpoint_bootid[UUID_LENGTH];
+  // Timestamps recorded before checkpoint.
+  static jlong _checkpoint_wallclock_seconds; // Wall-clock time, full seconds
+  static jlong _checkpoint_wallclock_nanos;   // Wall-clock time, nanoseconds remainder [0, 999999999]
+  static jlong _checkpoint_monotonic_nanos;   // Monotonic time, nanoseconds
+  // Value based on wall clock time difference that will guarantee monotonic
+  // System.nanoTime() close to actual wall-clock time difference.
+  static jlong _javaTimeNanos_offset;
 
   static bool read_bootid(char *dest);
 


### PR DESCRIPTION
This is an alternative to #209 that also fixes `TimedWaitingTest`.

The solution is to offset `os::javaTimeNanos()` using nanosecond-precision wall clock time instead of millisecond-precision. See the explanation in the related JBS issue.

I've run the test 100 times in CI and haven't witnessed it failing. To compare, without the fix it would usually fail in the first 5-10 runs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8354432](https://bugs.openjdk.org/browse/JDK-8354432): [CRaC] Timed waiting finishes early w.r.t. wall clock time (**Bug** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/221/head:pull/221` \
`$ git checkout pull/221`

Update a local copy of the PR: \
`$ git checkout pull/221` \
`$ git pull https://git.openjdk.org/crac.git pull/221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 221`

View PR using the GUI difftool: \
`$ git pr show -t 221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/221.diff">https://git.openjdk.org/crac/pull/221.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/221#issuecomment-2797138829)
</details>
