### PR TITLE
8364554: [CRaC] Improve CRaC VM options' docs

### DIFF
--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -183,18 +183,18 @@ define_pd_global(intx, InitArrayShortSize, 8*BytesPerLong);
              "mitigations for the Intel JCC erratum")                       \
                                                                             \
   product(ccstr, CPUFeatures, nullptr, "CPU feature set, "                  \
-      "use -XX:CPUFeatures=0xnumber with -XX:CRaCCheckpointTo when you "    \
-      "get an error during -XX:CRaCRestoreFrom on a different machine; "    \
-      "-XX:CPUFeatures=native is the default; "                             \
-      "-XX:CPUFeatures=ignore will disable the CPU features check; "        \
-      "-XX:CPUFeatures=generic is compatible but not as slow as 0")         \
+          "use -XX:CPUFeatures=0xnumber with -XX:CRaCCheckpointTo when you "\
+          "get an error during -XX:CRaCRestoreFrom on a different machine; "\
+          "-XX:CPUFeatures=native is the default; "                         \
+          "-XX:CPUFeatures=ignore will disable the CPU features check; "    \
+          "-XX:CPUFeatures=generic is compatible but not as slow as 0")     \
                                                                             \
   product(bool, ShowCPUFeatures, false, "Show features of this CPU "        \
-      "to be possibly used for the -XX:CPUFeatures=0xnumber option")        \
+          "to be possibly used for the -XX:CPUFeatures=0xnumber option")    \
                                                                             \
   product(bool, IgnoreCPUFeatures, false, RESTORE_SETTABLE | EXPERIMENTAL,  \
-      "Do not refuse to run after -XX:CRaCRestoreFrom finds out some "      \
-      "CPU features are missing")                                           \
+          "Do not refuse to run after -XX:CRaCRestoreFrom finds out some "  \
+          "CPU features are missing")                                       \
                                                                             \
   product(int, X86ICacheSync, -1, DIAGNOSTIC,                               \
              "Select the X86 ICache sync mechanism: -1 = auto-select; "     \

--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -64,8 +64,8 @@
   product(bool, UseCpuAllocPath, false, DIAGNOSTIC,                     \
           "Use CPU_ALLOC code path in os::active_processor_count ")     \
                                                                         \
-  product(bool, CRaCCPUCountInit, false, "Reinitialize number of CPUs " \
-      "during -XX:CRaCRestoreFrom")                                     \
+  product(bool, CRaCCPUCountInit, false, "Reinitialize the recorded "   \
+          "number of CPUs on restore")                                  \
                                                                         \
   product(bool, DumpPerfMapAtExit, false, DIAGNOSTIC,                   \
           "Write map file for Linux perf tool at exit")                 \

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
@@ -87,7 +87,7 @@ void G1HeapRegionManager::initialize(G1RegionToSpaceMapper* heap_storage,
   _cardtable_mapper = cardtable;
 
   _regions.initialize(heap_storage->reserved(), G1HeapRegion::GrainBytes);
-  _max_available_regions = (uint) (CRaCMaxHeapSizeBeforeCheckpoint == 0 ? _regions.length() :
+  _max_available_regions = (uint) (FLAG_IS_DEFAULT(CRaCMaxHeapSizeBeforeCheckpoint) ? _regions.length() :
     CRaCMaxHeapSizeBeforeCheckpoint / G1HeapRegion::GrainBytes);
 
   _committed_map.initialize(max_num_regions());

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -94,8 +94,8 @@ void GCArguments::assert_size_info() {
   assert(MinHeapSize % HeapAlignment == 0, "MinHeapSize alignment");
   assert(InitialHeapSize % HeapAlignment == 0, "InitialHeapSize alignment");
   assert(MaxHeapSize % HeapAlignment == 0, "MaxHeapSize alignment");
-  assert(CRaCMaxHeapSizeBeforeCheckpoint == 0 || CRaCMaxHeapSizeBeforeCheckpoint >= InitialHeapSize, "Incompatible initial and maximum heap size before checkpoint");
-  assert(CRaCMaxHeapSizeBeforeCheckpoint == 0 || CRaCMaxHeapSizeBeforeCheckpoint <= MaxHeapSize, "Incompatible initial and maximum heap size before checkpoint");
+  assert(FLAG_IS_DEFAULT(CRaCMaxHeapSizeBeforeCheckpoint) || CRaCMaxHeapSizeBeforeCheckpoint >= InitialHeapSize, "Incompatible initial and maximum heap size before checkpoint");
+  assert(FLAG_IS_DEFAULT(CRaCMaxHeapSizeBeforeCheckpoint) || CRaCMaxHeapSizeBeforeCheckpoint <= MaxHeapSize, "Incompatible initial and maximum heap size before checkpoint");
 }
 #endif // ASSERT
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -577,6 +577,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "CRDoThrowCheckpointException", JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
   { "CRPauseOnCheckpointError",     JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
   { "CRTrace",                      JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::undefined() },
+  { "CRaCAllowToSkipCheckpoint",    JDK_Version::jdk(25), JDK_Version::undefined(), JDK_Version::undefined() },
   { "CRaCDoThrowCheckpointException", JDK_Version::undefined(), JDK_Version::jdk(25), JDK_Version::undefined() },
 
   { nullptr, JDK_Version(0), JDK_Version(0) }
@@ -592,7 +593,7 @@ static AliasedFlag const aliased_jvm_flags[] = {
   { "CreateMinidumpOnCrash",    "CreateCoredumpOnCrash" },
   { "CREngine",                        "CRaCEngine" },
   { "CRAllowedOpenFilePrefixes",       "CRaCAllowedOpenFilePrefixes" },
-  { "CRAllowToSkipCheckpoint",         "CRaCSkipCheckpoint "},
+  { "CRAllowToSkipCheckpoint",         "CRaCSkipCheckpoint"},
   { "CRHeapDumpOnCheckpointException", "CRaCHeapDumpOnCheckpointException" },
   { "CRPrintResourcesOnCheckpoint",    "CRaCPrintResourcesOnCheckpoint" },
   { "CRTraceStartupTime",              "CRaCTraceStartupTime" },

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -568,17 +568,17 @@ static SpecialFlag const special_jvm_flags[] = {
   { "dup option",                   JDK_Version::jdk(9), JDK_Version::undefined(), JDK_Version::undefined() },
 #endif
 
-  { "CREngine",                     JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRAllowedOpenFilePrefixes",    JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRAllowToSkipCheckpoint",      JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRHeapDumpOnCheckpointException", JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRPrintResourcesOnCheckpoint", JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRTraceStartupTime",           JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRDoThrowCheckpointException", JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRPauseOnCheckpointError",     JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRTrace",                      JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::undefined() },
-  { "CRaCAllowToSkipCheckpoint",    JDK_Version::jdk(25), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRaCDoThrowCheckpointException", JDK_Version::undefined(), JDK_Version::jdk(25), JDK_Version::undefined() },
+  { "CREngine",                     JDK_Version::jdk(24), JDK_Version::jdk(26), JDK_Version::jdk(27) },
+  { "CRAllowedOpenFilePrefixes",    JDK_Version::jdk(24), JDK_Version::jdk(26), JDK_Version::jdk(27) },
+  { "CRAllowToSkipCheckpoint",      JDK_Version::jdk(24), JDK_Version::jdk(26), JDK_Version::jdk(27) },
+  { "CRHeapDumpOnCheckpointException", JDK_Version::jdk(24), JDK_Version::jdk(26), JDK_Version::jdk(27) },
+  { "CRPrintResourcesOnCheckpoint", JDK_Version::jdk(24), JDK_Version::jdk(26), JDK_Version::jdk(27) },
+  { "CRTraceStartupTime",           JDK_Version::jdk(24), JDK_Version::jdk(26), JDK_Version::jdk(27) },
+  { "CRDoThrowCheckpointException", JDK_Version::jdk(24), JDK_Version::jdk(26), JDK_Version::jdk(27) },
+  { "CRPauseOnCheckpointError",     JDK_Version::jdk(24), JDK_Version::jdk(26), JDK_Version::jdk(27) },
+  { "CRTrace",                      JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
+  { "CRaCAllowToSkipCheckpoint",    JDK_Version::jdk(25), JDK_Version::jdk(26), JDK_Version::jdk(27) },
+  { "CRaCDoThrowCheckpointException", JDK_Version::undefined(), JDK_Version::jdk(25), JDK_Version::jdk(26) },
 
   { nullptr, JDK_Version(0), JDK_Version(0) }
 };

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -568,17 +568,17 @@ static SpecialFlag const special_jvm_flags[] = {
   { "dup option",                   JDK_Version::jdk(9), JDK_Version::undefined(), JDK_Version::undefined() },
 #endif
 
-  { "CREngine",                     JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRAllowedOpenFilePrefixes",    JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRAllowToSkipCheckpoint",      JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRHeapDumpOnCheckpointException", JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRPrintResourcesOnCheckpoint", JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRTraceStartupTime",           JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRDoThrowCheckpointException", JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRPauseOnCheckpointError",     JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRTrace",                      JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::undefined() },
-  { "CRaCAllowToSkipCheckpoint",    JDK_Version::jdk(25), JDK_Version::undefined(), JDK_Version::undefined() },
-  { "CRaCDoThrowCheckpointException", JDK_Version::undefined(), JDK_Version::jdk(25), JDK_Version::undefined() },
+  { "CREngine",                     JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
+  { "CRAllowedOpenFilePrefixes",    JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
+  { "CRAllowToSkipCheckpoint",      JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
+  { "CRHeapDumpOnCheckpointException", JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
+  { "CRPrintResourcesOnCheckpoint", JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
+  { "CRTraceStartupTime",           JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
+  { "CRDoThrowCheckpointException", JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
+  { "CRPauseOnCheckpointError",     JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
+  { "CRTrace",                      JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
+  { "CRaCAllowToSkipCheckpoint",    JDK_Version::undefined(), JDK_Version::jdk(25), JDK_Version::jdk(26) },
+  { "CRaCDoThrowCheckpointException", JDK_Version::undefined(), JDK_Version::jdk(25), JDK_Version::jdk(26) },
 
   { nullptr, JDK_Version(0), JDK_Version(0) }
 };

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -568,17 +568,17 @@ static SpecialFlag const special_jvm_flags[] = {
   { "dup option",                   JDK_Version::jdk(9), JDK_Version::undefined(), JDK_Version::undefined() },
 #endif
 
-  { "CREngine",                     JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
-  { "CRAllowedOpenFilePrefixes",    JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
-  { "CRAllowToSkipCheckpoint",      JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
-  { "CRHeapDumpOnCheckpointException", JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
-  { "CRPrintResourcesOnCheckpoint", JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
-  { "CRTraceStartupTime",           JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
-  { "CRDoThrowCheckpointException", JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
-  { "CRPauseOnCheckpointError",     JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
-  { "CRTrace",                      JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(26) },
-  { "CRaCAllowToSkipCheckpoint",    JDK_Version::undefined(), JDK_Version::jdk(25), JDK_Version::jdk(26) },
-  { "CRaCDoThrowCheckpointException", JDK_Version::undefined(), JDK_Version::jdk(25), JDK_Version::jdk(26) },
+  { "CREngine",                     JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRAllowedOpenFilePrefixes",    JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRAllowToSkipCheckpoint",      JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRHeapDumpOnCheckpointException", JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRPrintResourcesOnCheckpoint", JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRTraceStartupTime",           JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRDoThrowCheckpointException", JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRPauseOnCheckpointError",     JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRTrace",                      JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::undefined() },
+  { "CRaCAllowToSkipCheckpoint",    JDK_Version::jdk(25), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "CRaCDoThrowCheckpointException", JDK_Version::undefined(), JDK_Version::jdk(25), JDK_Version::undefined() },
 
   { nullptr, JDK_Version(0), JDK_Version(0) }
 };

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -591,12 +591,13 @@ static AliasedFlag const aliased_jvm_flags[] = {
   { "CreateMinidumpOnCrash",    "CreateCoredumpOnCrash" },
   { "CREngine",                        "CRaCEngine" },
   { "CRAllowedOpenFilePrefixes",       "CRaCAllowedOpenFilePrefixes" },
-  { "CRAllowToSkipCheckpoint",         "CRaCAllowToSkipCheckpoint "},
+  { "CRAllowToSkipCheckpoint",         "CRaCSkipCheckpoint "},
   { "CRHeapDumpOnCheckpointException", "CRaCHeapDumpOnCheckpointException" },
   { "CRPrintResourcesOnCheckpoint",    "CRaCPrintResourcesOnCheckpoint" },
   { "CRTraceStartupTime",              "CRaCTraceStartupTime" },
   { "CRDoThrowCheckpointException",    "CRaCDoThrowCheckpointException" },
   { "CRPauseOnCheckpointError",        "CRaCPauseOnCheckpointError" },
+  { "CRaCAllowToSkipCheckpoint",       "CRaCSkipCheckpoint" },
   { nullptr, nullptr}
 };
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -577,6 +577,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "CRDoThrowCheckpointException", JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
   { "CRPauseOnCheckpointError",     JDK_Version::jdk(24), JDK_Version::undefined(), JDK_Version::undefined() },
   { "CRTrace",                      JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::undefined() },
+  { "CRaCDoThrowCheckpointException", JDK_Version::undefined(), JDK_Version::jdk(25), JDK_Version::undefined() },
 
   { nullptr, JDK_Version(0), JDK_Version(0) }
 };

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -252,9 +252,7 @@ void VM_Crac::doit() {
     os::message_box("Checkpoint failed", "Errors were found during checkpoint.");
   }
 
-  if (!ok && CRaCDoThrowCheckpointException) {
-    return;
-  } else if (_dry_run) {
+  if (!ok || _dry_run) {
     _ok = ok;
     return;
   }

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -264,7 +264,7 @@ void VM_Crac::doit() {
   }
 
   int shmid = -1;
-  if (CRaCAllowToSkipCheckpoint) {
+  if (CRaCSkipCheckpoint) {
     log_info(crac)("Skip Checkpoint");
     shmid = 0;
   } else {

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1968,7 +1968,7 @@ const int ObjectAlignmentInBytes = 8;
           "Path to the image to restore from.")                             \
                                                                             \
   product(uint, CRaCMinPid, 128,                                            \
-          "Mininal PID value for checkpointed process (Unix only)")         \
+          "Mininal PID value for checkpointed process (POSIX only)")        \
           range(1, UINT_MAX)                                                \
                                                                             \
   product(bool, CRaCResetStartTime, true, DIAGNOSTIC | RESTORE_SETTABLE,    \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1959,11 +1959,13 @@ const int ObjectAlignmentInBytes = 8;
              "fence. Add cleanliness checks.")                              \
                                                                             \
   product(ccstr, CRaCCheckpointTo, nullptr, RESTORE_SETTABLE,               \
-          "Path to place the checkpoint image into")                        \
+          "Path where the checkpoint image should be placed. Currently an " \
+          "image is a directory, the directory will be created if it does " \
+          "not exist (parent directories are not created) or overwritten "  \
+          "otherwise.")                                                     \
                                                                             \
   product(ccstr, CRaCRestoreFrom, nullptr, RESTORE_SETTABLE,                \
-          "Path to the image to restore from. If restore succeeds, the "    \
-          "initializing VM is replaced with the restored one.")             \
+          "Path to the image to restore from.")                             \
                                                                             \
   product(uint, CRaCMinPid, 128,                                            \
           "Mininal PID value for checkpointed process (Unix only)")         \
@@ -2014,11 +2016,7 @@ const int ObjectAlignmentInBytes = 8;
           "Print low-level resources checked by VM before checkpoint")      \
                                                                             \
   product(bool, CRaCTraceStartupTime, false, DIAGNOSTIC,                    \
-          "Trace restore startup time")                                     \
-                                                                            \
-  product(bool, CRaCDoThrowCheckpointException, true, EXPERIMENTAL,         \
-          "Throw CheckpointException if non-checkpointable low-level "      \
-          "resources were found")                                           \
+          "Print the time at which the VM-level restore starts")            \
                                                                             \
   product(bool, CRaCPauseOnCheckpointError, false, DIAGNOSTIC,              \
           "Pauses the checkpoint when a problem is found on VM level.")     \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1959,69 +1959,72 @@ const int ObjectAlignmentInBytes = 8;
              "fence. Add cleanliness checks.")                              \
                                                                             \
   product(ccstr, CRaCCheckpointTo, nullptr, RESTORE_SETTABLE,               \
-        "Path to checkpoint image directory")                               \
+          "Path to place the checkpoint image into")                        \
                                                                             \
   product(ccstr, CRaCRestoreFrom, nullptr, RESTORE_SETTABLE,                \
-      "Path to image for restore, replaces the initializing VM on success") \
+          "Path to the image to restore from. If restore succeeds, the "    \
+          "initializing VM is replaced with the restored one.")             \
                                                                             \
   product(uint, CRaCMinPid, 128,                                            \
-      "Mininal PID value for checkpoint'ed process")                        \
-      range(1, UINT_MAX)                                                    \
+          "Mininal PID value for checkpointed process (Unix only)")         \
+          range(1, UINT_MAX)                                                \
                                                                             \
   product(bool, CRaCResetStartTime, true, DIAGNOSTIC | RESTORE_SETTABLE,    \
-      "Reset JVM's start time and uptime on restore")                       \
+          "Reset JVM's start time and uptime on restore")                   \
                                                                             \
   product_pd(ccstr, CRaCEngine, RESTORE_SETTABLE,                           \
-      "Path or name of a program or a shared library implementing "         \
-      "checkpoint and restore. On restore this option applies only to "     \
-      "the restoring VM, i.e. the restored VM keeps the value it had "      \
-      "before the checkpoint.")                                             \
+          "Path or name of a program or a shared library implementing "     \
+          "checkpoint and restore. On restore this option applies only to " \
+          "the restoring VM, i.e. the restored VM keeps the value it had "  \
+          "before the checkpoint.")                                         \
                                                                             \
   product(ccstrlist, CRaCEngineOptions, nullptr, RESTORE_SETTABLE,          \
-      "Options passed to CRaCEngine, in the form of 'key1=value,key2'. "    \
-      "The list of supported options is engine-dependent, use "             \
-      "'-XX:CRaCEngineOptions=help' to make the VM print the information "  \
-      "about the engine, including its supported options, and exit. On "    \
-      "restore this option applies only to the restoring VM, i.e. the "     \
-      "restored VM keeps the value it had before the checkpoint.")          \
+          "Options passed to CRaCEngine, in the form of 'key1=value,key2'. "\
+          "The list of supported options is engine-dependent, use "         \
+          "'-XX:CRaCEngineOptions=help' to make the VM print information "  \
+          "about the engine, including its supported options, and exit. On "\
+          "restore this option applies only to the restoring VM, i.e. the " \
+          "restored VM keeps the value it had before the checkpoint.")      \
                                                                             \
   product(bool, CRaCIgnoreRestoreIfUnavailable, false, RESTORE_SETTABLE,    \
-      "Ignore -XX:CRaCRestoreFrom and continue initialization if restore "  \
-      "is unavailable")                                                     \
+          "Ignore -XX:CRaCRestoreFrom and continue initialization if "      \
+          "restore is not possible")                                        \
                                                                             \
   product(ccstr, CRaCIgnoredFileDescriptors, nullptr, RESTORE_SETTABLE,     \
-      "Comma-separated list of file descriptor numbers or paths. "          \
-      "All file descriptors greater than 2 (stdin, stdout and stderr are "  \
-      "excluded automatically) not in this list are closed when the VM "    \
-      "is started.")                                                        \
+          "Comma-separated list of file descriptor numbers or paths. All "  \
+          "file descriptors greater than 2 (stdin, stdout and stderr are "  \
+          "excluded automatically) not in this list are closed when the VM "\
+          "is started. (Linux only)")                                       \
                                                                             \
   product_pd(ccstrlist, CRaCAllowedOpenFilePrefixes, "List of path "        \
-      "prefixes for files that can be open during checkpoint; CRaC won't "  \
-      "error upon detecting these and will leave the handling up to C/R "   \
-      "engine. This option applies only to files opened by native code; "   \
-      "for files opened by Java code use -Djdk.crac.resource-policies=...") \
+          "prefixes for files that can be open during checkpoint. CRaC "    \
+          "will not error upon detecting these and will leave the handling "\
+          "up to the engine. This option applies only to files opened by "  \
+          "native code and is Linux only; for files opened by Java code "   \
+          "use -Djdk.crac.resource-policies=...")                           \
                                                                             \
-  product(bool, CRaCAllowToSkipCheckpoint, false, DIAGNOSTIC,               \
-      "Allow implementation to not call Checkpoint if helper not found")    \
+  product(bool, CRaCSkipCheckpoint, false, DIAGNOSTIC,                      \
+          "On checkpoint, skip calling CRaC engine and restore immediately")\
                                                                             \
   product(bool, CRaCHeapDumpOnCheckpointException, false, DIAGNOSTIC,       \
-      "Dump heap on CheckpointException thrown because of CRaC "            \
-      "precondition failed")                                                \
+          "Dump heap on CheckpointException thrown because of a low-level " \
+          "CRaC precondition failing")                                      \
                                                                             \
   product(bool, CRaCPrintResourcesOnCheckpoint, false, DIAGNOSTIC,          \
-      "Print resources to decide CheckpointException")                      \
+          "Print low-level resources checked by VM before checkpoint")      \
                                                                             \
   product(bool, CRaCTraceStartupTime, false, DIAGNOSTIC,                    \
-      "Trace startup time")                                                 \
+          "Trace restore startup time")                                     \
                                                                             \
   product(bool, CRaCDoThrowCheckpointException, true, EXPERIMENTAL,         \
-      "Throw CheckpointException if uncheckpointable resource handle found")\
+          "Throw CheckpointException if non-checkpointable low-level "      \
+          "resources were found")                                           \
                                                                             \
   product(bool, CRaCPauseOnCheckpointError, false, DIAGNOSTIC,              \
-      "Pauses the checkpoint when a problem is found on VM level.")         \
+          "Pauses the checkpoint when a problem is found on VM level.")     \
                                                                             \
   product(size_t, CRaCMaxHeapSizeBeforeCheckpoint, 0, "Maximum size "       \
-      "of heap before checkpoint. By default equals to -Xmx.")              \
+          "of heap before checkpoint. By default equals to -Xmx.")          \
                                                                             \
   product(int, LockingMode, LM_LIGHTWEIGHT,                                 \
           "(Deprecated) Select locking mode: "                              \

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1075,18 +1075,19 @@ These `java` options control the runtime behavior of the Java HotSpot VM.
 
 `-XX:CRaCCheckpointTo=`*directory*
 :   The CRaC (Coordinated Restore at Checkpoint) Project provides checkpointing of
-    a running Java program into an image directory. Restoring from the image should
-    solve some of the problematic start-up and warm-up times.
+    a running Java program into an image. Restoring from the image should have
+    lower start-up and warm-up times compared to a full re-launch.
 
-    This option defines a path to the snapshot which is currently a directory. The
+    This option defines a path to the image which is currently a directory. The
     directory will be created if it does not exist, but no parent directories are
     created.
 
 `-XX:CRaCRestoreFrom=`*directory*
-:   Restores a snapshot created by `-XX:CRaCCheckpointTo=`*directory*.
+:   Restores an image created by `-XX:CRaCCheckpointTo`.
 
 `-XX:CRaCMinPid=`*value*
-:   A desired minimal PID value for checkpoint'ed process. Ignored on restore.
+:   A desired minimal PID value for checkpointed process. Used by the launcher,
+    only on POSIX-like platforms.
 
 `-XX:ErrorFile=`*filename*
 :   Specifies the path and file name to which error data is written when an

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1086,7 +1086,7 @@ These `java` options control the runtime behavior of the Java HotSpot VM.
 :   Restores an image created by `-XX:CRaCCheckpointTo`.
 
 `-XX:CRaCMinPid=`*value*
-:   A desired minimal PID value for checkpointed process. Used by the launcher,
+:   A desired minimal PID value for checkpointed process. Applied by the launcher,
     only on POSIX-like platforms.
 
 `-XX:ErrorFile=`*filename*

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1083,7 +1083,7 @@ These `java` options control the runtime behavior of the Java HotSpot VM.
     created.
 
 `-XX:CRaCRestoreFrom=`*directory*
-:   Restores an image created by `-XX:CRaCCheckpointTo`.
+:   Restores from the specified checkpoint image.
 
 `-XX:CRaCMinPid=`*value*
 :   A desired minimal PID value for checkpointed process. Applied by the launcher,

--- a/test/lib/jdk/test/lib/crac/CracBuilder.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilder.java
@@ -503,10 +503,6 @@ public class CracBuilder {
         }
         if (debug) {
             cmd.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0.0.0.0:5005");
-            if (!isRestore) {
-                cmd.add("-XX:+UnlockExperimentalVMOptions");
-                cmd.add("-XX:-CRaCDoThrowCheckpointException");
-            }
         }
         cmd.addAll(vmOptions);
         for (var entry : javaOptions.entrySet()) {


### PR DESCRIPTION
Besides some wording and formatting of VM options:
- Renames `CRaCAllowToSkipCheckpoint` to `CRaCSkipCheckpoint` since it makes the VM always skip checkpoints and not only in some cases
- Replaces `CRaCMaxHeapSizeBeforeCheckpoint == 0` with `FLAG_IS_DEFAULT(CRaCMaxHeapSizeBeforeCheckpoint)` because the docs 0 do not specify 0 as a special value

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8364554](https://bugs.openjdk.org/browse/JDK-8364554): [CRaC] Improve CRaC VM options' docs (**Enhancement** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/256/head:pull/256` \
`$ git checkout pull/256`

Update a local copy of the PR: \
`$ git checkout pull/256` \
`$ git pull https://git.openjdk.org/crac.git pull/256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 256`

View PR using the GUI difftool: \
`$ git pr show -t 256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/256.diff">https://git.openjdk.org/crac/pull/256.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/256#issuecomment-3145560970)
</details>
