### PR TITLE
8354514: [CRaC] Remove new methods from AbstractInterruptibleChannel and SocketImpl

### DIFF
--- a/src/java.base/share/classes/java/net/SocketImpl.java
+++ b/src/java.base/share/classes/java/net/SocketImpl.java
@@ -93,9 +93,10 @@ public abstract class SocketImpl implements SocketOptions {
 
         // We cannot override this in subclass because SocketImpl is public and resource factory method
         // would expose JDKSocketResource outside JDK.
+        // We cannot expose any public overridable methods either in order to pass JCK.
         @Override
         protected boolean isListening() {
-            return SocketImpl.this.isListening();
+            return (SocketImpl.this instanceof NioSocketImpl) && ((NioSocketImpl) SocketImpl.this).isListening();
         }
 
         @Override
@@ -105,25 +106,13 @@ public abstract class SocketImpl implements SocketOptions {
 
         @Override
         protected void reopenAfterRestore() throws IOException {
-            SocketImpl.this.reopenAfterRestore();
+            if (SocketImpl.this instanceof NioSocketImpl) {
+                ((NioSocketImpl) SocketImpl.this).reopenAfterRestore();
+            } else {
+                throw new UnsupportedOperationException("Reopen not implemented");
+            }
         }
     };
-
-    /**
-     * Is this socket listening (server)?
-     * @return True if listening
-     */
-    protected boolean isListening() {
-        return false;
-    }
-
-    /**
-     * Used only by CRaC
-     * @throws IOException When cannot be reopened
-     */
-    protected void reopenAfterRestore() throws IOException {
-        throw new UnsupportedOperationException("Reopen not implemented");
-    }
 
     /**
      * Initialize a new instance of this class

--- a/src/java.base/share/classes/java/nio/channels/spi/AbstractInterruptibleChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/AbstractInterruptibleChannel.java
@@ -31,6 +31,7 @@ import java.nio.channels.Channel;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.InterruptibleChannel;
 
+import jdk.internal.access.JavaNioChannelsSpiAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.Unsafe;
 import sun.nio.ch.Interruptible;
@@ -92,6 +93,15 @@ public abstract class AbstractInterruptibleChannel
     // invoked if a Thread is interrupted when blocked in an I/O op
     private final Interruptible interruptor;
 
+    static {
+        SharedSecrets.setJavaNioChannelsSpiAccess(new JavaNioChannelsSpiAccess() {
+            @Override
+            public void setChannelReopened(AbstractInterruptibleChannel channel) {
+                channel.setReopened();
+            }
+        });
+    }
+
     /**
      * Initializes a new instance of this class.
      */
@@ -133,7 +143,7 @@ public abstract class AbstractInterruptibleChannel
     /**
      * Used only internally by CRaC
      */
-    protected final void setReopened() {
+    private void setReopened() {
         synchronized (closeLock) {
             assert closed;
             closed = false;

--- a/src/java.base/share/classes/jdk/internal/access/JavaNioChannelsSpiAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaNioChannelsSpiAccess.java
@@ -1,0 +1,7 @@
+package jdk.internal.access;
+
+import java.nio.channels.spi.AbstractInterruptibleChannel;
+
+public interface JavaNioChannelsSpiAccess {
+    void setChannelReopened(AbstractInterruptibleChannel channel);
+}

--- a/src/java.base/share/classes/jdk/internal/access/JavaNioChannelsSpiAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaNioChannelsSpiAccess.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package jdk.internal.access;
 
 import java.nio.channels.spi.AbstractInterruptibleChannel;

--- a/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
+++ b/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
@@ -80,6 +80,7 @@ public class SharedSecrets {
     private static JavaNetUriAccess javaNetUriAccess;
     private static JavaNetURLAccess javaNetURLAccess;
     private static JavaNioAccess javaNioAccess;
+    private static JavaNioChannelsSpiAccess javaNioChannelsSpiAccess;
     private static JavaUtilCollectionAccess javaUtilCollectionAccess;
     private static JavaUtilConcurrentTLRAccess javaUtilConcurrentTLRAccess;
     private static JavaUtilConcurrentFJPAccess javaUtilConcurrentFJPAccess;
@@ -266,6 +267,19 @@ public class SharedSecrets {
             // shared secret.
             ensureClassInitialized(java.nio.Buffer.class);
             access = javaNioAccess;
+        }
+        return access;
+    }
+
+    public static void setJavaNioChannelsSpiAccess(JavaNioChannelsSpiAccess a) {
+        javaNioChannelsSpiAccess = a;
+    }
+
+    public static JavaNioChannelsSpiAccess getJavaNioChannelsSpiAccess() {
+        var access = javaNioChannelsSpiAccess;
+        if (access == null) {
+            ensureClassInitialized(java.nio.channels.spi.AbstractInterruptibleChannel.class);
+            access = javaNioChannelsSpiAccess;
         }
         return access;
     }

--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -454,13 +454,11 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
         }
     }
 
-    @Override
-    protected boolean isListening() {
+    public boolean isListening() {
         return server;
     }
 
-    @Override
-    protected void reopenAfterRestore() throws IOException {
+    public void reopenAfterRestore() throws IOException {
         if (!server) {
             throw new UnsupportedOperationException("Reopen not implemented for non-server sockets");
         }

--- a/src/java.base/share/classes/sun/nio/ch/ServerSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/ServerSocketChannelImpl.java
@@ -55,6 +55,8 @@ import static java.net.StandardProtocolFamily.INET;
 import static java.net.StandardProtocolFamily.INET6;
 import static java.net.StandardProtocolFamily.UNIX;
 
+import jdk.internal.access.JavaNioChannelsSpiAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.crac.JDKSocketResource;
 import sun.net.NetHooks;
 import sun.net.ext.ExtendedSocketOptions;
@@ -69,6 +71,7 @@ class ServerSocketChannelImpl
 {
     // Used to make native close and configure calls
     private static final NativeDispatcher nd = new SocketDispatcher();
+    private static final JavaNioChannelsSpiAccess SPI_ACCESS = SharedSecrets.getJavaNioChannelsSpiAccess();
 
     // The protocol family of the socket
     private final ProtocolFamily family;
@@ -792,7 +795,7 @@ class ServerSocketChannelImpl
                     localAddress = netBind(localAddress, backlog);
                 }
             }
-            setReopened();
+            SPI_ACCESS.setChannelReopened(ServerSocketChannelImpl.this);
         }
     }
 }


### PR DESCRIPTION
Fix errors in JCK due to newly exposed methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8354514](https://bugs.openjdk.org/browse/JDK-8354514): [CRaC] Remove new methods from AbstractInterruptibleChannel and SocketImpl (**Bug** - P4)


### Reviewers
 * [Timofei Pushkin](https://openjdk.org/census#tpushkin) (@TimPushkin - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/222/head:pull/222` \
`$ git checkout pull/222`

Update a local copy of the PR: \
`$ git checkout pull/222` \
`$ git pull https://git.openjdk.org/crac.git pull/222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 222`

View PR using the GUI difftool: \
`$ git pr show -t 222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/222.diff">https://git.openjdk.org/crac/pull/222.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/222#issuecomment-2801676631)
</details>
