### PR TITLE
8365484: [CRaC] Support IgnoreUnrecognizedVMOptions on restore

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2946,9 +2946,6 @@ static bool should_record_for_restore(const JVMFlag& flag) {
            "unexpected CRaCEngine* flag: %s", flag.name());
     return false;
   }
-  if (strcmp(flag.name(), "IgnoreUnrecognizedVMOptions") == 0) {
-    return false;
-  }
   return true;
 }
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2946,6 +2946,9 @@ static bool should_record_for_restore(const JVMFlag& flag) {
            "unexpected CRaCEngine* flag: %s", flag.name());
     return false;
   }
+  if (strcmp(flag.name(), "IgnoreUnrecognizedVMOptions") == 0) {
+    return false;
+  }
   return true;
 }
 

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -615,13 +615,6 @@ bool CracRestoreParameters::read_from(int fd) {
       result = WriteableFlags::set_flag(name, *cursor == '+' ? "true" : "false",
         JVMFlagOrigin::CRAC_RESTORE, err_msg);
       cursor += strlen(cursor) + 1;
-    } else if (strncmp(name, "CRaCEngine", ARRAY_SIZE("CRaCEngine") - 1) == 0) {
-      // CRaCEngine and CRaCEngineOptions are not updated from the restoring process
-      assert(strncmp(name, "CRaCEngine=", strlen("CRaCEngine=")) == 0 ||
-             strncmp(name, "CRaCEngineOptions=", strlen("CRaCEngineOptions=")) == 0,
-             "unexpected CRaCEngine* flag: %s", name);
-      result = JVMFlag::Error::SUCCESS;
-      cursor += strlen(cursor) + 1;
     } else {
       char* eq = strchrnul(cursor, '=');
       if (*eq == '\0') {

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1005,7 +1005,7 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, PrintVMOptions, false,                                      \
           "Print flags that appeared on the command line")                  \
                                                                             \
-  product(bool, IgnoreUnrecognizedVMOptions, false,                         \
+  product(bool, IgnoreUnrecognizedVMOptions, false, RESTORE_SETTABLE,       \
           "Ignore unrecognized VM options")                                 \
                                                                             \
   product(bool, PrintCommandLineFlags, false,                               \

--- a/test/jdk/jdk/crac/VMOptionsTest.java
+++ b/test/jdk/jdk/crac/VMOptionsTest.java
@@ -183,10 +183,6 @@ public class VMOptionsTest implements CracTest {
                 assertEquals(VMOption.Origin.VM_CREATION, opt.getOrigin(), optSpec.name() + ": origin changed after restore");
             }
         }
-        {
-            final var ignoreUnrecognized = bean.getVMOption("IgnoreUnrecognizedVMOptions");
-            assertEquals(VMOption.Origin.DEFAULT, ignoreUnrecognized.getOrigin(), "IgnoreUnrecognizedVMOptions: origin changed after restore");
-        }
         for (final var optSpec : OPTIONS_RESTORE) {
             final var opt = bean.getVMOption(optSpec.name());
             if (!optSpec.canChangeOnRestore()) {

--- a/test/jdk/jdk/crac/VMOptionsTest.java
+++ b/test/jdk/jdk/crac/VMOptionsTest.java
@@ -183,6 +183,10 @@ public class VMOptionsTest implements CracTest {
                 assertEquals(VMOption.Origin.VM_CREATION, opt.getOrigin(), optSpec.name() + ": origin changed after restore");
             }
         }
+        {
+            final var ignoreUnrecognized = bean.getVMOption("IgnoreUnrecognizedVMOptions");
+            assertEquals(VMOption.Origin.DEFAULT, ignoreUnrecognized.getOrigin(), "IgnoreUnrecognizedVMOptions: origin changed after restore");
+        }
         for (final var optSpec : OPTIONS_RESTORE) {
             final var opt = bean.getVMOption(optSpec.name());
             if (!optSpec.canChangeOnRestore()) {


### PR DESCRIPTION
Makes `IgnoreUnrecognizedVMOptions` restore-settable.

`IgnoreUnrecognizedVMOptions` is not forwarded to the restored JVM since that does not make much sense (the options are filtered in the restoring VM).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8365484](https://bugs.openjdk.org/browse/JDK-8365484): [CRaC] Support IgnoreUnrecognizedVMOptions on restore (**Enhancement** - P4)


### Reviewers
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/263/head:pull/263` \
`$ git checkout pull/263`

Update a local copy of the PR: \
`$ git checkout pull/263` \
`$ git pull https://git.openjdk.org/crac.git pull/263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 263`

View PR using the GUI difftool: \
`$ git pr show -t 263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/263.diff">https://git.openjdk.org/crac/pull/263.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/263#issuecomment-3183741230)
</details>
