### PR TITLE
8358063: [CRaC] Excessive PosixAttachListener-related availability and references

### DIFF
--- a/src/hotspot/os/posix/attachListener_posix.hpp
+++ b/src/hotspot/os/posix/attachListener_posix.hpp
@@ -26,9 +26,8 @@
 #ifndef OS_POSIX_ATTACHLISTENER_POSIX_HPP
 #define OS_POSIX_ATTACHLISTENER_POSIX_HPP
 
-class PosixAttachListener;
-
 #if INCLUDE_SERVICES
+#ifndef AIX
 
 #include "posixAttachOperation.hpp"
 #include "services/attachListener.hpp"
@@ -79,6 +78,8 @@ class PosixAttachListener: AllStatic {
   static void reset_current_op();
 
 };
+
+#endif // !AIX
 
 #endif // INCLUDE_SERVICES
 

--- a/src/hotspot/os/posix/posixAttachOperation.hpp
+++ b/src/hotspot/os/posix/posixAttachOperation.hpp
@@ -29,9 +29,8 @@
 #include "os_posix.hpp"
 #include "services/attachListener.hpp"
 
-class PosixAttachOperation;
-
 #if INCLUDE_SERVICES
+#ifndef AIX
 
 class SocketChannel : public AttachOperation::RequestReader, public AttachOperation::ReplyWriter {
 private:
@@ -100,6 +99,8 @@ class PosixAttachOperation: public AttachOperation {
     return AttachOperation::read_request(&_socket_channel, &_socket_channel);
   }
 };
+
+#endif // !AIX
 
 #endif // INCLUDE_SERVICES
 

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -67,10 +67,10 @@
 #include "utilities/formatBuffer.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/parseInteger.hpp"
-#if INCLUDE_SERVICES && !defined(_WINDOWS)
+#if INCLUDE_SERVICES && !defined(_WINDOWS) && !defined(AIX)
 #include "attachListener_posix.hpp"
 #include "posixAttachOperation.hpp"
-#endif // INCLUDE_SERVICES && !defined(_WINDOWS)
+#endif // INCLUDE_SERVICES && !defined(_WINDOWS) && !defined(AIX)
 #ifdef LINUX
 #include "os_posix.hpp"
 #include "mallocInfoDcmd.hpp"
@@ -1068,12 +1068,12 @@ void CheckpointDCmd::execute(DCmdSource source, TRAPS) {
     char* out = java_lang_String::as_utf8_string(str);
     if (out[0] != '\0') {
       outputStream* stream = output();
-#if INCLUDE_SERVICES && !defined(_WINDOWS)
+#if INCLUDE_SERVICES && !defined(_WINDOWS) && !defined(AIX)
       assert(PosixAttachListener::get_current_op(), "should exist");
       if (PosixAttachListener::get_current_op()->is_effectively_completed()) {
         stream = tty;
       }
-#endif // INCLUDE_SERVICES
+#endif // INCLUDE_SERVICES && !defined(_WINDOWS) && !defined(AIX)
       stream->print_cr("An exception during a checkpoint operation:");
       stream->print("%s", out);
     }


### PR DESCRIPTION
Makes `PosixAttachListener` and `PosixAttachOperation` declared, defined and referenced only when they are implemented. This makes the sources closer to the mainline where these classes are defined in `.cpp` files under `#if INCLUDE_SERVICES #ifndef AIX` guards.

Sadly, I don't have access to AIX to test the buildability there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8358063](https://bugs.openjdk.org/browse/JDK-8358063): [CRaC] Excessive PosixAttachListener-related availability and references (**Bug** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/234/head:pull/234` \
`$ git checkout pull/234`

Update a local copy of the PR: \
`$ git checkout pull/234` \
`$ git pull https://git.openjdk.org/crac.git pull/234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 234`

View PR using the GUI difftool: \
`$ git pr show -t 234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/234.diff">https://git.openjdk.org/crac/pull/234.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/234#issuecomment-2919072082)
</details>
