### PR TITLE
8364624: [CRaC] Resolve startup failures with static JDK build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -361,17 +361,17 @@ jobs:
       runs-on: ubuntu-22.04
       debug-suffix: -debug
 
-#  test-linux-x64-static:
-#    name: linux-x64-static
-#    needs:
-#      - build-linux-x64
-#      - build-linux-x64-static
-#    uses: ./.github/workflows/test.yml
-#    with:
-#      platform: linux-x64
-#      bootjdk-platform: linux-x64
-#      runs-on: ubuntu-22.04
-#      static-suffix: "-static"
+  test-linux-x64-static:
+    name: linux-x64-static
+    needs:
+      - build-linux-x64
+      - build-linux-x64-static
+    uses: ./.github/workflows/test.yml
+    with:
+      platform: linux-x64
+      bootjdk-platform: linux-x64
+      runs-on: ubuntu-22.04
+      static-suffix: "-static"
 
   test-macos-aarch64:
     name: macos-aarch64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,15 +186,17 @@ jobs:
         id: extra-options
         run: |
           if [[ '${{ inputs.static-suffix }}' == '-static' ]]; then
-            echo "test-jdk=JDK_UNDER_TEST=${{ steps.bundles.outputs.static-jdk-path }}" >> $GITHUB_OUTPUT
+            echo "test-jdk=${{ steps.bundles.outputs.static-jdk-path }}" >> $GITHUB_OUTPUT
             echo "compile-jdk=JDK_FOR_COMPILE=${{ steps.bundles.outputs.jdk-path }}" >> $GITHUB_OUTPUT
             echo "extra-problem-lists=EXTRA_PROBLEM_LISTS=${{ steps.path.outputs.static-hotspot-problemlist-path }}%20${{ steps.path.outputs.static-jdk-problemlist-path }}%20${{ steps.path.outputs.static-langtools-problemlist-path }}%20${{ steps.path.outputs.static-lib-test-problemlist-path }}" >> $GITHUB_OUTPUT
+          else
+            echo "test-jdk=${{ steps.bundles.outputs.jdk-path }}" >> $GITHUB_OUTPUT
           fi
 
       - name: 'Setup CRIU'
         uses: ./.github/actions/setup-criu
         with:
-          jdk-path: ${{ steps.bundles.outputs.jdk-path }}
+          jdk-path: ${{ steps.extra-options.outputs.test-jdk }}
         if: runner.os == 'Linux' && matrix.test-name == 'jdk/crac'
 
       - name: 'Run tests'
@@ -207,7 +209,7 @@ jobs:
           JDK_IMAGE_DIR=${{ steps.bundles.outputs.jdk-path }}
           SYMBOLS_IMAGE_DIR=${{ steps.bundles.outputs.symbols-path }}
           TEST_IMAGE_DIR=${{ steps.bundles.outputs.tests-path }}
-          ${{ steps.extra-options.outputs.test-jdk }}
+          JDK_UNDER_TEST=${{ steps.extra-options.outputs.test-jdk }}
           ${{ steps.extra-options.outputs.compile-jdk }}
           JTREG="JAVA_OPTIONS=$JAVA_OPTIONS;VERBOSE=fail,error,time;KEYWORDS=!headful;${{ steps.extra-options.outputs.extra-problem-lists }}"
           && bash ./.github/scripts/gen-test-summary.sh "$GITHUB_STEP_SUMMARY" "$GITHUB_OUTPUT"

--- a/test/jdk/ProblemList-StaticJdk.txt
+++ b/test/jdk/ProblemList-StaticJdk.txt
@@ -12,3 +12,16 @@ java/util/ResourceBundle/modules/unnamed/UnNamedTest.java                       
 
 # Require jps
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java                            8346719 generic-all
+
+# Require jcmd
+jdk/crac/DaemonAfterRestore.java                                                 8346719 generic-all
+jdk/crac/fileDescriptors/SharedLibraryTest.java                                  8346719 generic-all
+jdk/crac/jfr/FlightRecorderJcmdTest.java                                         8346719 generic-all
+jdk/crac/PerfMemoryRestoreTest.java                                              8346719 generic-all
+
+# Require container with libX11
+jdk/crac/ContainerOOMETest.java                                                  8364624 generic-all
+jdk/crac/ContainerPidAdjustmentTest.java                                         8364624 generic-all
+jdk/crac/java/lang/System/NanoTimeTest.java                                      8364624 generic-all
+jdk/crac/java/net/InetAddress/ResolveTest.java                                   8364624 generic-all
+jdk/crac/java/lang/System/TimedWaitingTest.java                                  8364624 generic-all


### PR DESCRIPTION
The patch fixes locating the `lib` folder and also fixes handling for `crexec` case for static JDK build.

It also fixes "setup CRIU" test step and ensures that criu is copied into static JDK for static JDK build. Another change in tests is to re-enable tests for static JDK and add some CRaC tests with known failures to the exclude list for static JDK (tests requiring jcmd and tests requiring a container with libX11 preinstalled).