### PR TITLE
8362837: [CRaC] jdk/crac/MXBean.java can fail on macOS

### DIFF
--- a/test/jdk/jdk/crac/MXBean.java
+++ b/test/jdk/jdk/crac/MXBean.java
@@ -76,21 +76,23 @@ public class MXBean implements CracTest {
             process.waitForPausePid();
             restoreStartTime = System.currentTimeMillis();
             builder.doRestore();
-            System.out.println("RestoreStartTime " + restoreStartTime + " " + formatTime(restoreStartTime));
         } else {
+            restoreStartTime = System.currentTimeMillis(); // A very rough approximation
             output = builder.engine(CracEngine.SIMULATE).startCheckpoint().waitForSuccess().outputAnalyzer();
-            restoreStartTime = -1; // Unknown
         }
+        System.out.println("RestoreStartTime " + restoreStartTime + " " + formatTime(restoreStartTime));
 
         final long uptimeSinceRestore = Long.parseLong(output.firstMatch("UptimeSinceRestore ([0-9-]+)", 1));
         assertGTE(uptimeSinceRestore, 0L, "Bad UptimeSinceRestore");
-        assertLT(uptimeSinceRestore, TIME_TOLERANCE, "UptimeSinceRestore should be close to 0");
+        assertLT(uptimeSinceRestore, TIME_TOLERANCE, "UptimeSinceRestore should be a bit greater than 0");
 
         final long restoreTime = Long.parseLong(output.firstMatch("RestoreTime ([0-9-]+)", 1));
         assertGTE(restoreTime, 0L, "Bad RestoreTime");
         if (Platform.isLinux()) {
-            assertLT(Math.abs(restoreTime - restoreStartTime), TIME_TOLERANCE,
-                    "RestoreTime " + restoreTime + " should be close to " + restoreStartTime);
+            assertLT(restoreTime - restoreStartTime, TIME_TOLERANCE,
+                    "RestoreTime " + restoreTime + " should be a bit greater than " + restoreStartTime);
+        } else {
+            assertGT(restoreTime, restoreStartTime, "Time has gone backwards?");
         }
     }
 }

--- a/test/jdk/jdk/crac/MXBean.java
+++ b/test/jdk/jdk/crac/MXBean.java
@@ -53,8 +53,6 @@ public class MXBean implements CracTest {
 
         Core.checkpointRestore();
 
-        System.out.println("UptimeSinceRestore " + cracMXBean.getUptimeSinceRestore());
-
         long restoreTime = cracMXBean.getRestoreTime();
         System.out.println("RestoreTime " + restoreTime + " " +
             DateTimeFormatter.ofPattern("E dd LLL yyyy HH:mm:ss.n").format(
@@ -75,7 +73,7 @@ public class MXBean implements CracTest {
             output = builder.captureOutput(true).doRestore().outputAnalyzer();
 
             long restoreTimePassed = System.currentTimeMillis() - restoreStart;
-            System.err.println("restoreTimePassed="+restoreTimePassed);
+            System.err.println("restoreTimePassed=" + restoreTimePassed);
             if (restoreTimePassed < 0 || TIME_TOLERANCE < restoreTimePassed) {
                 throw new Error("bad time since restore started: " + restoreTimePassed);
             }
@@ -83,12 +81,6 @@ public class MXBean implements CracTest {
             output = builder.engine(CracEngine.SIMULATE)
                     .captureOutput(true)
                     .startCheckpoint().waitForSuccess().outputAnalyzer();
-        }
-
-        long restoreUptime = Long.parseLong(output.firstMatch("UptimeSinceRestore ([0-9-]+)", 1));
-        System.err.println("restoreUptime=" + restoreUptime);
-        if (restoreUptime < 0) {
-            throw new Error("bad UptimeSinceRestore: " + restoreUptime);
         }
 
         long restoreTime = Long.parseLong(output.firstMatch("RestoreTime ([0-9-]+)", 1));

--- a/test/jdk/jdk/crac/MXBean.java
+++ b/test/jdk/jdk/crac/MXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Azul Systems, Inc. All rights reserved.
+ * Copyright (c) 2022, 2025, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/crac/MXBean.java
+++ b/test/jdk/jdk/crac/MXBean.java
@@ -69,20 +69,20 @@ public class MXBean implements CracTest {
 
         OutputAnalyzer output;
         if (Platform.isLinux()) {
-	    builder.doCheckpoint();
+            builder.doCheckpoint();
 
-	    long restoreStart = System.currentTimeMillis();
-	    output = builder.captureOutput(true).doRestore().outputAnalyzer();
+            long restoreStart = System.currentTimeMillis();
+            output = builder.captureOutput(true).doRestore().outputAnalyzer();
 
-	    long restoreTimePassed = System.currentTimeMillis() - restoreStart;
-	    System.err.println("restoreTimePassed="+restoreTimePassed);
-	    if (restoreTimePassed < 0 || TIME_TOLERANCE < restoreTimePassed) {
-		throw new Error("bad time since restore started: " + restoreTimePassed);
-	    }
+            long restoreTimePassed = System.currentTimeMillis() - restoreStart;
+            System.err.println("restoreTimePassed="+restoreTimePassed);
+            if (restoreTimePassed < 0 || TIME_TOLERANCE < restoreTimePassed) {
+                throw new Error("bad time since restore started: " + restoreTimePassed);
+            }
         } else {
-	    output = builder.engine(CracEngine.SIMULATE)
-		    .captureOutput(true)
-		    .startCheckpoint().waitForSuccess().outputAnalyzer();
+            output = builder.engine(CracEngine.SIMULATE)
+                    .captureOutput(true)
+                    .startCheckpoint().waitForSuccess().outputAnalyzer();
         }
 
         long restoreUptime = Long.parseLong(output.firstMatch("UptimeSinceRestore ([0-9-]+)", 1));


### PR DESCRIPTION
The CI runs fine but locally (Linux Fedora 42 x86_64) it is failing for me - for any testcase trying to use OutputAnalyzer for the restore-only part. Such testcases failing for me are for example:
- test/jdk/jdk/crac/fileDescriptors/CheckpointWithOpenFdsTest.java
- test/jdk/jdk/crac/fileDescriptors/LoggingFileOpenTest.java
- test/jdk/jdk/crac/SecureRandom/ReseedTest.java

It does not implement the part

> close to 0

as that is the problem being fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8362837](https://bugs.openjdk.org/browse/JDK-8362837): [CRaC] jdk/crac/MXBean.java can fail on macOS (**Bug** - P4)


### Reviewers
 * [Timofei Pushkin](https://openjdk.org/census#tpushkin) (@TimPushkin - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/246/head:pull/246` \
`$ git checkout pull/246`

Update a local copy of the PR: \
`$ git checkout pull/246` \
`$ git pull https://git.openjdk.org/crac.git pull/246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 246`

View PR using the GUI difftool: \
`$ git pr show -t 246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/246.diff">https://git.openjdk.org/crac/pull/246.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/246#issuecomment-3092569085)
</details>
