### PR TITLE
8358956: [CRaC] Fix NULL usage in hotspot

### DIFF
--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -192,7 +192,7 @@ define_pd_global(intx, InitArrayShortSize, 8*BytesPerLong);
              "Turn off JVM mitigations related to Intel micro code "        \
              "mitigations for the Intel JCC erratum")                       \
                                                                             \
-  product(ccstr, CPUFeatures, NULL, "CPU feature set, "                     \
+  product(ccstr, CPUFeatures, nullptr, "CPU feature set, "                  \
       "use -XX:CPUFeatures=0xnumber with -XX:CRaCCheckpointTo when you "    \
       "get an error during -XX:CRaCRestoreFrom on a different machine; "    \
       "-XX:CPUFeatures=native is the default; "                             \

--- a/src/hotspot/os/linux/crac_linux.cpp
+++ b/src/hotspot/os/linux/crac_linux.cpp
@@ -274,7 +274,7 @@ static int stat2stfail(mode_t mode) {
 // If checkpoint is called throught the API, jcmd operation and jcmd output doesn't exist.
 bool VM_Crac::is_socket_from_jcmd(int sock) {
 #if INCLUDE_SERVICES
-  if (_attach_op == NULL)
+  if (_attach_op == nullptr)
     return false;
   int sock_fd = _attach_op->socket();
   return sock == sock_fd;
@@ -285,7 +285,7 @@ bool VM_Crac::is_socket_from_jcmd(int sock) {
 
 void VM_Crac::report_ok_to_jcmd_if_any() {
 #if INCLUDE_SERVICES
-  if (_attach_op == NULL)
+  if (_attach_op == nullptr)
     return;
   bufferedStream* buf = static_cast<bufferedStream*>(_ostream);
   _attach_op->effectively_complete_raw(JNI_OK, buf);

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -293,7 +293,7 @@ class os::Linux {
 
   static void initialize_cpu_count() {
     initialize_processor_count();
-    if (cpu_to_node() != NULL) {
+    if (cpu_to_node() != nullptr) {
       rebuild_cpu_to_node_map();
     }
   }

--- a/src/hotspot/os/posix/attachListener_posix.cpp
+++ b/src/hotspot/os/posix/attachListener_posix.cpp
@@ -276,7 +276,7 @@ PosixAttachOperation* PosixAttachListener::get_current_op() {
 
 void PosixAttachListener::reset_current_op() {
   assert_listener_thread();
-  PosixAttachListener::_current_op = NULL;
+  PosixAttachListener::_current_op = nullptr;
 }
 
 // AttachListener functions

--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -1543,8 +1543,8 @@ static void signal_sets_init() {
 #ifdef LINUX
   // The signal is used with default crexec library, other CRaCEngines might use
   // signals in a different way and having this signal blocked could interfere.
-  const char *signal_engines[] = { "criu", "criuengine", "sim", "simengine", "pause", "pauseengine", NULL };
-  for (int i = 0; signal_engines[i] != NULL; ++i) {
+  const char *signal_engines[] = { "criu", "criuengine", "sim", "simengine", "pause", "pauseengine", nullptr };
+  for (int i = 0; signal_engines[i] != nullptr; ++i) {
     if (strcmp(CRaCEngine, signal_engines[i]) == 0) {
       sigaddset(&blocked_sigs, RESTORE_SIGNAL);
       break;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4729,7 +4729,7 @@ static wchar_t* wide_abs_unc_path(char const* path, errno_t & err, int additiona
 int os::mkdir(const char *path) {
   errno_t err;
   wchar_t* wide_path = wide_abs_unc_path(path, err);
-  if (wide_path == NULL) {
+  if (wide_path == nullptr) {
     errno = err;
     return -1;
   }
@@ -4741,7 +4741,7 @@ int os::mkdir(const char *path) {
 int os::rmdir(const char *path) {
   errno_t err;
   wchar_t* wide_path = wide_abs_unc_path(path, err);
-  if (wide_path == NULL) {
+  if (wide_path == nullptr) {
     errno = err;
     return -1;
   }

--- a/src/hotspot/share/compiler/compileLog.cpp
+++ b/src/hotspot/share/compiler/compileLog.cpp
@@ -194,7 +194,7 @@ void CompileLog::clear_identities() {
 void CompileLog::before_checkpoint() {
   // Remove only output stream, don't destroy the CompileLog itself.
   delete _out;
-  _out = NULL;
+  _out = nullptr;
   unlink(_file); // like in CompileLog dtor
   // _file_end: do not touch, mark_file_end calculates it based on the actual file size.
 }

--- a/src/hotspot/share/gc/g1/g1UncommitRegionTask.cpp
+++ b/src/hotspot/share/gc/g1/g1UncommitRegionTask.cpp
@@ -134,7 +134,7 @@ void G1UncommitRegionTask::execute() {
 }
 
 void G1UncommitRegionTask::finish_collection() {
-  // If _instance is NULL G1 GC is either not in use or its collection has not yet been executed.
+  // If _instance is null G1 GC is either not in use or its collection has not yet been executed.
   if (_instance) {
     G1CollectedHeap* g1h = G1CollectedHeap::heap();
     g1h->uncommit_regions((uint)-1);

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1116,7 +1116,7 @@ static void parse_argname(const char *arg, const char **argname, size_t *arg_len
   *argname = *has_plus_minus ? arg + 1 : arg;
 
   const char* equal_sign = strchr(*argname, '=');
-  if (equal_sign == NULL) {
+  if (equal_sign == nullptr) {
     *arg_len = strlen(*argname);
   } else {
     *arg_len = equal_sign - *argname;
@@ -1267,8 +1267,8 @@ const char* Arguments::get_property(const char* key) {
 }
 
 void Arguments::get_key_value(const char* prop, const char** key, const char** value) {
-  assert(key != NULL, "key should not be NULL");
-  assert(value != NULL, "value should not be NULL");
+  assert(key != nullptr, "key should not be null");
+  assert(value != nullptr, "value should not be null");
   const char* eq = strchr(prop, '=');
 
   if (eq == nullptr) {
@@ -1289,8 +1289,8 @@ void Arguments::get_key_value(const char* prop, const char** key, const char** v
 }
 
 bool Arguments::add_property(const char* prop, PropertyWriteable writeable, PropertyInternal internal) {
-  const char* key = NULL;
-  const char* value = NULL;
+  const char* key = nullptr;
+  const char* value = nullptr;
 
   get_key_value(prop, &key, &value);
 
@@ -2202,7 +2202,7 @@ bool Arguments::is_restore_option_set(const JavaVMInitArgs* args) {
 }
 
 bool Arguments::parse_options_for_restore(const JavaVMInitArgs* args) {
-  const char *tail = NULL;
+  const char *tail = nullptr;
 
   // iterate over arguments
   for (int index = 0; index < args->nOptions; index++) {
@@ -2216,15 +2216,15 @@ bool Arguments::parse_options_for_restore(const JavaVMInitArgs* args) {
       // or even inheriting the CLASSPATH env var; therefore it's too
       // late to prohibit explicitly setting them at this point.
     } else if (match_option(option, "-D", &tail)) {
-      const char* key = NULL;
-      const char* value = NULL;
+      const char* key = nullptr;
+      const char* value = nullptr;
 
       get_key_value(tail, &key, &value);
 
       if (strcmp(key, "sun.java.crac_command") == 0) {
         char *old_java_command = _java_command_crac;
         _java_command_crac = os::strdup_check_oom(value, mtArguments);
-        if (old_java_command != NULL) {
+        if (old_java_command != nullptr) {
           os::free(old_java_command);
         }
       } else {
@@ -2243,7 +2243,7 @@ bool Arguments::parse_options_for_restore(const JavaVMInitArgs* args) {
       bool ignored_plus_minus;
       parse_argname(tail, &argname, &arg_len, &ignored_plus_minus);
       const JVMFlag* flag = JVMFlag::find_declared_flag((const char*)argname, arg_len);
-      if (flag != NULL) {
+      if (flag != nullptr) {
         if (!flag->is_restore_settable()) {
           jio_fprintf(defaultStream::error_stream(),
             "Flag %.*s cannot be set during restore: %s\n", arg_len, argname, option->optionString);

--- a/src/hotspot/share/runtime/crac_structs.hpp
+++ b/src/hotspot/share/runtime/crac_structs.hpp
@@ -45,7 +45,7 @@ struct CracFailDep {
   { }
   CracFailDep() :
     _type(JVM_CR_FAIL),
-    _msg(NULL)
+    _msg(nullptr)
   { }
 };
 
@@ -77,7 +77,7 @@ class CracRestoreParameters : public CHeapObj<mtInternal> {
 
   static int system_props_length(const SystemProperty* props) {
     int len = 0;
-    while (props != NULL) {
+    while (props != nullptr) {
       ++len;
       props = props->next();
     }
@@ -97,9 +97,9 @@ class CracRestoreParameters : public CHeapObj<mtInternal> {
   GrowableArray<const char *>* properties() const { return _properties; }
 
   CracRestoreParameters() :
-    _raw_content(NULL),
+    _raw_content(nullptr),
     _properties(new (mtInternal) GrowableArray<const char *>(0, mtInternal)),
-    _args(NULL)
+    _args(nullptr)
   {}
 
   ~CracRestoreParameters() {
@@ -134,7 +134,7 @@ class CracRestoreParameters : public CHeapObj<mtInternal> {
     }
 
     const SystemProperty* p = props;
-    while (p != NULL) {
+    while (p != nullptr) {
       char prop[4096];
       int len = snprintf(prop, sizeof(prop), "%s=%s", p->key(), p->value());
       guarantee((0 < len) && ((unsigned)len < sizeof(prop)), "property does not fit temp buffer");
@@ -178,7 +178,7 @@ public:
     _restore_parameters(),
     _ostream(jcmd_stream ? jcmd_stream : tty)
 #if defined(LINUX) && INCLUDE_SERVICES
-    , _attach_op(jcmd_stream ? PosixAttachListener::get_current_op() : NULL)
+    , _attach_op(jcmd_stream ? PosixAttachListener::get_current_op() : nullptr)
 #endif // LINUX && INCLUDE_SERVICES
   { }
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1956,10 +1956,10 @@ const int ObjectAlignmentInBytes = 8;
              "Mark all threads after a safepoint, and clear on a modify "   \
              "fence. Add cleanliness checks.")                              \
                                                                             \
-  product(ccstr, CRaCCheckpointTo, NULL, RESTORE_SETTABLE,                  \
+  product(ccstr, CRaCCheckpointTo, nullptr, RESTORE_SETTABLE,               \
         "Path to checkpoint image directory")                               \
                                                                             \
-  product(ccstr, CRaCRestoreFrom, NULL, RESTORE_SETTABLE,                   \
+  product(ccstr, CRaCRestoreFrom, nullptr, RESTORE_SETTABLE,                \
       "Path to image for restore, replaces the initializing VM on success") \
                                                                             \
   product(uint, CRaCMinPid, 128,                                            \
@@ -1987,7 +1987,7 @@ const int ObjectAlignmentInBytes = 8;
       "Ignore -XX:CRaCRestoreFrom and continue initialization if restore "  \
       "is unavailable")                                                     \
                                                                             \
-  product(ccstr, CRaCIgnoredFileDescriptors, NULL, RESTORE_SETTABLE,        \
+  product(ccstr, CRaCIgnoredFileDescriptors, nullptr, RESTORE_SETTABLE,     \
       "Comma-separated list of file descriptor numbers or paths. "          \
       "All file descriptors greater than 2 (stdin, stdout and stderr are "  \
       "excluded automatically) not in this list are closed when the VM "    \

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -1064,7 +1064,7 @@ void CheckpointDCmd::execute(DCmdSource source, TRAPS) {
                          vmSymbols::checkpointRestoreInternal_name(),
                          vmSymbols::checkpointRestoreInternal_signature(), &args, CHECK);
   oop str = result.get_oop();
-  if (str != NULL) {
+  if (str != nullptr) {
     char* out = java_lang_String::as_utf8_string(str);
     if (out[0] != '\0') {
       outputStream* stream = output();

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -139,6 +139,7 @@ serviceability_ttf_virtual = \
   -serviceability/jvmti/negative
 
 tier1_common = \
+  sources \
   sanity/BasicVMTest.java \
   gtest/GTestWrapper.java \
   gtest/LockStackGtests.java \
@@ -619,16 +620,12 @@ tier1_serviceability = \
   -serviceability/sa/TestJmapCore.java \
   -serviceability/sa/TestJmapCoreMetaspace.java
 
-tier1_sources = \
-   sources
-
 tier1 = \
   :tier1_common \
   :tier1_compiler \
   :tier1_gc \
   :tier1_runtime \
   :tier1_serviceability \
-  :tier1_sources
 
 tier2 = \
   :hotspot_tier2_runtime \


### PR DESCRIPTION
jtreg test TestNoNULL.java fails due to a number of usages of NULL in CRaC code.

The test becomes a part of hg/tier1_common after [JDK-8352645](https://bugs.openjdk.org/browse/JDK-8352645)  (integrated in b17) and GHA starts reporting the failures after merge with jdk-25+17.

The patch replaces NULL with nullptr (and with null in comments and messages in asserts). The test passes with the change.
