### PR TITLE
8365143: [CRaC] CRaCIgnoreRestoreIfUnavailable tests do not check exit value

### DIFF
--- a/test/jdk/jdk/crac/ignoreRestore/EngineFailureTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/EngineFailureTest.java
@@ -58,6 +58,7 @@ public class EngineFailureTest {
             .forwardClasspathOnRestore(true)
             .captureOutput(true)
             .startRestoreWithArgs(null, List.of(Main.class.getName(), "false"))
+            .waitForSuccess()
             .outputAnalyzer()
             .shouldContain("CRaC engine failed to restore")
             .shouldContain(MAIN_MSG);

--- a/test/jdk/jdk/crac/ignoreRestore/InvalidImageLocationTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/InvalidImageLocationTest.java
@@ -66,8 +66,9 @@ public class InvalidImageLocationTest {
             case IMAGE_IS_NOT_DIR -> "CRaCRestoreFrom=" + builder.imageDir() + " is not a directory";
         };
 
-        final var out = builder.startRestoreWithArgs(null, List.of(Main.class.getName())).outputAnalyzer();
-        out.shouldContain(errMsg).shouldContain(MAIN_MSG);
+        builder.startRestoreWithArgs(null, List.of(Main.class.getName()))
+            .waitForSuccess().outputAnalyzer()
+            .shouldContain(errMsg).shouldContain(MAIN_MSG);
     }
 
     public static class Main {

--- a/test/jdk/jdk/crac/ignoreRestore/NoCPUFeaturesTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/NoCPUFeaturesTest.java
@@ -48,7 +48,8 @@ public class NoCPUFeaturesTest {
         Files.createDirectory(builder.imageDir());
 
         builder.startRestoreWithArgs(null, List.of(Main.class.getName(), "false"))
-            .outputAnalyzer().shouldContain("incompatible CPU features").shouldContain(MAIN_MSG);
+            .waitForSuccess().outputAnalyzer()
+            .shouldContain("incompatible CPU features").shouldContain(MAIN_MSG);
     }
 
     public static class Main {

--- a/test/jdk/jdk/crac/ignoreRestore/RestoreIfPossibleTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/RestoreIfPossibleTest.java
@@ -61,8 +61,9 @@ public class RestoreIfPossibleTest {
             FileUtils.deleteFileTreeWithRetry(builder.imageDir()); // Existance depends on the order of @run tags
         }
 
-        final var out = builder.startRestoreWithArgs(null, List.of(Main.class.getName(), "false")).outputAnalyzer();
-        out.stdoutShouldNotContain(WARMUP_MSG).stdoutShouldContain(MAIN_MSG);
+        builder.startRestoreWithArgs(null, List.of(Main.class.getName(), "false"))
+            .waitForSuccess().outputAnalyzer()
+            .stdoutShouldNotContain(WARMUP_MSG).stdoutShouldContain(MAIN_MSG);
     }
 
     public static class Main {


### PR DESCRIPTION
Adds missing exit value checks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8365143](https://bugs.openjdk.org/browse/JDK-8365143): [CRaC] CRaCIgnoreRestoreIfUnavailable tests do not check exit value (**Bug** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/260/head:pull/260` \
`$ git checkout pull/260`

Update a local copy of the PR: \
`$ git checkout pull/260` \
`$ git pull https://git.openjdk.org/crac.git pull/260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 260`

View PR using the GUI difftool: \
`$ git pr show -t 260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/260.diff">https://git.openjdk.org/crac/pull/260.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/260#issuecomment-3167679636)
</details>
