### PR TITLE
8358161: [CRaC] Make VM-controlled options engine-dependent

### DIFF
--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -347,6 +347,7 @@ void crac::print_engine_info_and_exit() {
     }
   }
   tty->cr();
+  delete controlled_opts;
 
   vm_exit(0);
   ShouldNotReachHere();

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -336,12 +336,13 @@ void crac::print_engine_info_and_exit() {
   tty->print_raw_cr("Configuration options:");
   tty->print_raw(conf_doc); // Doc string ends with CR by convention
 
-  const char * const *controlled_opts = CracEngine::vm_controlled_options();
+  const GrowableArrayCHeap<const char *, MemTag::mtInternal> *controlled_opts = engine.vm_controlled_options();
   tty->cr();
   tty->print_raw("Configuration options controlled by the JVM: ");
-  for (const auto *opt = controlled_opts; *opt != nullptr; opt++) {
-    tty->print_raw(*opt);
-    if (*(opt + 1) != nullptr) {
+  for (int i = 0; i < controlled_opts->length(); i++) {
+    const char *opt = controlled_opts->at(i);
+    tty->print_raw(opt);
+    if (i < controlled_opts->length() - 1) {
       tty->print_raw(", ");
     }
   }

--- a/src/hotspot/share/runtime/crac_engine.hpp
+++ b/src/hotspot/share/runtime/crac_engine.hpp
@@ -31,6 +31,7 @@
 #include "memory/allocation.hpp"
 #include "nmt/memTag.hpp"
 #include "runtime/vm_version.hpp"
+#include "utilities/growableArray.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -38,8 +39,6 @@
 // CRaC engine library wrapper.
 class CracEngine : public CHeapObj<mtInternal> {
 public:
-  static const char * const *vm_controlled_options();
-
   explicit CracEngine(const char *image_location = nullptr);
   ~CracEngine();
 
@@ -54,6 +53,7 @@ public:
   int checkpoint() const;
   int restore() const;
   bool configure_image_location(const char *image_location) const;
+  GrowableArrayCHeap<const char *, MemTag::mtInternal> *vm_controlled_options() const;
 
   // Optionally-supported operations
 


### PR DESCRIPTION
"Configuration options controlled by the JVM: ..." section of `-XX:CRaCEngineOptions=help` will now only list the options which are supported by the current engine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8358161](https://bugs.openjdk.org/browse/JDK-8358161): [CRaC] Make VM-controlled options engine-dependent (**Enhancement** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/235/head:pull/235` \
`$ git checkout pull/235`

Update a local copy of the PR: \
`$ git checkout pull/235` \
`$ git pull https://git.openjdk.org/crac.git pull/235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 235`

View PR using the GUI difftool: \
`$ git pr show -t 235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/235.diff">https://git.openjdk.org/crac/pull/235.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/235#issuecomment-2922322399)
</details>
