### PR TITLE
8364662: [CRaC] Process restore options in the common arguments parser

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2968,7 +2968,7 @@ bool Arguments::process_flag_for_restore(const char *arg) {
   if (flag->is_restore_settable()) {
     // Restored JVM will search for the flag using the name we record here so we
     // must ensure the real one is recorded
-    if (strncmp(name, flag->name(), name_len) == 0) {
+    if (strcmp(flag->name(), name) == 0) {
       build_jvm_restore_flags(arg);
     } else {
       const size_t real_arg_len = strlen(arg) + (strlen(flag->name()) - name_len);

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -88,6 +88,8 @@ char** Arguments::_jvm_flags_array              = nullptr;
 int    Arguments::_num_jvm_flags                = 0;
 char** Arguments::_jvm_args_array               = nullptr;
 int    Arguments::_num_jvm_args                 = 0;
+char** Arguments::_jvm_restore_flags_array      = nullptr;
+int    Arguments::_num_jvm_restore_flags        = 0;
 unsigned int Arguments::_addmods_count          = 0;
 #if INCLUDE_JVMCI
 bool   Arguments::_jvmci_module_added           = false;
@@ -1041,6 +1043,10 @@ void Arguments::build_jvm_flags(const char* arg) {
   add_string(&_jvm_flags_array, &_num_jvm_flags, arg);
 }
 
+void Arguments::build_jvm_restore_flags(const char* arg) {
+  add_string(&_jvm_restore_flags_array, &_num_jvm_restore_flags, arg);
+}
+
 // utility function to return a string that concatenates all
 // strings in a given char** array
 const char* Arguments::build_resource_string(char** args, int count) {
@@ -1331,6 +1337,12 @@ bool Arguments::add_property(const char* prop, PropertyWriteable writeable, Prop
       _java_command = os::strdup_check_oom(value, mtArguments);
       if (old_java_command != nullptr) {
         os::free(old_java_command);
+      }
+    } else if (strcmp(key, "sun.java.crac_command") == 0) {
+      char *old_java_command_crac = _java_command_crac;
+      _java_command_crac = os::strdup_check_oom(value, mtArguments);
+      if (old_java_command_crac != nullptr) {
+        os::free(old_java_command_crac);
       }
     } else if (strcmp(key, "java.vendor.url.bug") == 0) {
       // If this property is set on the command line then its value will be
@@ -2168,89 +2180,6 @@ jint Arguments::parse_xss(const JavaVMOption* option, const char* tail, intx* ou
   return JNI_OK;
 }
 
-bool Arguments::is_restore_option_set(const JavaVMInitArgs* args) {
-  const char* tail;
-  // iterate over arguments
-  for (int index = 0; index < args->nOptions; index++) {
-    const JavaVMOption* option = args->options + index;
-    if (!match_option(option, "-XX:CRaCRestoreFrom", &tail)) {
-      continue;
-    }
-    // ccstr is never set to an empty string by the parser so we should not
-    // treat an empty string value as the option being set. If it ever becomes
-    // ccstrlist or the parser changes, the value check will need to be removed.
-    static_assert(std::is_same<ccstr, decltype(CRaCRestoreFrom)>(), "expected ccstr");
-    const char* eq = strchr(tail, '=');
-    if (eq != nullptr && eq[1] != '\0') {
-      return true; // the value is not an empty string
-    }
-  }
-  return false;
-}
-
-bool Arguments::parse_options_for_restore(const JavaVMInitArgs* args) {
-  const char *tail = nullptr;
-
-  // iterate over arguments
-  for (int index = 0; index < args->nOptions; index++) {
-    bool is_absolute_path = false;  // for -agentpath vs -agentlib
-
-    const JavaVMOption* option = args->options + index;
-
-    if (match_option(option, "-Djava.class.path", &tail) ||
-        match_option(option, "-Dsun.java.launcher", &tail)) {
-      // These options are already set based on -cp (and aliases), -jar
-      // or even inheriting the CLASSPATH env var; therefore it's too
-      // late to prohibit explicitly setting them at this point.
-    } else if (match_option(option, "-D", &tail)) {
-      const char* key = nullptr;
-      const char* value = nullptr;
-
-      get_key_value(tail, &key, &value);
-
-      if (strcmp(key, "sun.java.crac_command") == 0) {
-        char *old_java_command = _java_command_crac;
-        _java_command_crac = os::strdup_check_oom(value, mtArguments);
-        if (old_java_command != nullptr) {
-          os::free(old_java_command);
-        }
-      } else {
-        add_property(tail);
-      }
-
-      if (key != tail) { // key was copied
-        FreeHeap(const_cast<char *>(key));
-      }
-    } else if (match_option(option, "-XX:", &tail)) { // -XX:xxxx
-      if (!process_argument(tail, args->ignoreUnrecognized, JVMFlagOrigin::COMMAND_LINE)) {
-        return false;
-      }
-      const char *argname;
-      size_t arg_len;
-      bool ignored_plus_minus;
-      parse_argname(tail, &argname, &arg_len, &ignored_plus_minus);
-      const JVMFlag* flag = JVMFlag::find_declared_flag((const char*)argname, arg_len);
-      if (flag != nullptr) {
-        if (!flag->is_restore_settable()) {
-          jio_fprintf(defaultStream::error_stream(),
-            "Flag %.*s cannot be set during restore: %s\n", arg_len, argname, option->optionString);
-          return false;
-        }
-        build_jvm_flags(tail);
-      }
-    }
-  }
-
-  postcond(CRaCRestoreFrom != nullptr);
-
-  if (CRaCEngineOptions && strcmp(CRaCEngineOptions, "help") == 0) {
-    crac::print_engine_info_and_exit(); // Does not return on success
-    return false;
-  }
-
-  return true;
-}
-
 jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin origin) {
   // For match_option to return remaining or value part of option string
   const char* tail;
@@ -3006,6 +2935,87 @@ void Arguments::fix_appclasspath() {
   }
 }
 
+// arg is a JVM argument without the leading "-XX:", e.g. "+BoolOpt" or "StrOpt=str"
+bool Arguments::process_flag_for_restore(const char *arg) {
+  // -XX:Flags and -XX:VMOptionsFile do not have corresponding JVMFlags
+  if ((strncmp(arg, "Flags=", ARRAY_SIZE("Flags=") - 1) == 0) ||
+      (strncmp(arg, "VMOptionsFile=", ARRAY_SIZE("VMOptionsFile=") - 1) == 0)) {
+    return true;
+  }
+
+  const char* name;
+  size_t name_len;
+  bool ignored_plus_minus;
+  parse_argname(arg, &name, &name_len, &ignored_plus_minus);
+
+  const JVMFlag* flag;
+  {
+    char buf[BUFLEN + 1];
+    const char* stripped_name;
+    if (name[name_len] == '\0') {
+      stripped_name = name;
+    } else {
+      guarantee(name_len <= BUFLEN, "argument name too long: %s", name); // Should've been detected earlier
+      strncpy(buf, name, name_len);
+      buf[name_len] = '\0';
+      stripped_name = buf;
+    }
+    flag = JVMFlag::find_declared_flag(real_flag_name(stripped_name));
+    guarantee(flag != nullptr, "unknown JVM flag name: %s", name); // Should've been detected earlier
+  }
+
+  if (flag->is_restore_settable()) {
+    // Restored JVM will search for the flag using the name we record here so we
+    // must ensure the real one is recorded
+    if (strncmp(name, flag->name(), name_len) == 0) {
+      build_jvm_restore_flags(arg);
+    } else {
+      const size_t real_tail_len = strlen(arg) + (strlen(flag->name()) - name_len);
+      char* const real_tail = AllocateHeap(real_tail_len + 1, MemTag::mtArguments);
+      const int ret = jio_snprintf(real_tail, real_tail_len + 1, "%s%s", flag->name(), arg + name_len);
+      guarantee(ret >= 0 && checked_cast<size_t>(ret) == real_tail_len, "snprintf failed: %i", ret);
+      build_jvm_restore_flags(real_tail);
+      FreeHeap(real_tail);
+    }
+  } else if (!CRaCIgnoreRestoreIfUnavailable) {
+    // Same message format as used in JVMFlag::get_locked_message() for
+    // diagnostic/experimental/develop options
+    jio_fprintf(defaultStream::error_stream(),
+                "Error: VM option '%*.s' is not restore-settable and is not available on restore.\n",
+                name_len, name);
+    return false;
+  }
+
+  return true;
+}
+
+bool Arguments::process_flags_for_restore() {
+  precond(CRaCRestoreFrom != nullptr);
+
+  char** const vm_flags = Arguments::jvm_flags_array();
+  for (int i = 0; i < Arguments::num_jvm_flags(); i++) {
+    if (!process_flag_for_restore(vm_flags[i])) {
+      return false;
+    }
+  }
+
+  char** const vm_args = Arguments::jvm_args_array();
+  for (int i = 0; i < Arguments::num_jvm_args(); i++) {
+    const JavaVMOption opt{vm_args[i]};
+    const char *tail;
+    // FIXME: other kinds of arguments can also lead to VM flags being set so
+    //  ideally we would want to process those too. But there seems to be no way
+    //  to do this except highly intrusive (add processing into each special
+    //  branch of arguments parsing) or performance-costly (iterate through all
+    //  JVMFlags) ones.
+    if (match_option(&opt, "-XX:", &tail) && !process_flag_for_restore(tail)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 jint Arguments::finalize_vm_init_args() {
   // check if the default lib/endorsed directory exists; if so, error
   char path[JVM_MAXPATHLEN];
@@ -3088,6 +3098,9 @@ jint Arguments::finalize_vm_init_args() {
   if (CRaCEngineOptions && strcmp(CRaCEngineOptions, "help") == 0) {
     crac::print_engine_info_and_exit(); // Does not return on success
     return JNI_ERR;
+  }
+  if (CRaCRestoreFrom && !process_flags_for_restore()) {
+    return JNI_EINVAL;
   }
   if (CRaCCheckpointTo && !crac::prepare_checkpoint()) {
     return JNI_ERR;
@@ -4200,4 +4213,16 @@ void Arguments::reset_for_crac_restore() {
     FLAG_SET_DEFAULT(LogVMOutput, false);
     FLAG_SET_DEFAULT(LogFile, nullptr);
   }
+}
+
+void Arguments::free_restore_only_data() {
+  os::free(_java_command_crac);
+  _java_command_crac = nullptr;
+
+  for (int i = 0; i < _num_jvm_restore_flags; i++) {
+    os::free(_jvm_restore_flags_array[i]);
+  }
+  FREE_C_HEAP_ARRAY(char*, _jvm_restore_flags_array);
+  _num_jvm_restore_flags = 0;
+  _jvm_restore_flags_array = nullptr;
 }

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -196,8 +196,12 @@ class Arguments : AllStatic {
   // an array containing all jvm arguments specified in the command line
   static char** _jvm_args_array;
   static int    _num_jvm_args;
+  // an array containing all restore-settable jvm flags specified in any way on restore
+  static char** _jvm_restore_flags_array;
+  static int    _num_jvm_restore_flags;
   // string containing all java command (class/jarfile name and app args)
   static char* _java_command;
+  // same as _java_command but with spaces inside args escaped
   static char* _java_command_crac;
   // number of unique modules specified in the --add-modules option
   static unsigned int _addmods_count;
@@ -354,6 +358,7 @@ class Arguments : AllStatic {
   // methods to build strings from individual args
   static void build_jvm_args(const char* arg);
   static void build_jvm_flags(const char* arg);
+  static void build_jvm_restore_flags(const char* arg);
   static void add_string(char*** bldarray, int* count, const char* arg);
   static const char* build_resource_string(char** args, int count);
 
@@ -406,11 +411,13 @@ class Arguments : AllStatic {
   // return a char* array containing all options
   static char** jvm_flags_array()          { return _jvm_flags_array; }
   static char** jvm_args_array()           { return _jvm_args_array; }
+  static char** jvm_restore_flags_array()  { return _jvm_restore_flags_array; }
   static int num_jvm_flags()               { return _num_jvm_flags; }
   static int num_jvm_args()                { return _num_jvm_args; }
+  static int num_jvm_restore_flags()       { return _num_jvm_restore_flags; }
   // return the arguments passed to the Java application
   static const char* java_command()        { return _java_command; }
-  static const char* java_command_crac()        { return _java_command_crac; }
+  static const char* java_command_crac()   { return _java_command_crac; }
 
   // print jvm_flags, jvm_args and java_command
   static void print_on(outputStream* st);
@@ -532,9 +539,10 @@ class Arguments : AllStatic {
 
   static bool has_jfr_option() NOT_JFR_RETURN_(false);
 
-  static bool is_restore_option_set(const JavaVMInitArgs* args);
+  static bool process_flag_for_restore(const char *arg);
+  static bool process_flags_for_restore();
 
-  static bool parse_options_for_restore(const JavaVMInitArgs* args);
+  static void free_restore_only_data();
 
   DEBUG_ONLY(static bool verify_special_jvm_flags(bool check_globals);)
 };

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -555,7 +555,7 @@ void crac::restore(crac_restore_data& restore_data) {
       }
       const bool write_success = CracRestoreParameters::write_to(
         shmfd,
-        Arguments::jvm_flags_array(), Arguments::num_jvm_flags(),
+        Arguments::jvm_restore_flags_array(), Arguments::num_jvm_restore_flags(),
         Arguments::system_properties(),
         Arguments::java_command_crac() ? Arguments::java_command_crac() : "",
         restore_data.restore_time,
@@ -632,6 +632,11 @@ bool CracRestoreParameters::read_from(int fd) {
       } else {
         *eq = '\0';
         char* value = eq + 1;
+        // A single ccstrlist flag can be specified multiple times meaning those
+        // should be concatenated. But with the current code the last occurence
+        // will just overwrite the previous ones.
+        assert(!JVMFlag::find_flag(cursor)->ccstr_accumulates(),
+               "setting ccstrlist flags on restore is not supported: %s", cursor);
         result = WriteableFlags::set_flag(cursor, value, JVMFlagOrigin::CRAC_RESTORE, err_msg);
         cursor = value + strlen(value) + 1;
       }

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -426,15 +426,6 @@ void Threads::initialize_jsr292_core_classes(TRAPS) {
   }
 }
 
-static jint check_for_restore(JavaVMInitArgs* args) {
-  if (Arguments::is_restore_option_set(args)) {
-    if (!Arguments::parse_options_for_restore(args)) {
-      return JNI_ERR;
-    }
-  }
-  return JNI_OK;
-}
-
 // One-shot PeriodicTask subclass for reading the release file
 class ReadReleaseFileTask : public PeriodicTask {
  public:
@@ -491,8 +482,6 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 
   // So that JDK version can be used as a discriminator when parsing arguments
   JDK_Version_init();
-
-  if (check_for_restore(args) != JNI_OK) return JNI_ERR;
 
   // Update/Initialize System properties after JDK version number is known
   Arguments::init_version_specific_system_properties();
@@ -628,6 +617,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
       return JNI_ERR;
     }
   }
+  Arguments::free_restore_only_data(); // Not needed anymore
 
   // Have the WatcherThread read the release file in the background.
   ReadReleaseFileTask* read_task = new ReadReleaseFileTask();

--- a/test/jdk/jdk/crac/fileDescriptors/LoggingVMlogOpenTestNegative.java
+++ b/test/jdk/jdk/crac/fileDescriptors/LoggingVMlogOpenTestNegative.java
@@ -73,7 +73,9 @@ public class LoggingVMlogOpenTestNegative implements CracTest {
                 builder.vmOption("-XX:+UnlockDiagnosticVMOptions");
                 builder.vmOption("-XX:+LogCompilation");
                 builder.vmOption("-XX:LogFile=" + logPathR);
-                OutputAnalyzer oa = builder.captureOutput(true).startRestore().outputAnalyzer().shouldContain("cannot be set during restore").shouldNotHaveExitValue(0);
+                builder.captureOutput(true).startRestore().outputAnalyzer()
+                    .shouldContain("is not restore-settable and is not available on restore")
+                    .shouldNotHaveExitValue(0);
             }
         } finally {
             assertFalse(Files.exists(logPathO));


### PR DESCRIPTION
Options for restore are now processed during the common VM arguments parsing stage.

Notable improvements compared to the old code:
- Options from `-XX:Flags=<file>` and `-XX:VMOptionsFile=<file>` are now also considered
- Option aliasing is now handled correctly

**Behavioral change**. If `CRaCIgnoreRestoreIfUnavailable` is true it is now not an error to specify non-restore-settable options on restore — these will just be omitted from forwarding to the restored JVM. This makes it possible to specify non-restore-settable to be used after a failed restore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8364662](https://bugs.openjdk.org/browse/JDK-8364662): [CRaC] Process restore options in the common arguments parser (**Enhancement** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/258/head:pull/258` \
`$ git checkout pull/258`

Update a local copy of the PR: \
`$ git checkout pull/258` \
`$ git pull https://git.openjdk.org/crac.git pull/258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 258`

View PR using the GUI difftool: \
`$ git pr show -t 258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/258.diff">https://git.openjdk.org/crac/pull/258.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/258#issuecomment-3151943142)
</details>
