### PR TITLE
8357645: [CRaC] Use Alpine-based images when executing tests on musl

### DIFF
--- a/test/jdk/jdk/crac/java/lang/System/NanoTimeTest.java
+++ b/test/jdk/jdk/crac/java/lang/System/NanoTimeTest.java
@@ -24,6 +24,7 @@
 import jdk.crac.*;
 import jdk.crac.management.CRaCMXBean;
 import jdk.test.lib.Container;
+import jdk.test.lib.Platform;
 import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerTestUtils;
 import jdk.test.lib.crac.CracBuilder;
@@ -71,7 +72,8 @@ public class NanoTimeTest implements CracTest {
 
         try {
             // TODO: use more official image
-            builder.withBaseImage("ghcr.io/crac/test-base", "latest")
+            String baseImage = Platform.isMusl() ? "ghcr.io/crac/test-base-musl" : "ghcr.io/crac/test-base";
+            builder.withBaseImage(baseImage, "latest")
                     .dockerOptions("-v", bootIdFile + ":/fake_boot_id")
                     .inDockerImage(imageName);
 

--- a/test/jdk/jdk/crac/java/lang/System/TimedWaitingTest.java
+++ b/test/jdk/jdk/crac/java/lang/System/TimedWaitingTest.java
@@ -22,6 +22,7 @@
  */
 
 import jdk.test.lib.Container;
+import jdk.test.lib.Platform;
 import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerTestUtils;
 import jdk.test.lib.crac.CracBuilder;
@@ -66,7 +67,8 @@ public class TimedWaitingTest implements CracTest {
         CracBuilder builder = new CracBuilder();
         Path bootIdFile = Files.createTempFile("TimedWaitingTest-", "-boot_id");
         try {
-            builder.withBaseImage("ghcr.io/crac/test-base", "latest")
+            String baseImage = Platform.isMusl() ? "ghcr.io/crac/test-base-musl" : "ghcr.io/crac/test-base";
+            builder.withBaseImage(baseImage, "latest")
                     .dockerOptions("-v", bootIdFile + ":/fake_boot_id")
                     .inDockerImage(imageName);
             builder.captureOutput(true);

--- a/test/lib/jdk/test/lib/containers/docker/DockerfileConfig.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerfileConfig.java
@@ -51,6 +51,10 @@ public class DockerfileConfig {
             return name;
         }
 
+        if (Platform.isMusl()) {
+            return "alpine";
+        }
+
         switch (Platform.getOsArch()) {
             case "aarch64":
                 return "arm64v8/ubuntu";


### PR DESCRIPTION
Makes CRaC tests which use containers use Alpine-based images when run on a musl-based system.