### PR TITLE
8364272: [CRaC] Make inclusion of crac.hpp in os_posix.cpp conditional

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -35,7 +35,6 @@
 #include "runtime/frame.inline.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
-#include "runtime/crac.hpp"
 #include "runtime/java.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/osThread.hpp"
@@ -63,6 +62,9 @@
 #endif
 #ifdef LINUX
 #include "os_linux.hpp"
+#endif
+#if !defined(__APPLE__) && !defined(AIX)
+#include "runtime/crac.hpp"
 #endif
 
 #include <dirent.h>


### PR DESCRIPTION
Just a small, mostly cosmetic enhancement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8364272](https://bugs.openjdk.org/browse/JDK-8364272): [CRaC] Make inclusion of crac.hpp in os_posix.cpp conditional (**Enhancement** - P5)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/252/head:pull/252` \
`$ git checkout pull/252`

Update a local copy of the PR: \
`$ git checkout pull/252` \
`$ git pull https://git.openjdk.org/crac.git pull/252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 252`

View PR using the GUI difftool: \
`$ git pr show -t 252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/252.diff">https://git.openjdk.org/crac/pull/252.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/252#issuecomment-3132371016)
</details>
