### PR TITLE
8381620: [CRaC] MissingMetadataTest fails on Linux ARM

### DIFF
--- a/test/jdk/jdk/crac/ignoreRestore/MissingMetadataTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/MissingMetadataTest.java
@@ -43,7 +43,9 @@ public class MissingMetadataTest {
     public static void main(String[] args) throws Exception {
         test("criuengine", null, "Cannot open file cr/engine");
         test("criuengine", "badengine", "Image format does not match");
-        test("criuengine", "criuengine", Platform.isX64() ? "cannot open cr/tags in mode r" : "");
+        if (Platform.isX64()) { // Requires a platform supporting CPU features
+            test("criuengine", "criuengine", "cannot open cr/tags in mode r");
+        }
     }
 
     public static void test(String engine, String recordedEngine, String expectedMessage) throws Exception {
@@ -61,7 +63,7 @@ public class MissingMetadataTest {
             Files.writeString(builder.imageDir().resolve("engine"), recordedEngine);
         }
 
-        builder.startRestoreWithArgs(List.of(), List.of(Main.class.getName(), "false"))
+        builder.startRestoreWithArgs(List.of(), List.of(Main.class.getName()))
             .outputAnalyzer()
             .shouldHaveExitValue(0)
             .shouldContain(expectedMessage).shouldContain(MAIN_MSG);


### PR DESCRIPTION
Restricts the test case that relies on CPU features support to x64 platforms.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8381620](https://bugs.openjdk.org/browse/JDK-8381620): [CRaC] MissingMetadataTest fails on Linux ARM (**Bug** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/306/head:pull/306` \
`$ git checkout pull/306`

Update a local copy of the PR: \
`$ git checkout pull/306` \
`$ git pull https://git.openjdk.org/crac.git pull/306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 306`

View PR using the GUI difftool: \
`$ git pr show -t 306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/306.diff">https://git.openjdk.org/crac/pull/306.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/306#issuecomment-4183364711)
</details>
