### PR TITLE
8378259: [CRaC] Tests using CRIU fail in GitHub Actions

### DIFF
--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -40,9 +40,9 @@ MACOS_AARCH64_BOOT_JDK_EXT=tar.gz
 MACOS_AARCH64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_macos-aarch64_bin.tar.gz
 MACOS_AARCH64_BOOT_JDK_SHA256=2006337bf326fdfdf6117081751ba38c1c8706d63419ecac7ff102ff7c776876
 
-LINUX_X64_CRIU_FILENAME=criu-crac-release-1.3.tar.gz
-LINUX_X64_CRIU_URL=https://github.com/CRaC/criu/releases/download/release-1.3/criu-crac-release-1.3.tar.gz
-LINUX_X64_CRIU_SHA256=82a014bf342c957305b98a71867c0994ebf6e7379f01f083121884793768d966
+LINUX_X64_CRIU_FILENAME=criu-crac-release-1.5.2.tar.gz
+LINUX_X64_CRIU_URL=https://github.com/CRaC/criu/releases/download/release-1.5.2/criu-crac-release-1.5.2.tar.gz
+LINUX_X64_CRIU_SHA256=817482b303e85fbf9aa5b441a64a5ce55eabc23549af16be98e56c4a928a199b
 
 MACOS_X64_BOOT_JDK_EXT=tar.gz
 MACOS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_macos-x64_bin.tar.gz


### PR DESCRIPTION
Updates CRIU to fix its failures in GitHub CI we started seeing recently.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8378259](https://bugs.openjdk.org/browse/JDK-8378259): [CRaC] Tests using CRIU fail in GitHub Actions (**Task** - P1)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/296/head:pull/296` \
`$ git checkout pull/296`

Update a local copy of the PR: \
`$ git checkout pull/296` \
`$ git pull https://git.openjdk.org/crac.git pull/296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 296`

View PR using the GUI difftool: \
`$ git pr show -t 296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/296.diff">https://git.openjdk.org/crac/pull/296.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/296#issuecomment-3927811315)
</details>
