### PR TITLE
8357984: [CRaC] Improve new properties installation code

### DIFF
--- a/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
@@ -37,7 +37,6 @@ import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
@@ -194,11 +193,8 @@ public class Core {
 
         if (newProperties != null) {
             for (var prop : newProperties) {
-                String[] pair = prop.split("=", 2);
-                AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    System.setProperty(pair[0], pair[1]);
-                    return null;
-                });
+                String[] pair = prop.split("=", 2); // There should always be a "="
+                System.setProperty(pair[0], pair[1]);
             }
         }
 

--- a/test/jdk/jdk/crac/NewPropertiesTest.java
+++ b/test/jdk/jdk/crac/NewPropertiesTest.java
@@ -30,22 +30,38 @@ import jdk.test.lib.crac.CracTest;
  * @test
  * @requires (os.family == "linux")
  * @library /test/lib
- * @build NewPropertyTest
+ * @build NewPropertiesTest
  * @run driver jdk.test.lib.crac.CracTest
  */
-public class NewPropertyTest implements CracTest {
+public class NewPropertiesTest implements CracTest {
     @Override
     public void test() throws Exception {
         final var builder = new CracBuilder();
+
+        builder.javaOption("old", "old val");
+
         builder.doCheckpoint();
-        builder.javaOption("k", "v");
+
+        builder.javaOption("old", "new val");
+        builder.javaOption("new1", "foo=bar");
+        builder.vmOption("-Dnew2=");
+        builder.vmOption("-Dnew3");
+
         builder.doRestore();
     }
 
     @Override
     public void exec() throws Exception {
-        Asserts.assertNull(System.getProperty("k"));
+        Asserts.assertEquals(System.getProperty("old"), "old val");
+        Asserts.assertNull(System.getProperty("new1"));
+        Asserts.assertNull(System.getProperty("new2"));
+        Asserts.assertNull(System.getProperty("new3"));
+
         Core.checkpointRestore();
-        Asserts.assertEquals(System.getProperty("k"), "v");
+
+        Asserts.assertEquals(System.getProperty("old"), "new val");
+        Asserts.assertEquals(System.getProperty("new1"), "foo=bar");
+        Asserts.assertEquals(System.getProperty("new2"), "");
+        Asserts.assertEquals(System.getProperty("new3"), "");
     }
 }


### PR DESCRIPTION
Rewrites the code which installs new properties on restore to make it more concise by using direct array iteration and lambdas.

Note that initially the lambdas were removed from this code in #75 because they triggered a resource registration in a blocking context during C/R which led to a deadlock. But as I understand #73 made it possible to use lambdas during C/R.

I also noted that there are no tests for new properties so I added one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8357984](https://bugs.openjdk.org/browse/JDK-8357984): [CRaC] Improve new properties installation code (**Bug** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/233/head:pull/233` \
`$ git checkout pull/233`

Update a local copy of the PR: \
`$ git checkout pull/233` \
`$ git pull https://git.openjdk.org/crac.git pull/233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 233`

View PR using the GUI difftool: \
`$ git pr show -t 233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/233.diff">https://git.openjdk.org/crac/pull/233.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/233#issuecomment-2916839323)
</details>
