### PR TITLE
8364538: [CRaC] Test CRaCIgnoreRestoreIfUnavailable

### DIFF
--- a/test/jdk/jdk/crac/ignoreRestore/CheckpointAfterIgnoredRestoreTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/CheckpointAfterIgnoredRestoreTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022, 2025, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Files;
+import java.util.List;
+
+import jdk.crac.Core;
+import static jdk.test.lib.Asserts.*;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracEngine;
+
+/**
+ * @test
+ * @summary If a restore attempt failed and was ignored by
+ *          CRaCIgnoreRestoreIfUnavailable the normal execution started instead
+ *          should be checkpointable.
+ * @requires (os.family == "linux")
+ * @library /test/lib
+ */
+public class CheckpointAfterIgnoredRestoreTest {
+    public static void main(String[] args) throws Exception {
+        final var builder = new CracBuilder().engine(CracEngine.CRIU)
+            .vmOption("-XX:+CRaCIgnoreRestoreIfUnavailable")
+            .forwardClasspathOnRestore(true);
+        assertTrue(Files.notExists(builder.imageDir()), "Image should not exist yet: " + builder.imageDir());
+        builder
+            .startRestoreWithArgs(null, List.of("-XX:CRaCCheckpointTo=" + builder.imageDir(), Main.class.getName()))
+            .waitForCheckpointed();
+        builder.doRestore();
+    }
+
+    public static class Main {
+        public static void main(String[] args) throws Exception {
+            Core.checkpointRestore();
+        }
+    }
+}

--- a/test/jdk/jdk/crac/ignoreRestore/CheckpointAfterIgnoredRestoreTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/CheckpointAfterIgnoredRestoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Azul Systems, Inc. All rights reserved.
+ * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/crac/ignoreRestore/EngineFailureTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/EngineFailureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Azul Systems, Inc. All rights reserved.
+ * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/crac/ignoreRestore/EngineFailureTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/EngineFailureTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022, 2025, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Files;
+import java.util.List;
+
+import jdk.test.lib.crac.CracBuilder;
+
+/**
+ * @test
+ * @summary If CRaCIgnoreRestoreIfUnavailable is specified and the engine
+ *          fails to restore for any reason VM should proceed without restoring.
+ * @library /test/lib
+ */
+public class EngineFailureTest {
+    private static final String MAIN_MSG = "Hello, world!";
+
+    public static void main(String[] args) throws Exception {
+        // With crexec we need to make it itself fail and not the real engine
+        // it executes: the executable replaces the JVM and thus exits the whole
+        // process on failure instead of returning to JVM. This is achieved by
+        // specifying "crexec" as the engine manually (normally one is not
+        // supposed to do that, JVM does it automatically when needed) and do
+        // not provide the mandatory 'exec_location' option.
+
+        final var builder = new CracBuilder()
+            .vmOption("-XX:CRaCEngine=crexec")
+            .vmOption("-XX:+CRaCIgnoreRestoreIfUnavailable")
+            .forwardClasspathOnRestore(true)
+            .captureOutput(true);
+
+        // Make VM's internal image checks pass
+        Files.createDirectory(builder.imageDir());
+
+        // simengine does not support restoring
+        builder.startRestoreWithArgs(null, List.of(Main.class.getName())).outputAnalyzer()
+            .shouldContain("CRaC engine failed to restore")
+            .shouldContain(MAIN_MSG);
+    }
+
+    public static class Main {
+        public static void main(String[] args) {
+            System.out.println(MAIN_MSG);
+        }
+    }
+}

