### PR TITLE
8364931: [CRaC] Stabilize recompiler tests

### DIFF
--- a/test/jdk/jdk/crac/recompiler/NaturalDecompilationTest.java
+++ b/test/jdk/jdk/crac/recompiler/NaturalDecompilationTest.java
@@ -28,6 +28,7 @@ import jdk.crac.Context;
 import jdk.crac.Core;
 import jdk.crac.Resource;
 import static jdk.test.lib.Asserts.*;
+import jdk.test.lib.Utils;
 import jdk.test.lib.crac.CracBuilder;
 import jdk.test.lib.crac.CracEngine;
 import jdk.test.lib.crac.CracTest;
@@ -103,7 +104,12 @@ public class NaturalDecompilationTest implements CracTest {
         // waiting never completes
         final var proc = builder.startCheckpoint();
         final var out = proc.outputAnalyzer();
-        proc.waitForSuccess();
+        try {
+            proc.waitForSuccess();
+        } catch (Exception ex) {
+            out.reportDiagnosticSummary();
+            throw ex;
+        }
         out.shouldContain("Requesting recompilation: int " + NaturalDecompilationTest.class.getName() + "." + TEST_METHOD_NAME + "(int)");
     }
 
@@ -112,24 +118,22 @@ public class NaturalDecompilationTest implements CracTest {
         final var whiteBox = WhiteBox.getWhiteBox();
         final var testMethodRef = NaturalDecompilationTest.class.getDeclaredMethod(TEST_METHOD_NAME, int.class);
 
-        timedDoWhile("compilation", () -> {
+        waitForCondition("compilation (enqueue)", () -> {
             for (int i = 0; i < 2000; i++) {
                 final var res = testMethod(TEST_ARG_EXPECTED);
                 blackhole(res);
             }
-            try {
-                Thread.sleep(500); // Time to compile
-            } catch (InterruptedException ex) {
-                throw new RuntimeException(ex);
-            }
-            return whiteBox.isMethodCompiled(testMethodRef);
+            return whiteBox.isMethodCompiled(testMethodRef) || whiteBox.isMethodQueuedForCompilation(testMethodRef);
         });
+        waitForCondition("compilation (dequeue)",
+            () -> !whiteBox.isMethodQueuedForCompilation(testMethodRef));
+        assertTrue(whiteBox.isMethodCompiled(testMethodRef), "Should be compiled");
 
         final var resource = new Resource() {
             @Override
             public void beforeCheckpoint(Context<? extends Resource> context) {
                 assertTrue(whiteBox.isMethodCompiled(testMethodRef), "Should still be compiled");
-                timedDoWhile("deoptimization", () -> {
+                waitForCondition("deoptimization", () -> {
                     // We don't want to call to many times or the method may
                     // get compiled again. Normally just one call is enough
                     // to make it decompile,
@@ -140,36 +144,32 @@ public class NaturalDecompilationTest implements CracTest {
 
             @Override
             public void afterRestore(Context<? extends Resource> context) {
-                assertFalse(whiteBox.isMethodCompiled(testMethodRef), "Should still be deoptimized");
+                assertFalse(
+                    whiteBox.isMethodCompiled(testMethodRef) || whiteBox.isMethodQueuedForCompilation(testMethodRef),
+                    "Should remain deoptimized"
+                );
             }
         };
         Core.getGlobalContext().register(resource);
 
         Core.checkpointRestore();
 
-        timedDoWhile("recompilation", () -> {
-            try {
-                Thread.sleep(1000); // Time to recompile
-            } catch (InterruptedException ex) {
-                throw new RuntimeException(ex);
-            }
-            return whiteBox.isMethodCompiled(testMethodRef);
-        });
+        waitForCondition("recompilation", () -> whiteBox.isMethodCompiled(testMethodRef));
     }
 
-    private static void timedDoWhile(String name, BooleanSupplier action) {
-        final var startTime = System.nanoTime();
-        boolean completed;
-        do {
-            if (STAGE_TIME_LIMIT_SEC > 0) {
-                assertLessThan(
-                    (System.nanoTime() - startTime) / 1_000_000_000, STAGE_TIME_LIMIT_SEC,
-                    "Task takes too long: " + name
-                );
-            }
-            System.out.println("Running: " + name);
-            completed = action.getAsBoolean();
-        } while (!completed);
-        System.out.println("Completed: " + name);
+    private static void waitForCondition(String name, BooleanSupplier condition) {
+        // Utils.waitForCondition() invokes its supplier argument one more time
+        // after it returns true. For our conditions that is unacceptable.
+        final var result = new Object() { boolean value = false; };
+        Utils.waitForCondition(() -> {
+                if (!result.value) {
+                    System.out.println("Running: " + name);
+                    result.value = condition.getAsBoolean();
+                }
+                return result.value;
+            },
+            STAGE_TIME_LIMIT_SEC > 0 ? STAGE_TIME_LIMIT_SEC * 1000 : -1
+        );
+        assertTrue(result.value, "Task takes too long: " + name);
     }
 }

--- a/test/jdk/jdk/crac/recompiler/RecompilationFlagsTest.java
+++ b/test/jdk/jdk/crac/recompiler/RecompilationFlagsTest.java
@@ -154,7 +154,7 @@ public class RecompilationFlagsTest implements CracTest {
             recompilerThreadField.setAccessible(true);
             recompilerThread = (Thread) recompilerThreadField.get(null);
         } catch (ReflectiveOperationException ex) {
-            throw new IllegalStateException("Cannot invoke Thread.getAllThreads()", ex);
+            throw new IllegalStateException("Cannot read jdk.internal.crac.mirror.Core.recompilerThread", ex);
         }
 
         if (recompilerThread != null) {


### PR DESCRIPTION
Stabilizes recompiler tests:
- `NaturalDecompilationTest` now ensures the method is not enqueued for another compilation before proceeding with the test.
- In `RecompilationFlagsTest` recompilation waiting period of a predefined length is replaced with waiting for the methods to get enqueued and dequeued to/from the compilation queue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8364931](https://bugs.openjdk.org/browse/JDK-8364931): [CRaC] Stabilize recompiler tests (**Bug** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/259/head:pull/259` \
`$ git checkout pull/259`

Update a local copy of the PR: \
`$ git checkout pull/259` \
`$ git pull https://git.openjdk.org/crac.git pull/259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 259`

View PR using the GUI difftool: \
`$ git pr show -t 259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/259.diff">https://git.openjdk.org/crac/pull/259.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/259#issuecomment-3160670354)
</details>
