### PR TITLE
Fix confusing but harmless typos

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -58,9 +58,9 @@ uint64_t VM_Version::_glibc_features;
 uint64_t VM_Version::_features_saved;
 uint64_t VM_Version::_glibc_features_saved;
 
-#define DECLARE_CPU_FEATURE_NAME(id, name, bit) name,
-const char* VM_Version::      _features_names[] = {   CPU_FEATURE_FLAGS(DECLARE_CPU_FEATURE_NAME)};
-const char* VM_Version::_glibc_features_names[] = { GLIBC_FEATURE_FLAGS(DECLARE_CPU_FEATURE_NAME)};
+#define DECLARE_CPU_FEATURE_FLAG(id, name, bit) name,
+const char* VM_Version::      _features_names[] = {   CPU_FEATURE_FLAGS(DECLARE_CPU_FEATURE_FLAG)};
+const char* VM_Version::_glibc_features_names[] = { GLIBC_FEATURE_FLAGS(DECLARE_CPU_FEATURE_FLAG)};
 #undef DECLARE_CPU_FEATURE_FLAG
 
 // Address of instruction which causes SEGV

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -1073,7 +1073,6 @@ VMLongConstantEntry JVMCIVMStructs::localHotSpotVMLongConstants[] = {
 #endif
   GENERATE_VM_LONG_CONSTANT_LAST_ENTRY()
 };
-#undef DECLARE_CPU_FEATURE_FLAG
 
 VMAddressEntry JVMCIVMStructs::localHotSpotVMAddresses[] = {
   VM_ADDRESSES(GENERATE_VM_ADDRESS_ENTRY,


### PR DESCRIPTION
The name `DECLARE_CPU_FEATURE_FLAG` is used in all other cases. In `vmStructs_jvmci.cpp` there was no matching `#define`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/245/head:pull/245` \
`$ git checkout pull/245`

Update a local copy of the PR: \
`$ git checkout pull/245` \
`$ git pull https://git.openjdk.org/crac.git pull/245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 245`

View PR using the GUI difftool: \
`$ git pr show -t 245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/245.diff">https://git.openjdk.org/crac/pull/245.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/245#issuecomment-3084339977)
</details>