--- a/test/jdk/jdk/crac/ignoreRestore/EngineFailureTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/EngineFailureTest.java
@@ -54,7 +54,6 @@ public class EngineFailureTest {
         // Make VM's internal image checks pass
         Files.createDirectory(builder.imageDir());
 
-        // simengine does not support restoring
         builder.startRestoreWithArgs(null, List.of(Main.class.getName())).outputAnalyzer()
             .shouldContain("CRaC engine failed to restore")
             .shouldContain(MAIN_MSG);

--- a/test/jdk/jdk/crac/ignoreRestore/InvalidImageLocationTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/InvalidImageLocationTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, 2025, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Files;
+import java.util.List;
+
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracEngine;
+
+/**
+ * @test
+ * @summary If CRaCIgnoreRestoreIfUnavailable is specified and CRaCRestoreFrom
+ *          points to an invalid location VM should proceed without restoring.
+ * @requires (os.family == "linux")
+ * @library /test/lib
+ * @run main InvalidImageLocationTest IMAGE_NOT_EXISTS
+ * @run main InvalidImageLocationTest IMAGE_IS_NOT_DIR
+ */
+public class InvalidImageLocationTest {
+    private static final String MAIN_MSG = "Hello, world!";
+
+    private enum Variant {
+        IMAGE_NOT_EXISTS,
+        IMAGE_IS_NOT_DIR,
+    }
+
+    public static void main(String[] args) throws Exception {
+        final var variant = Variant.valueOf(args[0]);
+
+        final var builder = new CracBuilder().engine(CracEngine.CRIU)
+            .vmOption("-XX:+CRaCIgnoreRestoreIfUnavailable")
+            .forwardClasspathOnRestore(true)
+            .captureOutput(true);
+
+        // Existance depends on the order of @run tags
+        if (variant == Variant.IMAGE_NOT_EXISTS) {
+            Files.deleteIfExists(builder.imageDir());
+        } else if (variant == Variant.IMAGE_IS_NOT_DIR && Files.notExists(builder.imageDir())) {
+            Files.createFile(builder.imageDir());
+        }
+
+        final var errMsg = switch (variant) {
+            case IMAGE_NOT_EXISTS -> "Cannot open CRaCRestoreFrom=" + builder.imageDir() + ":";
+            case IMAGE_IS_NOT_DIR -> "CRaCRestoreFrom=" + builder.imageDir() + " is not a directory";
+        };
+
+        final var out = builder.startRestoreWithArgs(null, List.of(Main.class.getName())).outputAnalyzer();
+        out.shouldContain(errMsg).shouldContain(MAIN_MSG);
+    }
+
+    public static class Main {
+        public static void main(String[] args) {
+            System.out.println(MAIN_MSG);
+        }
+    }
+}

--- a/test/jdk/jdk/crac/ignoreRestore/InvalidImageLocationTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/InvalidImageLocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Azul Systems, Inc. All rights reserved.
+ * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/crac/ignoreRestore/NoCPUFeaturesTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/NoCPUFeaturesTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Files;
+import java.util.List;
+
+import jdk.test.lib.crac.CracBuilder;
+
+/**
+ * @test
+ * @summary If CRaCIgnoreRestoreIfUnavailable is specified and there are no CPU
+ *          features recorded in the image VM should proceed without restoring.
+ * @requires (os.arch == "amd64" | os.arch == "x86_64")
+ * @library /test/lib
+ */
+public class NoCPUFeaturesTest {
+    private static final String MAIN_MSG = "Hello, world!";
+
+    public static void main(String[] args) throws Exception {
+        final var builder = new CracBuilder()
+            .vmOption("-XX:+CRaCIgnoreRestoreIfUnavailable")
+            .forwardClasspathOnRestore(true)
+            .captureOutput(true);
+
+        // Create an empty image without CPU features data
+        Files.createDirectory(builder.imageDir());
+
+        builder.startRestoreWithArgs(null, List.of(Main.class.getName(), "false"))
+            .outputAnalyzer().shouldContain("incompatible CPU features").shouldContain(MAIN_MSG);
+    }
+
+    public static class Main {
+        public static void main(String[] args) throws Exception {
+            System.out.println(MAIN_MSG);
+        }
+    }
+}

--- a/test/jdk/jdk/crac/ignoreRestore/NoCPUFeaturesTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/NoCPUFeaturesTest.java
@@ -32,7 +32,7 @@ import jdk.test.lib.crac.CracBuilder;
  * @test
  * @summary If CRaCIgnoreRestoreIfUnavailable is specified and there are no CPU
  *          features recorded in the image VM should proceed without restoring.
- * @requires (os.arch == "amd64" | os.arch == "x86_64")
+ * @requires (os.family == "linux") & (os.arch == "amd64" | os.arch == "x86_64")
  * @library /test/lib
  */
 public class NoCPUFeaturesTest {

--- a/test/jdk/jdk/crac/ignoreRestore/RestoreIfPossibleTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/RestoreIfPossibleTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, 2025, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.List;
+
+import jdk.crac.Core;
+
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracEngine;
+import jdk.test.lib.util.FileUtils;
+
+/**
+ * @test
+ * @summary With CRaCIgnoreRestoreIfUnavailable specified, if the image in
+ *          CRaCRestoreFrom can be restored from it should be used, otherwise
+ *          main should be launched as usual.
+ * @requires (os.family == "linux")
+ * @library /test/lib
+ * @run main RestoreIfPossibleTest true
+ * @run main RestoreIfPossibleTest false
+ */
+public class RestoreIfPossibleTest {
+    private static final String WARMUP_MSG = "Running warmup workload...";
+    private static final String MAIN_MSG = "Running main workload...";
+
+    public static void main(String[] args) throws Exception {
+        final var makeRestorePossible = Boolean.parseBoolean(args[0]);
+
+        final var builder = new CracBuilder().engine(CracEngine.CRIU)
+            .vmOption("-XX:+CRaCIgnoreRestoreIfUnavailable")
+            .forwardClasspathOnRestore(true)
+            .captureOutput(true);
+        if (makeRestorePossible) {
+            final var checkpointProcess = builder.main(Main.class).args("true").startCheckpoint();
+            checkpointProcess.waitForCheckpointed();
+            final var out = checkpointProcess.outputAnalyzer();
+            out.stdoutShouldContain(WARMUP_MSG).stdoutShouldNotContain(MAIN_MSG);
+        } else {
+            FileUtils.deleteFileTreeWithRetry(builder.imageDir()); // Existance depends on the order of @run tags
+        }
+
+        final var out = builder.startRestoreWithArgs(null, List.of(Main.class.getName(), "false")).outputAnalyzer();
+        out.stdoutShouldNotContain(WARMUP_MSG).stdoutShouldContain(MAIN_MSG);
+    }
+
+    public static class Main {
+        public static void main(String[] args) throws Exception {
+            final var shouldCheckpoint = Boolean.parseBoolean(args[0]);
+            if (shouldCheckpoint) {
+                System.out.println(WARMUP_MSG);
+                Core.checkpointRestore();
+            }
+            System.out.println(MAIN_MSG);
+        }
+    }
+}

--- a/test/jdk/jdk/crac/ignoreRestore/RestoreIfPossibleTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/RestoreIfPossibleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Azul Systems, Inc. All rights reserved.
+ * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/lib/crac/CracBuilder.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilder.java
@@ -50,6 +50,7 @@ public class CracBuilder {
     CracEngine engine;
     String[] engineOptions;
     boolean printResources;
+    boolean forwardClasspathOnRestore;
     Class<?> main;
     String[] args;
     boolean captureOutput;
@@ -93,6 +94,7 @@ public class CracBuilder {
         other.engine = engine;
         other.engineOptions = engineOptions == null ? null : Arrays.copyOf(engineOptions, engineOptions.length);
         other.printResources = printResources;
+        other.forwardClasspathOnRestore = forwardClasspathOnRestore;
         other.main = main;
         other.args = args == null ? null : Arrays.copyOf(args, args.length);
         other.captureOutput = captureOutput;
@@ -173,6 +175,11 @@ public class CracBuilder {
 
     public CracBuilder printResources(boolean print) {
         this.printResources = print;
+        return this;
+    }
+
+    public CracBuilder forwardClasspathOnRestore(boolean forward) {
+        this.forwardClasspathOnRestore = forward;
         return this;
     }
 
@@ -493,13 +500,13 @@ public class CracBuilder {
         if (engineOptions != null) {
             cmd.add("-XX:CRaCEngineOptions=" + String.join(",", engineOptions));
         }
-        if (!isRestore) {
+        if (!isRestore || forwardClasspathOnRestore) {
             cmd.add("-cp");
             cmd.add(getClassPath());
-            if (printResources) {
-                cmd.add("-XX:+UnlockDiagnosticVMOptions");
-                cmd.add("-XX:+CRaCPrintResourcesOnCheckpoint");
-            }
+        }
+        if (!isRestore && printResources) {
+            cmd.add("-XX:+UnlockDiagnosticVMOptions");
+            cmd.add("-XX:+CRaCPrintResourcesOnCheckpoint");
         }
         if (debug) {
             cmd.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0.0.0.0:5005");


### PR DESCRIPTION
Adds tests for `CRaCIgnoreRestoreIfUnavailable`.

The case for incompatible CPU features is not tested, although I believe it should work. Such test would be more complex (to the best of my knowledge, emulation is needed to be able to reduce the set of available features between checkpoint and restore) so it deserves a separate task. It would be something like what `test/jdk/jdk/crac/CPUFeatures/CPUFeatures.sh` does (have never run it, not sure if it works).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8364538](https://bugs.openjdk.org/browse/JDK-8364538): [CRaC] Test CRaCIgnoreRestoreIfUnavailable (**Enhancement** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/255/head:pull/255` \
`$ git checkout pull/255`

Update a local copy of the PR: \
`$ git checkout pull/255` \
`$ git pull https://git.openjdk.org/crac.git pull/255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 255`

View PR using the GUI difftool: \
`$ git pr show -t 255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/255.diff">https://git.openjdk.org/crac/pull/255.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/255#issuecomment-3144751951)
</details>
