### PR TITLE
8352675: Support Intel AVX10 converged vector ISA feature detection

### DIFF
--- a/src/hotspot/cpu/aarch64/vmStructs_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vmStructs_aarch64.hpp
@@ -35,8 +35,7 @@
               static_field(VM_Version,      _rop_protection, bool)      \
               static_field(VM_Version,      _pac_mask,       uintptr_t)
 
-#define VM_TYPES_CPU(declare_type, declare_toplevel_type, declare_oop_type, declare_integer_type, declare_unsigned_integer_type) \
-  declare_toplevel_type(VM_Version)
+#define VM_TYPES_CPU(declare_type, declare_toplevel_type, declare_oop_type, declare_integer_type, declare_unsigned_integer_type)
 
 #define VM_INT_CONSTANTS_CPU(declare_constant, declare_preprocessor_constant)
 

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -194,9 +194,6 @@ enum Ampere_CPU_Model {
   static bool is_cpu_emulated();
 #endif
 
-  // No _features_names[] available on this CPU.
-  static void insert_features_names(char* buf, size_t buflen, uint64_t features = _features) {}
-
   static void initialize_cpu_information(void);
 
   static bool use_rop_protection() { return _rop_protection; }

--- a/src/hotspot/cpu/ppc/vm_version_ppc.hpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.hpp
@@ -131,9 +131,6 @@ public:
   static void allow_all();
   static void revert();
 
-  // No _features_names[] available on this CPU.
-  static void insert_features_names(char* buf, size_t buflen, uint64_t features = _features) {}
-
   // POWER 8: DSCR current value.
   static uint64_t _dscr_val;
 

--- a/src/hotspot/cpu/s390/vm_version_s390.hpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.hpp
@@ -589,9 +589,6 @@ class VM_Version: public Abstract_VM_Version {
   static unsigned long z_SIGILL();
   static unsigned long z_SIGSEGV();
 
-  // No _features_names[] available on this CPU.
-  static void insert_features_names(char* buf, size_t buflen, unsigned long features[] = _features) {}
-
   static void initialize_cpu_information(void);
 };
 

--- a/src/hotspot/cpu/x86/vmStructs_x86.hpp
+++ b/src/hotspot/cpu/x86/vmStructs_x86.hpp
@@ -29,15 +29,20 @@
 // constants required by the Serviceability Agent. This file is
 // referenced by vmStructs.cpp.
 
-#define VM_STRUCTS_CPU(nonstatic_field, static_field, unchecked_nonstatic_field, volatile_nonstatic_field, nonproduct_nonstatic_field)            \
-  volatile_nonstatic_field(JavaFrameAnchor, _last_Java_fp, intptr_t*)
+#define VM_STRUCTS_CPU(nonstatic_field, static_field, unchecked_nonstatic_field, volatile_nonstatic_field, nonproduct_nonstatic_field) \
+  volatile_nonstatic_field(JavaFrameAnchor,         _last_Java_fp,                  intptr_t*)               \
+              static_field(VM_Version,              _features,                      VM_Version::VM_Features) \
+           nonstatic_field(VM_Version::VM_Features, _features_bitmap[0],            uint64_t)                \
+              static_field(VM_Version::VM_Features, _features_bitmap_size,          int)
 
 #define VM_TYPES_CPU(declare_type, declare_toplevel_type, declare_oop_type, declare_integer_type, declare_unsigned_integer_type) \
+  declare_toplevel_type(VM_Version::VM_Features)
 
 #define VM_INT_CONSTANTS_CPU(declare_constant, declare_preprocessor_constant) \
-  LP64_ONLY(declare_constant(frame::arg_reg_save_area_bytes))       \
-  declare_constant(frame::interpreter_frame_sender_sp_offset)       \
-  declare_constant(frame::interpreter_frame_last_sp_offset)
+  declare_constant(frame::arg_reg_save_area_bytes)            \
+  declare_constant(frame::interpreter_frame_sender_sp_offset) \
+  declare_constant(frame::interpreter_frame_last_sp_offset)   \
+  declare_constant(frame::entry_frame_call_wrapper_offset)
 
 #define VM_LONG_CONSTANTS_CPU(declare_constant, declare_preprocessor_constant)
 

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -299,9 +299,29 @@ class VM_Version : public Abstract_VM_Version {
   union SefCpuid7SubLeaf1Edx {
     uint32_t value;
     struct {
-      uint32_t       : 21,
+      uint32_t       : 19,
+              avx10  : 1,
+                     : 1,
               apx_f  : 1,
                      : 10;
+    } bits;
+  };
+
+  union StdCpuid24MainLeafEax {
+    uint32_t value;
+    struct {
+      uint32_t  sub_leaves_cnt  : 31;
+    } bits;
+  };
+
+  union StdCpuid24MainLeafEbx {
+    uint32_t value;
+    struct {
+      uint32_t  avx10_converged_isa_version  : 8,
+                                             : 8,
+                                             : 2,
+                avx10_vlen_512               : 1,
+                                             : 13;
     } bits;
   };
 
@@ -346,9 +366,9 @@ protected:
   /*
    * Update following files when declaring new flags:
    * test/lib-test/jdk/test/whitebox/CPUInfoTest.java
-   * src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.amd64/src/jdk/vm/ci/amd64/AMD64.java
+   * src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
    */
-  enum Feature_Flag : uint64_t {
+  enum Feature_Flag {
 #define CPU_FEATURE_FLAGS(decl) \
     decl(CX8,               "cx8",               0)  /*  next bits are from cpuid 1 (EDX) */ \
     decl(CMOV,              "cmov",              1)  \
@@ -424,14 +444,25 @@ protected:
     decl(AVX_IFMA,          "avx_ifma",          59) /* 256-bit VEX-coded variant of AVX512-IFMA*/ \
     decl(APX_F,             "apx_f",             60) /* Intel Advanced Performance Extensions*/ \
     decl(SHA512,            "sha512",            61) /* SHA512 instructions*/ \
-    decl(AVX512_FP16,       "avx512_fp16",       62) /* AVX512 FP16 ISA support*/
+    decl(AVX512_FP16,       "avx512_fp16",       62) /* AVX512 FP16 ISA support*/ \
+    decl(AVX10_1,           "avx10_1",           63) /* AVX10 512 bit vector ISA Version 1 support*/ \
+    decl(AVX10_2,           "avx10_2",           64) /* AVX10 512 bit vector ISA Version 2 support*/
 
-#define DECLARE_CPU_FEATURE_FLAG(id, name, bit) CPU_##id = (1ULL << bit),
+#define DECLARE_CPU_FEATURE_FLAG(id, name, bit) CPU_##id = (bit),
     CPU_FEATURE_FLAGS(DECLARE_CPU_FEATURE_FLAG)
 #undef DECLARE_CPU_FEATURE_FLAG
+#if 0
+FIXME:CPUFeatures1
     MAX_CPU = CPU_SHA512 << 1
+FIXME:CPUFeatures2
+FIXME:CPUFeatures3
+#endif
+    MAX_CPU_FEATURES
+//FIXME:CPUFeatures4
   };
 
+#if 0
+FIXME:CPUFeatures1
   /* Tracking of a CPU feature for glibc */ \
   enum Glibc_Feature_Flag : uint64_t {
 #define GLIBC_FEATURE_FLAGS(decl) \
@@ -457,8 +488,79 @@ protected:
 
   static uint64_t _features_saved, _glibc_features_saved;
 
+FIXME:CPUFeatures2
+FIXME:CPUFeatures3
+#endif
+  class VM_Features {
+    friend class VMStructs;
+    friend class JVMCIVMStructs;
+
+   private:
+    uint64_t _features_bitmap[(MAX_CPU_FEATURES / BitsPerLong) + 1];
+
+    STATIC_ASSERT(sizeof(_features_bitmap) * BitsPerByte >= MAX_CPU_FEATURES);
+
+    // Number of 8-byte elements in _bitmap.
+    constexpr static int features_bitmap_element_count() {
+      return sizeof(_features_bitmap) / sizeof(uint64_t);
+    }
+
+    constexpr static int features_bitmap_element_shift_count() {
+      return LogBitsPerLong;
+    }
+
+    constexpr static uint64_t features_bitmap_element_mask() {
+      return (1ULL << features_bitmap_element_shift_count()) - 1;
+    }
+
+    static int index(Feature_Flag feature) {
+      int idx = feature >> features_bitmap_element_shift_count();
+      assert(idx < features_bitmap_element_count(), "Features array index out of bounds");
+      return idx;
+    }
+
+    static uint64_t bit_mask(Feature_Flag feature) {
+      return (1ULL << (feature & features_bitmap_element_mask()));
+    }
+
+    static int _features_bitmap_size; // for JVMCI purposes
+   public:
+    VM_Features() {
+      for (int i = 0; i < features_bitmap_element_count(); i++) {
+        _features_bitmap[i] = 0;
+      }
+    }
+
+    void set_feature(Feature_Flag feature) {
+      int idx = index(feature);
+      _features_bitmap[idx] |= bit_mask(feature);
+    }
+
+    void clear_feature(VM_Version::Feature_Flag feature) {
+      int idx = index(feature);
+      _features_bitmap[idx] &= ~bit_mask(feature);
+    }
+
+    bool supports_feature(VM_Version::Feature_Flag feature) {
+      int idx = index(feature);
+      return (_features_bitmap[idx] & bit_mask(feature)) != 0;
+    }
+  };
+
+  // CPU feature flags vector, can be affected by VM settings.
+  static VM_Features _features;
+
+  // Original CPU feature flags vector, not affected by VM settings.
+  static VM_Features _cpu_features;
+
+//FIXME:CPUFeatures4
   static const char* _features_names[];
   static const char* _glibc_features_names[];
+
+  static void clear_cpu_features() {
+    _features = VM_Features();
+    _cpu_features = VM_Features();
+  }
 
   enum Extended_Family {
     // AMD
@@ -522,6 +624,11 @@ protected:
     // eax = 7, ecx = 1
     SefCpuid7SubLeaf1Eax sefsl1_cpuid7_eax;
     SefCpuid7SubLeaf1Edx sefsl1_cpuid7_edx;
+
+    // cpuid function 24 converged vector ISA main leaf
+    // eax = 24, ecx = 0
+    StdCpuid24MainLeafEax std_cpuid24_eax;
+    StdCpuid24MainLeafEbx std_cpuid24_ebx;
 
     // cpuid function 0xB (processor topology)
     // ecx = 0
@@ -596,8 +703,10 @@ protected:
     // Space to save apx registers after signal handle
     jlong        apx_save[2]; // Save r16 and r31
 
-    uint64_t feature_flags() const;
+    VM_Features feature_flags() const;
 
+#if 0
+FIXME:CPUFeatures1
 #ifdef LINUX
     uint64_t glibc_flags() const {
       uint64_t result = 0;
@@ -619,7 +728,10 @@ protected:
         result |= GLIBC_HTT;
       return result;
     }
+#else
+    uint64_t glibc_flags() const { return 0; }
 #endif //LINUX
+#endif
 
     // Asserts
     void assert_is_initialized() const {
@@ -682,6 +794,7 @@ public:
   // Offsets for cpuid asm stub
   static ByteSize std_cpuid0_offset() { return byte_offset_of(CpuidInfo, std_max_function); }
   static ByteSize std_cpuid1_offset() { return byte_offset_of(CpuidInfo, std_cpuid1_eax); }
+  static ByteSize std_cpuid24_offset() { return byte_offset_of(CpuidInfo, std_cpuid24_eax); }
   static ByteSize dcp_cpuid4_offset() { return byte_offset_of(CpuidInfo, dcp_cpuid4_eax); }
   static ByteSize sef_cpuid7_offset() { return byte_offset_of(CpuidInfo, sef_cpuid7_eax); }
   static ByteSize sefsl1_cpuid7_offset() { return byte_offset_of(CpuidInfo, sefsl1_cpuid7_eax); }
@@ -715,17 +828,28 @@ public:
 
   static void clear_apx_test_state();
 
-  static void clean_cpuFeatures()   { _features = 0; }
-  static void set_avx_cpuFeatures() { _features |= (CPU_SSE | CPU_SSE2 | CPU_AVX | CPU_VZEROUPPER ); }
-  static void set_evex_cpuFeatures() { _features |= (CPU_AVX512F | CPU_SSE | CPU_SSE2 | CPU_VZEROUPPER ); }
-  static void set_apx_cpuFeatures() { _features |= CPU_APX_F; }
-  static void set_bmi_cpuFeatures() { _features |= (CPU_BMI1 | CPU_BMI2 | CPU_LZCNT | CPU_POPCNT); }
-
-  static void insert_features_names(char* buf, size_t buflen, uint64_t features = _features) {
-    Abstract_VM_Version::insert_features_names(buf, buflen, _features_names, features);
+  static void clean_cpuFeatures()   {
+    VM_Version::clear_cpu_features();
   }
-  static void insert_glibc_features_names(char* buf, size_t buflen, uint64_t glibc_features) {
-    Abstract_VM_Version::insert_features_names(buf, buflen, _glibc_features_names, glibc_features);
+  static void set_avx_cpuFeatures() {
+    _features.set_feature(CPU_SSE);
+    _features.set_feature(CPU_SSE2);
+    _features.set_feature(CPU_AVX);
+    _features.set_feature(CPU_VZEROUPPER);
+  }
+  static void set_evex_cpuFeatures() {
+    _features.set_feature(CPU_AVX10_1);
+    _features.set_feature(CPU_AVX512F);
+    _features.set_feature(CPU_SSE);
+    _features.set_feature(CPU_SSE2);
+    _features.set_feature(CPU_VZEROUPPER);
+  }
+  static void set_apx_cpuFeatures() { _features.set_feature(CPU_APX_F); }
+  static void set_bmi_cpuFeatures() {
+    _features.set_feature(CPU_BMI1);
+    _features.set_feature(CPU_BMI2);
+    _features.set_feature(CPU_LZCNT);
+    _features.set_feature(CPU_POPCNT);
   }
 
   // Initialization
@@ -735,7 +859,12 @@ public:
   };
   static bool cpu_features_binary(CPUFeaturesBinary *data);
   static bool cpu_features_binary_check(const CPUFeaturesBinary *data);
+#if 0
+FIXME:CPUFeatures1
   static bool ignore_cpu_features() { return _ignore_glibc_not_using; }
+#else
+  static bool ignore_cpu_features() { return true; }
+#endif
   static void restore_check(const char* str, const char* msg_prefix);
 
   // Override Abstract_VM_Version implementation
@@ -788,40 +917,39 @@ public:
   //
   // Feature identification which can be affected by VM settings
   //
-  static bool supports_cpuid()        { return _features  != 0; }
-  static bool supports_cmov()         { return (_features & CPU_CMOV) != 0; }
-  static bool supports_fxsr()         { return (_features & CPU_FXSR) != 0; }
-  static bool supports_ht()           { return (_features & CPU_HT) != 0; }
-  static bool supports_mmx()          { return (_features & CPU_MMX) != 0; }
-  static bool supports_sse()          { return (_features & CPU_SSE) != 0; }
-  static bool supports_sse2()         { return (_features & CPU_SSE2) != 0; }
-  static bool supports_sse3()         { return (_features & CPU_SSE3) != 0; }
-  static bool supports_ssse3()        { return (_features & CPU_SSSE3)!= 0; }
-  static bool supports_sse4_1()       { return (_features & CPU_SSE4_1) != 0; }
-  static bool supports_sse4_2()       { return (_features & CPU_SSE4_2) != 0; }
-  static bool supports_popcnt()       { return (_features & CPU_POPCNT) != 0; }
-  static bool supports_avx()          { return (_features & CPU_AVX) != 0; }
-  static bool supports_avx2()         { return (_features & CPU_AVX2) != 0; }
-  static bool supports_tsc()          { return (_features & CPU_TSC) != 0; }
-  static bool supports_rdtscp()       { return (_features & CPU_RDTSCP) != 0; }
-  static bool supports_rdpid()        { return (_features & CPU_RDPID) != 0; }
-  static bool supports_aes()          { return (_features & CPU_AES) != 0; }
-  static bool supports_erms()         { return (_features & CPU_ERMS) != 0; }
-  static bool supports_fsrm()         { return (_features & CPU_FSRM) != 0; }
-  static bool supports_clmul()        { return (_features & CPU_CLMUL) != 0; }
-  static bool supports_rtm()          { return (_features & CPU_RTM) != 0; }
-  static bool supports_bmi1()         { return (_features & CPU_BMI1) != 0; }
-  static bool supports_bmi2()         { return (_features & CPU_BMI2) != 0; }
-  static bool supports_adx()          { return (_features & CPU_ADX) != 0; }
-  static bool supports_evex()         { return (_features & CPU_AVX512F) != 0; }
-  static bool supports_avx512dq()     { return (_features & CPU_AVX512DQ) != 0; }
-  static bool supports_avx512ifma()   { return (_features & CPU_AVX512_IFMA) != 0; }
-  static bool supports_avxifma()      { return (_features & CPU_AVX_IFMA) != 0; }
-  static bool supports_avx512pf()     { return (_features & CPU_AVX512PF) != 0; }
-  static bool supports_avx512er()     { return (_features & CPU_AVX512ER) != 0; }
-  static bool supports_avx512cd()     { return (_features & CPU_AVX512CD) != 0; }
-  static bool supports_avx512bw()     { return (_features & CPU_AVX512BW) != 0; }
-  static bool supports_avx512vl()     { return (_features & CPU_AVX512VL) != 0; }
+  static bool supports_cmov()         { return _features.supports_feature(CPU_CMOV); }
+  static bool supports_fxsr()         { return _features.supports_feature(CPU_FXSR); }
+  static bool supports_ht()           { return _features.supports_feature(CPU_HT); }
+  static bool supports_mmx()          { return _features.supports_feature(CPU_MMX); }
+  static bool supports_sse()          { return _features.supports_feature(CPU_SSE); }
+  static bool supports_sse2()         { return _features.supports_feature(CPU_SSE2); }
+  static bool supports_sse3()         { return _features.supports_feature(CPU_SSE3); }
+  static bool supports_ssse3()        { return _features.supports_feature(CPU_SSSE3); }
+  static bool supports_sse4_1()       { return _features.supports_feature(CPU_SSE4_1); }
+  static bool supports_sse4_2()       { return _features.supports_feature(CPU_SSE4_2); }
+  static bool supports_popcnt()       { return _features.supports_feature(CPU_POPCNT); }
+  static bool supports_avx()          { return _features.supports_feature(CPU_AVX); }
+  static bool supports_avx2()         { return _features.supports_feature(CPU_AVX2); }
+  static bool supports_tsc()          { return _features.supports_feature(CPU_TSC); }
+  static bool supports_rdtscp()       { return _features.supports_feature(CPU_RDTSCP); }
+  static bool supports_rdpid()        { return _features.supports_feature(CPU_RDPID); }
+  static bool supports_aes()          { return _features.supports_feature(CPU_AES); }
+  static bool supports_erms()         { return _features.supports_feature(CPU_ERMS); }
+  static bool supports_fsrm()         { return _features.supports_feature(CPU_FSRM); }
+  static bool supports_clmul()        { return _features.supports_feature(CPU_CLMUL); }
+  static bool supports_rtm()          { return _features.supports_feature(CPU_RTM); }
+  static bool supports_bmi1()         { return _features.supports_feature(CPU_BMI1); }
+  static bool supports_bmi2()         { return _features.supports_feature(CPU_BMI2); }
+  static bool supports_adx()          { return _features.supports_feature(CPU_ADX); }
+  static bool supports_evex()         { return _features.supports_feature(CPU_AVX512F); }
+  static bool supports_avx512dq()     { return _features.supports_feature(CPU_AVX512DQ); }
+  static bool supports_avx512ifma()   { return _features.supports_feature(CPU_AVX512_IFMA); }
+  static bool supports_avxifma()      { return _features.supports_feature(CPU_AVX_IFMA); }
+  static bool supports_avx512pf()     { return _features.supports_feature(CPU_AVX512PF); }
+  static bool supports_avx512er()     { return _features.supports_feature(CPU_AVX512ER); }
+  static bool supports_avx512cd()     { return _features.supports_feature(CPU_AVX512CD); }
+  static bool supports_avx512bw()     { return _features.supports_feature(CPU_AVX512BW); }
+  static bool supports_avx512vl()     { return _features.supports_feature(CPU_AVX512VL); }
   static bool supports_avx512vlbw()   { return (supports_evex() && supports_avx512bw() && supports_avx512vl()); }
   static bool supports_avx512bwdq()   { return (supports_evex() && supports_avx512bw() && supports_avx512dq()); }
   static bool supports_avx512vldq()   { return (supports_evex() && supports_avx512dq() && supports_avx512vl()); }
@@ -830,33 +958,39 @@ public:
   static bool supports_avx512novl()   { return (supports_evex() && !supports_avx512vl()); }
   static bool supports_avx512nobw()   { return (supports_evex() && !supports_avx512bw()); }
   static bool supports_avx256only()   { return (supports_avx2() && !supports_evex()); }
-  static bool supports_apx_f()        { return (_features & CPU_APX_F) != 0; }
+  static bool supports_apx_f()        { return _features.supports_feature(CPU_APX_F); }
   static bool supports_avxonly()      { return ((supports_avx2() || supports_avx()) && !supports_evex()); }
-  static bool supports_sha()          { return (_features & CPU_SHA) != 0; }
-  static bool supports_fma()          { return (_features & CPU_FMA) != 0 && supports_avx(); }
-  static bool supports_vzeroupper()   { return (_features & CPU_VZEROUPPER) != 0; }
-  static bool supports_avx512_vpopcntdq()  { return (_features & CPU_AVX512_VPOPCNTDQ) != 0; }
-  static bool supports_avx512_vpclmulqdq() { return (_features & CPU_AVX512_VPCLMULQDQ) != 0; }
-  static bool supports_avx512_vaes()  { return (_features & CPU_AVX512_VAES) != 0; }
-  static bool supports_gfni()         { return (_features & CPU_GFNI) != 0; }
-  static bool supports_avx512_vnni()  { return (_features & CPU_AVX512_VNNI) != 0; }
-  static bool supports_avx512_bitalg()  { return (_features & CPU_AVX512_BITALG) != 0; }
-  static bool supports_avx512_vbmi()  { return (_features & CPU_AVX512_VBMI) != 0; }
-  static bool supports_avx512_vbmi2() { return (_features & CPU_AVX512_VBMI2) != 0; }
-  static bool supports_avx512_fp16()  { return (_features & CPU_AVX512_FP16) != 0; }
-  static bool supports_hv()           { return (_features & CPU_HV) != 0; }
-  static bool supports_serialize()    { return (_features & CPU_SERIALIZE) != 0; }
-  static bool supports_f16c()         { return (_features & CPU_F16C) != 0; }
-  static bool supports_pku()          { return (_features & CPU_PKU) != 0; }
-  static bool supports_ospke()        { return (_features & CPU_OSPKE) != 0; }
-  static bool supports_cet_ss()       { return (_features & CPU_CET_SS) != 0; }
-  static bool supports_cet_ibt()      { return (_features & CPU_CET_IBT) != 0; }
-  static bool supports_sha512()       { return (_features & CPU_SHA512) != 0; }
+  static bool supports_sha()          { return _features.supports_feature(CPU_SHA); }
+  static bool supports_fma()          { return _features.supports_feature(CPU_FMA) && supports_avx(); }
+  static bool supports_vzeroupper()   { return _features.supports_feature(CPU_VZEROUPPER); }
+  static bool supports_avx512_vpopcntdq()  { return _features.supports_feature(CPU_AVX512_VPOPCNTDQ); }
+  static bool supports_avx512_vpclmulqdq() { return _features.supports_feature(CPU_AVX512_VPCLMULQDQ); }
+  static bool supports_avx512_vaes()  { return _features.supports_feature(CPU_AVX512_VAES); }
+  static bool supports_gfni()         { return _features.supports_feature(CPU_GFNI); }
+  static bool supports_avx512_vnni()  { return _features.supports_feature(CPU_AVX512_VNNI); }
+  static bool supports_avx512_bitalg()  { return _features.supports_feature(CPU_AVX512_BITALG); }
+  static bool supports_avx512_vbmi()  { return _features.supports_feature(CPU_AVX512_VBMI); }
+  static bool supports_avx512_vbmi2() { return _features.supports_feature(CPU_AVX512_VBMI2); }
+  static bool supports_avx512_fp16()  { return _features.supports_feature(CPU_AVX512_FP16); }
+  static bool supports_hv()           { return _features.supports_feature(CPU_HV); }
+  static bool supports_serialize()    { return _features.supports_feature(CPU_SERIALIZE); }
+  static bool supports_f16c()         { return _features.supports_feature(CPU_F16C); }
+  static bool supports_pku()          { return _features.supports_feature(CPU_PKU); }
+  static bool supports_ospke()        { return _features.supports_feature(CPU_OSPKE); }
+  static bool supports_cet_ss()       { return _features.supports_feature(CPU_CET_SS); }
+  static bool supports_cet_ibt()      { return _features.supports_feature(CPU_CET_IBT); }
+  static bool supports_sha512()       { return _features.supports_feature(CPU_SHA512); }
+
+  // Intel® AVX10 introduces a versioned approach for enumeration that is monotonically increasing, inclusive,
+  // and supporting all vector lengths. Feature set supported by an AVX10 vector ISA version is also supported
+  // by all the versions above it.
+  static bool supports_avx10_1()      { return _features.supports_feature(CPU_AVX10_1);}
+  static bool supports_avx10_2()      { return _features.supports_feature(CPU_AVX10_2);}
 
   //
   // Feature identification not affected by VM flags
   //
-  static bool cpu_supports_evex()     { return (_cpu_features & CPU_AVX512F) != 0; }
+  static bool cpu_supports_evex()     { return _cpu_features.supports_feature(CPU_AVX512F); }
 
   static bool supports_avx512_simd_sort() {
     if (supports_avx512dq()) {
@@ -887,6 +1021,8 @@ public:
 
   static bool is_intel_tsc_synched_at_init();
 
+  static void insert_features_names(VM_Version::VM_Features features, char* buf, size_t buflen);
+
   // This checks if the JVM is potentially affected by an erratum on Intel CPUs (SKX102)
   // that causes unpredictable behaviour when jcc crosses 64 byte boundaries. Its microcode
   // mitigation causes regressions when jumps or fused conditional branches cross or end at
@@ -894,19 +1030,19 @@ public:
   static bool has_intel_jcc_erratum() { return _has_intel_jcc_erratum; }
 
   // AMD features
-  static bool supports_3dnow_prefetch()    { return (_features & CPU_3DNOW_PREFETCH) != 0; }
-  static bool supports_lzcnt()    { return (_features & CPU_LZCNT) != 0; }
-  static bool supports_sse4a()    { return (_features & CPU_SSE4A) != 0; }
+  static bool supports_3dnow_prefetch()    { return _features.supports_feature(CPU_3DNOW_PREFETCH); }
+  static bool supports_lzcnt()    { return _features.supports_feature(CPU_LZCNT); }
+  static bool supports_sse4a()    { return _features.supports_feature(CPU_SSE4A); }
 
   static bool is_amd_Barcelona()  { return is_amd() &&
                                            extended_cpu_family() == CPU_FAMILY_AMD_11H; }
 
   // Intel and AMD newer cores support fast timestamps well
   static bool supports_tscinv_bit() {
-    return (_features & CPU_TSCINV_BIT) != 0;
+    return _features.supports_feature(CPU_TSCINV_BIT);
   }
   static bool supports_tscinv() {
-    return (_features & CPU_TSCINV) != 0;
+    return _features.supports_feature(CPU_TSCINV);
   }
 
   // Intel Core and newer cpus have fast IDIV instruction (excluding Atom).
@@ -967,8 +1103,8 @@ public:
   static bool supports_clflush(); // Can't inline due to header file conflict
 
   // Note: CPU_FLUSHOPT and CPU_CLWB bits should always be zero for 32-bit
-  static bool supports_clflushopt() { return ((_features & CPU_FLUSHOPT) != 0); }
-  static bool supports_clwb() { return ((_features & CPU_CLWB) != 0); }
+  static bool supports_clflushopt() { return (_features.supports_feature(CPU_FLUSHOPT)); }
+  static bool supports_clwb() { return (_features.supports_feature(CPU_CLWB)); }
 
   // Old CPUs perform lea on AGU which causes additional latency transferring the
   // value from/to ALU for other operations

--- a/src/hotspot/cpu/zero/vm_version_zero.hpp
+++ b/src/hotspot/cpu/zero/vm_version_zero.hpp
@@ -37,9 +37,6 @@ class VM_Version : public Abstract_VM_Version {
   static bool cpu_features_binary_check(const CPUFeaturesBinary *data) { return data == nullptr; }
   static bool ignore_cpu_features() { return true; }
 
-  // No _features_names[] available on this CPU.
-  static void insert_features_names(char* buf, size_t buflen, uint64_t features = _features) {}
-
   constexpr static bool supports_stack_watermark_barrier() { return true; }
 
   static void initialize_cpu_information(void);

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -470,6 +470,7 @@ jobjectArray readConfiguration0(JNIEnv *env, JVMCI_TRAPS) {
                  strcmp(vmField.typeString, "intptr_t") == 0 ||
                  strcmp(vmField.typeString, "uintptr_t") == 0 ||
                  strcmp(vmField.typeString, "OopHandle") == 0 ||
+                 strcmp(vmField.typeString, "VM_Version::VM_Features") == 0 ||
                  strcmp(vmField.typeString, "size_t") == 0 ||
                  // All foo* types are addresses.
                  vmField.typeString[strlen(vmField.typeString) - 1] == '*') {

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -150,7 +150,7 @@
                                                                                                                                      \
   static_field(CompilerToVM::Data,             data_section_item_alignment,            int)                                          \
                                                                                                                                      \
-  JVMTI_ONLY(static_field(CompilerToVM::Data,  _should_notify_object_alloc,            int*))                                         \
+  JVMTI_ONLY(static_field(CompilerToVM::Data,  _should_notify_object_alloc,            int*))                                        \
                                                                                                                                      \
   static_field(Abstract_VM_Version,            _features,                              uint64_t)                                     \
                                                                                                                                      \
@@ -997,7 +997,11 @@
 
 #define VM_STRUCTS_CPU(nonstatic_field, static_field, unchecked_nonstatic_field, volatile_nonstatic_field, nonproduct_nonstatic_field) \
   volatile_nonstatic_field(JavaFrameAnchor, _last_Java_fp, intptr_t*) \
-  static_field(VM_Version, _has_intel_jcc_erratum, bool)
+  static_field(VM_Version,                     _features,                      VM_Version::VM_Features) \
+                                                                                                        \
+  nonstatic_field(VM_Version::VM_Features,     _features_bitmap[0],            uint64_t)                \
+  static_field(VM_Version::VM_Features,        _features_bitmap_size,          int)                     \
+  static_field(VM_Version,                     _has_intel_jcc_erratum,         bool)
 
 #define VM_INT_CONSTANTS_CPU(declare_constant, declare_preprocessor_constant) \
   LP64_ONLY(declare_constant(frame::arg_reg_save_area_bytes))       \
@@ -1005,7 +1009,8 @@
   declare_constant(frame::interpreter_frame_last_sp_offset)
 
 #define DECLARE_LONG_CPU_FEATURE_CONSTANT(id, name, bit) GENERATE_VM_LONG_CONSTANT_ENTRY(VM_Version::CPU_##id)
-#define VM_LONG_CPU_FEATURE_CONSTANTS CPU_FEATURE_FLAGS(DECLARE_LONG_CPU_FEATURE_CONSTANT)
+#define VM_LONG_CPU_FEATURE_CONSTANTS \
+   CPU_FEATURE_FLAGS(DECLARE_LONG_CPU_FEATURE_CONSTANT)
 
 #endif
 

--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -325,21 +325,6 @@ unsigned int Abstract_VM_Version::jvm_version() {
          (Abstract_VM_Version::vm_build_number() & 0xFF);
 }
 
-void Abstract_VM_Version::insert_features_names(char* buf, size_t buflen, const char* features_names[], uint64_t features) {
-  uint features_names_index = 0;
-
-  while (features != 0) {
-    if (features & 1) {
-      int res = jio_snprintf(buf, buflen, ", %s", features_names[features_names_index]);
-      assert(res > 0, "not enough temporary space allocated");
-      buf += res;
-      buflen -= res;
-    }
-    features >>= 1;
-    ++features_names_index;
-  }
-}
-
 const char* Abstract_VM_Version::extract_features_string(const char* cpu_info_string,
                                                          size_t cpu_info_string_len,
                                                          size_t features_offset) {

--- a/src/hotspot/share/runtime/abstract_vm_version.hpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.hpp
@@ -56,6 +56,7 @@ class Abstract_VM_Version: AllStatic {
 
   // CPU feature flags, can be affected by VM settings.
   static uint64_t _features;
+
   static const char* _features_string;
 
   static const char* _cpu_info_string;
@@ -80,7 +81,6 @@ class Abstract_VM_Version: AllStatic {
   static int          _vm_build_number;
   static unsigned int _data_cache_line_flush_size;
 
-  static void insert_features_names(char* buf, size_t buflen, const char* features_names[], uint64_t features = _features);
  public:
 
   static VirtualizationType _detected_virtualization;
@@ -129,10 +129,9 @@ class Abstract_VM_Version: AllStatic {
   static const char* jdk_debug_level();
   static const char* printable_jdk_debug_level();
 
-  static uint64_t features()           { return _features; }
   static const char* features_string() { return _features_string; }
+
   static const char* cpu_info_string() { return _cpu_info_string; }
-  static void insert_features_names(char* buf, size_t buflen, const char* features_names[]);
   static const char* extract_features_string(const char* cpu_info_string,
                                              size_t cpu_info_string_len,
                                              size_t features_offset);

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -1164,6 +1165,7 @@
   /********************/                                                  \
                                                                           \
   declare_toplevel_type(Abstract_VM_Version)                              \
+  declare_toplevel_type(VM_Version)                                       \
                                                                           \
   /*************/                                                         \
   /* Arguments */                                                         \
@@ -1716,7 +1718,6 @@
   /**********************/                                                \
   NOT_ZERO(PPC64_ONLY(declare_constant(frame::entry_frame_locals_size)))  \
                                                                           \
-  NOT_ZERO(X86_ONLY(declare_constant(frame::entry_frame_call_wrapper_offset)))      \
   declare_constant(frame::pc_return_offset)                               \
                                                                           \
   /*************/                                                         \
@@ -2147,3 +2148,4 @@ void vmStructs_init() {
   VMStructs::init();
 }
 #endif // ASSERT
+

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
@@ -258,6 +258,8 @@ public class AMD64 extends Architecture {
         APX_F,
         SHA512,
         AVX512_FP16,
+        AVX10_1,
+        AVX10_2
     }
 
     private final EnumSet<CPUFeature> features;

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIBackendFactory.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIBackendFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.util.Map.Entry;
 
 import jdk.vm.ci.common.JVMCIError;
 import jdk.vm.ci.runtime.JVMCIBackend;
+import static jdk.vm.ci.hotspot.UnsafeAccess.UNSAFE;
 
 public interface HotSpotJVMCIBackendFactory {
 
@@ -68,6 +69,60 @@ public interface HotSpotJVMCIBackendFactory {
                 try {
                     CPUFeatureType feature = Enum.valueOf(enumType, renaming.getOrDefault(name, name));
                     if ((features & bitMask) != 0) {
+                        outFeatures.add(feature);
+                    }
+                } catch (IllegalArgumentException iae) {
+                    missing.add(name);
+                }
+            }
+        }
+        if (!missing.isEmpty()) {
+            throw new JVMCIError("Missing CPU feature constants: %s", missing);
+        }
+        return outFeatures;
+    }
+
+    /**
+     * Converts CPU features bit map into enum constants.
+     *
+     * @param <CPUFeatureType> CPU feature enum type
+     * @param enumType the class of {@code CPUFeatureType}
+     * @param constants VM constants. Each entry whose key starts with {@code "VM_Version::CPU_"}
+     *            specifies a CPU feature and its value is a mask for a bit in {@code features}
+     * @param featuresBitMapAddress pointer to {@code VM_Features::_features_bitmap} field of {@code VM_Version::_features}
+     * @param featuresBitMapSize size of feature bit map in bytes
+     * @param renaming maps from VM feature names to enum constant names where the two differ
+     * @throws IllegalArgumentException if any VM CPU feature constant cannot be converted to an
+     *             enum value
+     * @return the set of converted values
+     */
+    static <CPUFeatureType extends Enum<CPUFeatureType>> EnumSet<CPUFeatureType> convertFeatures(
+                    Class<CPUFeatureType> enumType,
+                    Map<String, Long> constants,
+                    long featuresBitMapAddress,
+                    long featuresBitMapSize,
+                    Map<String, String> renaming) {
+        EnumSet<CPUFeatureType> outFeatures = EnumSet.noneOf(enumType);
+        List<String> missing = new ArrayList<>();
+
+        for (Entry<String, Long> e : constants.entrySet()) {
+            String key = e.getKey();
+            long bitIndex = e.getValue();
+            if (key.startsWith("VM_Version::CPU_")) {
+                String name = key.substring("VM_Version::CPU_".length());
+                try {
+                    final long featuresElementShiftCount = 6; // log (# of bits per long)
+                    final long featuresElementMask = (1L << featuresElementShiftCount) - 1;
+
+                    CPUFeatureType feature = Enum.valueOf(enumType, renaming.getOrDefault(name, name));
+
+                    long featureIndex = bitIndex >>> featuresElementShiftCount;
+                    long featureBitMask = 1L << (bitIndex & featuresElementMask);
+                    assert featureIndex < featuresBitMapSize;
+
+                    long featuresElement = UNSAFE.getLong(featuresBitMapAddress + featureIndex * Long.BYTES);
+
+                    if ((featuresElement & featureBitMask) != 0) {
                         outFeatures.add(feature);
                     }
                 } catch (IllegalArgumentException iae) {

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/amd64/AMD64HotSpotJVMCIBackendFactory.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/amd64/AMD64HotSpotJVMCIBackendFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,12 @@ public class AMD64HotSpotJVMCIBackendFactory implements HotSpotJVMCIBackendFacto
         Map<String, Long> constants = config.getStore().getConstants();
         Map<String, String> renaming = Map.of("3DNOW_PREFETCH", "AMD_3DNOW_PREFETCH");
         assert config.useSSE >= 2 : "minimum config for x64";
-        EnumSet<CPUFeature> features = HotSpotJVMCIBackendFactory.convertFeatures(CPUFeature.class, constants, config.vmVersionFeatures, renaming);
+        long featuresBitMapAddress = config.vmVersionFeatures + config.vmFeaturesFeaturesOffset;
+        EnumSet<CPUFeature> features = HotSpotJVMCIBackendFactory.convertFeatures(CPUFeature.class,
+                                                                                  constants,
+                                                                                  featuresBitMapAddress,
+                                                                                  config.vmFeaturesFeaturesSize,
+                                                                                  renaming);
         features.add(AMD64.CPUFeature.SSE);
         features.add(AMD64.CPUFeature.SSE2);
         return features;

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/amd64/AMD64HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/amd64/AMD64HotSpotVMConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,11 +42,13 @@ class AMD64HotSpotVMConfig extends HotSpotVMConfigAccess {
     final boolean useCountTrailingZerosInstruction = getFlag("UseCountTrailingZerosInstruction", Boolean.class);
     final boolean useCompressedOops = getFlag("UseCompressedOops", Boolean.class);
 
+    final long vmVersionFeatures = getFieldAddress("VM_Version::_features", "VM_Version::VM_Features");
+    final long vmFeaturesFeaturesOffset = getFieldOffset("VM_Version::VM_Features::_features_bitmap[0]", Long.class, "uint64_t");
+    final long vmFeaturesFeaturesSize = getFieldValue("VM_Version::VM_Features::_features_bitmap_size", Long.class, "int");
+
     // CPU capabilities
     final int useSSE = getFlag("UseSSE", Integer.class);
     final int useAVX = getFlag("UseAVX", Integer.class);
-
-    final long vmVersionFeatures = getFieldValue("Abstract_VM_Version::_features", Long.class, "uint64_t");
 
     // CPU feature flags
     final long amd64CX8 = getConstant("VM_Version::CPU_CX8", Long.class);
@@ -88,4 +90,6 @@ class AMD64HotSpotVMConfig extends HotSpotVMConfigAccess {
     final long amd64OSPKE = getConstant("VM_Version::CPU_OSPKE", Long.class);
     final long amd64CET_IBT = getConstant("VM_Version::CPU_CET_IBT", Long.class);
     final long amd64CET_SS = getConstant("VM_Version::CPU_CET_SS", Long.class);
+    final long amd64AVX10_1 = getConstant("VM_Version::CPU_AVX10_1", Long.class);
+    final long amd64AVX10_2 = getConstant("VM_Version::CPU_AVX10_2", Long.class);
 }

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbLongConstant.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbLongConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,7 +92,7 @@ public class ClhsdbLongConstant {
 
         // Expected output snippet is of the form (on x64-64):
         // ...
-        // longConstant VM_Version::CPU_SHA 17179869184
+        // longConstant VM_Version::CPU_SHA 34
         // longConstant markWord::age_shift 3
         // longConstant markWord::hash_mask_in_place 4398046509056
         // ...
@@ -106,7 +106,7 @@ public class ClhsdbLongConstant {
             // Expected value obtained from the CPU_SHA definition in vm_version_x86.hpp
             checkLongValue("VM_Version::CPU_SHA ",
                            longConstantOutput,
-                           17179869184L);
+                           34L);
         }
     }
 

--- a/test/lib-test/jdk/test/whitebox/CPUInfoTest.java
+++ b/test/lib-test/jdk/test/whitebox/CPUInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ public class CPUInfoTest {
                     "hv",           "fsrm",             "avx512_bitalg",     "gfni",
                     "f16c",         "pku",              "ospke",             "cet_ibt",
                     "cet_ss",       "avx512_ifma",      "serialize",         "avx_ifma",
-                    "apx_f"
+                    "apx_f",        "avx10_1",          "avx10_2"
                     );
             // @formatter:on
             // Checkstyle: resume


### PR DESCRIPTION
This is the merge of the single commit [3b336a9da091c4df4373d2b845b60d2a7a4e3b1d](https://github.com/openjdk/jdk/commit/3b336a9da091c4df4373d2b845b60d2a7a4e3b1d) which also disables CPUFeatures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8352675](https://bugs.openjdk.org/browse/JDK-8352675): Support Intel AVX10 converged vector ISA feature detection (**Enhancement** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/247/head:pull/247` \
`$ git checkout pull/247`

Update a local copy of the PR: \
`$ git checkout pull/247` \
`$ git pull https://git.openjdk.org/crac.git pull/247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 247`

View PR using the GUI difftool: \
`$ git pr show -t 247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/247.diff">https://git.openjdk.org/crac/pull/247.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/247#issuecomment-3097936164)
</details>
