### PR TITLE
8365241: [CRaC] Ignore new arguments when CRaCIgnoreRestoreIfUnavailable is true

### DIFF
--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -555,7 +555,8 @@ void crac::restore(crac_restore_data& restore_data) {
         shmfd,
         Arguments::jvm_restore_flags_array(), Arguments::num_jvm_restore_flags(),
         Arguments::system_properties(),
-        Arguments::java_command_crac() ? Arguments::java_command_crac() : "",
+        !CRaCIgnoreRestoreIfUnavailable && Arguments::java_command_crac() != nullptr ?
+          Arguments::java_command_crac() : "",
         restore_data.restore_time,
         restore_data.restore_nanos
       );

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1989,8 +1989,12 @@ const int ObjectAlignmentInBytes = 8;
           "restored VM keeps the value it had before the checkpoint.")      \
                                                                             \
   product(bool, CRaCIgnoreRestoreIfUnavailable, false, RESTORE_SETTABLE,    \
-          "Ignore -XX:CRaCRestoreFrom and continue initialization if "      \
-          "restore is not possible")                                        \
+          "If the image selected via CRaCRestoreFrom is identified as "     \
+          "being unusable, continue initializing the JVM instead of "       \
+          "failing. Enabling this option does not guarantee that the "      \
+          "initialization will continue after any failed restoration "      \
+          "attempt; it only covers an early image/environment "             \
+          "verification.")                                                  \
                                                                             \
   product(ccstr, CRaCIgnoredFileDescriptors, nullptr, RESTORE_SETTABLE,     \
           "Comma-separated list of file descriptor numbers or paths. All "  \

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1093,8 +1093,10 @@ These `java` options control the runtime behavior of the Java HotSpot VM.
     of its existing call stack.
 
 `-XX:+CRaCIgnoreRestoreIfUnavailable`
-:   If restoration from a checkpoint image fails, continue with the normal startup
-    instead of failing.
+:   If the checkpoint image specified for restoration is identified as being unusable,
+    continue with the normal startup instead of failing. Enabling this option does
+    not guarantee that the normal startup will follow any failed restoration attempt;
+    it only covers an early image/environment verification.
 
     When restoring with this option, you should specify a main class and its
     arguments as usual. If the restoration succeeds, they are ignored, but if it

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1085,22 +1085,21 @@ These `java` options control the runtime behavior of the Java HotSpot VM.
 `-XX:CRaCRestoreFrom=`*directory*
 :   Restores from the specified checkpoint image.
 
-    When using this option, there is no requirement to specify a main class and its
-    arguments because the restored execution is based on the ones specified before
-    the checkpoint. However, it is possible to pass a new main class and new
-    arguments. After a successful restoration, the new main method will be invoked
-    with the specified arguments in the thread that started the checkpoint, on top
-    of its existing call stack.
+    You can optionally pass the name of the new main class and its arguments when
+    using this option. In such a case, the new main method will be invoked with
+    the specified arguments by the thread that initiated the checkpoint, after all
+    CRaC resources have been successfully processed.
 
 `-XX:+CRaCIgnoreRestoreIfUnavailable`
-:   If the checkpoint image specified for restoration is identified as being unusable,
-    continue with the normal startup instead of failing. Enabling this option does
-    not guarantee that the normal startup will follow any failed restoration attempt;
-    it only covers an early image/environment verification.
+:   If the checkpoint image specified for restoration is identified as being
+    unusable, continue with the normal startup instead of failing.
 
-    When restoring with this option, you should specify a main class and its
-    arguments as usual. If the restoration succeeds, they are ignored, but if it
-    fails, they are used for the normal startup process.
+    When restoring with this option, you should specify the command-line arguments
+    for the normal startup process. If the restoration succeeds, they are ignored;
+    otherwise, they are used for starting up.
+
+    If an initial image verification passes, but restoration still fails, the JVM
+    will not attempt to start normally.
 
 `-XX:CRaCMinPid=`*value*
 :   A desired minimal PID value for checkpointed process. Applied by the launcher,

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1085,6 +1085,21 @@ These `java` options control the runtime behavior of the Java HotSpot VM.
 `-XX:CRaCRestoreFrom=`*directory*
 :   Restores from the specified checkpoint image.
 
+    When using this option, there is no requirement to specify a main class and its
+    arguments because the restored execution is based on the ones specified before
+    the checkpoint. However, it is possible to pass a new main class and new
+    arguments. After a successful restoration, the new main method will be invoked
+    with the specified arguments in the thread that started the checkpoint, on top
+    of its existing call stack.
+
+`-XX:+CRaCIgnoreRestoreIfUnavailable`
+:   If restoration from a checkpoint image fails, continue with the normal startup
+    instead of failing.
+
+    When restoring with this option, you should specify a main class and its
+    arguments as usual. If the restoration succeeds, they are ignored, but if it
+    fails, they are used for the normal startup process.
+
 `-XX:CRaCMinPid=`*value*
 :   A desired minimal PID value for checkpointed process. Applied by the launcher,
     only on POSIX-like platforms.

--- a/test/jdk/jdk/crac/ignoreRestore/RestoreIfPossibleTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/RestoreIfPossibleTest.java
@@ -23,10 +23,13 @@
  * questions.
  */
 
+import java.nio.file.Files;
+import java.util.Collections;
 import java.util.List;
 
 import jdk.crac.Core;
 
+import static jdk.test.lib.Asserts.*;
 import jdk.test.lib.crac.CracBuilder;
 import jdk.test.lib.crac.CracEngine;
 import jdk.test.lib.util.FileUtils;
@@ -57,12 +60,19 @@ public class RestoreIfPossibleTest {
             checkpointProcess.waitForCheckpointed();
             final var out = checkpointProcess.outputAnalyzer();
             out.stdoutShouldContain(WARMUP_MSG).stdoutShouldNotContain(MAIN_MSG);
-        } else {
-            FileUtils.deleteFileTreeWithRetry(builder.imageDir()); // Existance depends on the order of @run tags
+        } else if (Files.exists(builder.imageDir())) { // Existance depends on the order of @run tags
+            FileUtils.deleteFileTreeWithRetry(builder.imageDir());
         }
 
         final var out = builder.startRestoreWithArgs(null, List.of(Main.class.getName(), "false")).outputAnalyzer();
-        out.stdoutShouldNotContain(WARMUP_MSG).stdoutShouldContain(MAIN_MSG);
+        out.stdoutShouldNotContain(WARMUP_MSG);
+
+        // Check the count to ensure a new main is not launched on successful restore
+        final var mainMsgCount = Collections.frequency(out.stdoutAsLines(), MAIN_MSG);
+        if (mainMsgCount != 1) {
+            out.reportDiagnosticSummary();
+            assertEquals(1, mainMsgCount, "Main message should be printed exactly once");
+        }
     }
 
     public static class Main {

--- a/test/jdk/jdk/crac/ignoreRestore/RestoreIfPossibleTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/RestoreIfPossibleTest.java
@@ -72,7 +72,7 @@ public class RestoreIfPossibleTest {
         final var mainMsgCount = Collections.frequency(out.stdoutAsLines(), MAIN_MSG);
         if (mainMsgCount != 1) {
             out.reportDiagnosticSummary();
-            assertEquals(1, mainMsgCount, "Main message should be printed exactly once");
+            fail("Main message should be printed exactly once, got printed " + mainMsgCount + " times instead");
         }
     }
 


### PR DESCRIPTION
Arguments are not passed to the restored process when `-XX:+CRaCIgnoreRestoreIfUnavailable` is set on restore. The check is performed on the side of the restoring VM since in the restored VM `CRaCIgnoreRestoreIfUnavailable` could have been set before the current restore.

Documentation for the new arguments feature and `CRaCIgnoreRestoreIfUnavailable` is also added, explaining this behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8365241](https://bugs.openjdk.org/browse/JDK-8365241): [CRaC] Ignore new arguments when CRaCIgnoreRestoreIfUnavailable is true (**Enhancement** - P1)


### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/261/head:pull/261` \
`$ git checkout pull/261`

Update a local copy of the PR: \
`$ git checkout pull/261` \
`$ git pull https://git.openjdk.org/crac.git pull/261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 261`

View PR using the GUI difftool: \
`$ git pr show -t 261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/261.diff">https://git.openjdk.org/crac/pull/261.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/261#issuecomment-3174318184)
</details>
