### PR TITLE
8344647: Make java.se participate in the preview language feature `requires transitive java.base`

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -154,7 +154,6 @@ module java.base {
     exports jdk.internal.javac to
         java.compiler,
         java.desktop, // for ScopedValue
-        java.se, // for ParticipatesInPreview
         jdk.compiler,
         jdk.incubator.vector, // participates in preview features
         jdk.jartool, // participates in preview features

--- a/src/java.se/share/classes/module-info.java
+++ b/src/java.se/share/classes/module-info.java
@@ -23,8 +23,6 @@
  * questions.
  */
 
-import jdk.internal.javac.ParticipatesInPreview;
-
 /**
  * Defines the API of the Java SE Platform.
  *
@@ -40,7 +38,6 @@ import jdk.internal.javac.ParticipatesInPreview;
  * @moduleGraph
  * @since 9
  */
-@ParticipatesInPreview
 module java.se {
     requires transitive java.base;
     requires transitive java.compiler;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Directive.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Directive.java
@@ -76,7 +76,7 @@ public abstract class Directive implements ModuleElement.Directive {
 
         @Override
         public String toString() {
-            return String.format("ACC_%s (0x%04x", name(), value);
+            return String.format("ACC_%s (0x%04x)", name(), value);
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Preview.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Preview.java
@@ -150,7 +150,9 @@ public class Preview {
         // s participates in the preview API
         return syms.java_base.exports.stream()
                 .filter(ed -> ed.packge.fullname == names.jdk_internal_javac)
-                .anyMatch(ed -> ed.modules.contains(m));
+                .anyMatch(ed -> ed.modules.contains(m)) ||
+               //the specification lists the java.se module as participating in preview:
+               m.name == names.java_se;
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3770,7 +3770,7 @@ compiler.misc.cant.resolve.modules=\
     cannot resolve modules
 
 compiler.misc.bad.requires.flag=\
-    bad requires flag: {0}
+    invalid flag for "requires java.base": {0}
 
 # 0: string
 compiler.err.invalid.module.specifier=\

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -127,6 +127,7 @@ public class Names {
 
     // module names
     public final Name java_base;
+    public final Name java_se;
     public final Name jdk_unsupported;
 
     // attribute names
@@ -315,6 +316,7 @@ public class Names {
 
         // module names
         java_base = fromString("java.base");
+        java_se = fromString("java.se");
         jdk_unsupported = fromString("jdk.unsupported");
 
         // attribute names

--- a/test/langtools/tools/javac/modules/AnnotationsOnModules.java
+++ b/test/langtools/tools/javac/modules/AnnotationsOnModules.java
@@ -804,7 +804,7 @@ public class AnnotationsOnModules extends ModuleTestBase {
                 .writeAll()
                 .getOutputLines(OutputKind.DIRECT);
         List<String> expectedErrors = List.of(
-            "- compiler.err.cant.access: m.module-info, (compiler.misc.bad.class.file.header: module-info.class, (compiler.misc.bad.requires.flag: ACC_TRANSITIVE (0x0020))",
+            "- compiler.err.cant.access: m.module-info, (compiler.misc.bad.class.file.header: module-info.class, (compiler.misc.bad.requires.flag: ACC_TRANSITIVE (0x0020)))",
             "1 error"
         );
 


### PR DESCRIPTION
CRaC trunk (647105388b66b7acedf03d049dc60323912a8fe7) fails to compile for me the same way as `jdk-25+2`:
```
=== Output from failing command(s) repeated here ===
* For target buildtools_depend__the.COMPILE_DEPEND_batch:
error: cannot access module-info
  bad class file: /modules/java.se/module-info.class
    bad requires flag: ACC_TRANSITIVE (0x0020
    Please remove or make sure it appears in the correct subdirectory of the classpath.
1 error
* For target buildtools_jdk_tools_classes__the.BUILD_TOOLS_JDK_batch:
error: cannot access module-info
  bad class file: /modules/java.se/module-info.class
    bad requires flag: ACC_TRANSITIVE (0x0020
    Please remove or make sure it appears in the correct subdirectory of the classpath.
1 error
```
It has been fixed upstream which is what I am backporting.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8344647](https://bugs.openjdk.org/browse/JDK-8344647): Make java.se participate in the preview language feature `requires transitive java.base` (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/226/head:pull/226` \
`$ git checkout pull/226`

Update a local copy of the PR: \
`$ git checkout pull/226` \
`$ git pull https://git.openjdk.org/crac.git pull/226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 226`

View PR using the GUI difftool: \
`$ git pr show -t 226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/226.diff">https://git.openjdk.org/crac/pull/226.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/226#issuecomment-2820876928)
</details>
