### PR TITLE
8357977: [CRaC] Unused imports in CRaC's classes

### DIFF
--- a/src/java.base/share/classes/jdk/internal/crac/ClaimedFDs.java
+++ b/src/java.base/share/classes/jdk/internal/crac/ClaimedFDs.java
@@ -31,7 +31,6 @@ import jdk.internal.access.SharedSecrets;
 
 import java.io.FileDescriptor;
 import java.util.List;
-import java.util.Objects;
 import java.util.WeakHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;

--- a/src/java.base/share/classes/jdk/internal/crac/JDKFileResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKFileResource.java
@@ -11,9 +11,6 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.function.Supplier;
 
 public abstract class JDKFileResource extends JDKFdResource {

--- a/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
@@ -26,7 +26,6 @@
 
 package jdk.internal.crac;
 
-import jdk.internal.crac.mirror.Context;
 import jdk.internal.crac.mirror.Resource;
 
 public interface JDKResource extends Resource {

--- a/src/java.base/share/classes/jdk/internal/crac/mirror/impl/OrderedContext.java
+++ b/src/java.base/share/classes/jdk/internal/crac/mirror/impl/OrderedContext.java
@@ -26,10 +26,7 @@
 
 package jdk.internal.crac.mirror.impl;
 
-import jdk.internal.crac.mirror.Context;
 import jdk.internal.crac.mirror.Resource;
-import jdk.internal.crac.mirror.RestoreException;
-import jdk.internal.crac.mirror.impl.AbstractContext;
 
 import java.util.*;
 


### PR DESCRIPTION
Removes unused imports from CRaC's Java code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8357977](https://bugs.openjdk.org/browse/JDK-8357977): [CRaC] Unused imports in CRaC's classes (**Bug** - P5)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/232/head:pull/232` \
`$ git checkout pull/232`

Update a local copy of the PR: \
`$ git checkout pull/232` \
`$ git pull https://git.openjdk.org/crac.git pull/232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 232`

View PR using the GUI difftool: \
`$ git pr show -t 232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/232.diff">https://git.openjdk.org/crac/pull/232.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/232#issuecomment-2916341943)
</details>
