### PR TITLE
8365380: [CRaC] Require non-static JDK for EngineFailureTest

### DIFF
--- a/test/jdk/jdk/crac/ignoreRestore/EngineFailureTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/EngineFailureTest.java
@@ -33,6 +33,8 @@ import jdk.test.lib.crac.CracEngine;
  * @test
  * @summary If CRaCIgnoreRestoreIfUnavailable is specified and the engine
  *          fails to restore for any reason VM should proceed without restoring.
+ * @comment The test needs crexec as a dynamic library.
+ * @requires !jdk.static
  * @library /test/lib
  */
 public class EngineFailureTest {


### PR DESCRIPTION
Requires a non-static JDK to run `EngineFailureTest`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8365380](https://bugs.openjdk.org/browse/JDK-8365380): [CRaC] Require non-static JDK for EngineFailureTest (**Bug** - P1)


### Reviewers
 * [Dmitry Cherepanov](https://openjdk.org/census#dcherepanov) (@dimitryc - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/262/head:pull/262` \
`$ git checkout pull/262`

Update a local copy of the PR: \
`$ git checkout pull/262` \
`$ git pull https://git.openjdk.org/crac.git pull/262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 262`

View PR using the GUI difftool: \
`$ git pr show -t 262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/262.diff">https://git.openjdk.org/crac/pull/262.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/262#issuecomment-3182380993)
</details>
