### PR TITLE
8382488: [CRaC] Testing of cpuid FMA4 should be done only on AMDs

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -3677,8 +3677,10 @@ VM_Version::VM_Features VM_Version::CpuidInfo::feature_flags() const {
   if (std_cpuid1_ecx.bits.cmpxchg16 != 0) {
     vm_features.set_feature(CPU_CMPXCHG16);
   }
-  if (ext_cpuid1_ecx.bits.fma4 != 0) {
-    vm_features.set_feature(CPU_FMA4);
+  if (is_amd_family()) {
+    if (ext_cpuid1_ecx.bits.fma4 != 0) {
+      vm_features.set_feature(CPU_FMA4);
+    }
   }
   if (ext_cpuid1_ecx.bits.LahfSahf != 0) {
     vm_features.set_feature(CPU_LAHFSAHF);


### PR DESCRIPTION
The current code in `src/hotspot/cpu/x86/vm_version_x86.cpp`:
```
if (ext_cpuid1_ecx.bits.fma4 != 0) {
    vm_features.set_feature(CPU_FMA4);
}
```
It should be protected by:
```
  if (is_amd_family())
```
as that bit is reserved on Intel.

Bugreported by @rvansa.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8382488](https://bugs.openjdk.org/browse/JDK-8382488): [CRaC] Testing of cpuid FMA4 should be done only on AMDs (**Bug** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/310/head:pull/310` \
`$ git checkout pull/310`

Update a local copy of the PR: \
`$ git checkout pull/310` \
`$ git pull https://git.openjdk.org/crac.git pull/310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 310`

View PR using the GUI difftool: \
`$ git pr show -t 310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/310.diff">https://git.openjdk.org/crac/pull/310.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/310#issuecomment-4278400033)
</details>
