### PR TITLE
8383789: [CRaC] Add reading to Java-side score API

### DIFF
--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -741,9 +741,13 @@ class SerializeClosure;
   template(toFileURL_name,                                  "toFileURL")                                          \
   template(toFileURL_signature,                             "(Ljava/lang/String;)Ljava/net/URL;")                 \
                                                                                                                   \
+  /* CRaC */                                                                                                      \
   template(jdk_internal_crac_mirror_Core,          "jdk/internal/crac/mirror/Core")                               \
   template(checkpointRestoreInternal_name,         "checkpointRestoreInternal")                                   \
   template(checkpointRestoreInternal_signature,    "(J)Ljava/lang/String;")                                       \
+  template(jdk_internal_crac_Score,                "jdk/internal/crac/Score")                                     \
+  template(setScore_name,                          "setScore")                                                    \
+  template(setScore_signature,                     "(Ljava/lang/String;D)V")                                      \
                                                                                                                   \
   /* jcmd Thread.dump_to_file */                                                                                  \
   template(jdk_internal_vm_ThreadDumper,           "jdk/internal/vm/ThreadDumper")                                \

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1191,10 +1191,10 @@ JNIEXPORT jboolean JNICALL
 JVM_IsCRaCScoreSupported(JNIEnv *env);
 
 JNIEXPORT jobjectArray JNICALL
-JVM_GetJVMCRaCScore(JNIEnv *env);
+JVM_GetCRaCScore(JNIEnv *env);
 
 JNIEXPORT void JNICALL
-JVM_RecordJavaCRaCScore(JNIEnv *env, jobjectArray metrics, jdoubleArray values);
+JVM_RecordCRaCScore(JNIEnv *env, jobjectArray metrics, jdoubleArray values);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1191,10 +1191,10 @@ JNIEXPORT jboolean JNICALL
 JVM_IsCRaCScoreSupported(JNIEnv *env);
 
 JNIEXPORT jobjectArray JNICALL
-JVM_GetCRaCScore(JNIEnv *env);
+JVM_GetCRaCScores(JNIEnv *env);
 
 JNIEXPORT void JNICALL
-JVM_RecordCRaCScore(JNIEnv *env, jobjectArray metrics, jdoubleArray values);
+JVM_RecordCRaCScores(JNIEnv *env, jobjectArray metrics, jdoubleArray values);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1190,8 +1190,11 @@ JVM_FinishRecordingDecompilationsAndRecompile(JNIEnv *env);
 JNIEXPORT jboolean JNICALL
 JVM_IsCRaCScoreSupported(JNIEnv *env);
 
-JNIEXPORT jboolean JNICALL
-JVM_RecordCRaCScore(JNIEnv *env, jobjectArray metrics, jdoubleArray values);
+JNIEXPORT jobjectArray JNICALL
+JVM_GetJVMCRaCScore(JNIEnv *env);
+
+JNIEXPORT void JNICALL
+JVM_RecordJavaCRaCScore(JNIEnv *env, jobjectArray metrics, jdoubleArray values);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3676,27 +3676,27 @@ JVM_ENTRY(jboolean, JVM_IsCRaCScoreSupported(JNIEnv *env))
   return crac::is_image_score_supported();
 JVM_END
 
-JVM_ENTRY(jobjectArray, JVM_GetCRaCScore(JNIEnv *env))
+JVM_ENTRY(jobjectArray, JVM_GetCRaCScores(JNIEnv *env))
   ResourceMark rm;
-  const GrowableArray<crac::score> score = crac::collect_image_score_from_jvm();
-  const objArrayOop score_flat_oop = oopFactory::new_objectArray(2 * score.length(), CHECK_NULL);
-  const objArrayHandle score_flat(THREAD, score_flat_oop);
-  for (int i = 0; i < score.length(); i++) {
-    const crac::score &score_i = score.at(i);
-    Handle metric = java_lang_String::create_from_str(score_i.metric, CHECK_NULL);
+  const GrowableArray<crac::score> scores = crac::get_image_scores_from_jvm();
+  const objArrayOop scores_flat_oop = oopFactory::new_objectArray(2 * scores.length(), CHECK_NULL);
+  const objArrayHandle scores_flat(THREAD, scores_flat_oop);
+  for (int i = 0; i < scores.length(); i++) {
+    const crac::score &score = scores.at(i);
+    Handle metric = java_lang_String::create_from_str(score.metric, CHECK_NULL);
     jvalue value_jval;
-    value_jval.d = score_i.value;
+    value_jval.d = score.value;
     oop value = java_lang_boxing_object::create(T_DOUBLE, &value_jval, CHECK_NULL);
-    score_flat->obj_at_put(2 * i, metric());
-    score_flat->obj_at_put(2 * i + 1, value);
+    scores_flat->obj_at_put(2 * i, metric());
+    scores_flat->obj_at_put(2 * i + 1, value);
   }
-  return checked_cast<jobjectArray>(JNIHandles::make_local(THREAD, score_flat()));
+  return checked_cast<jobjectArray>(JNIHandles::make_local(THREAD, scores_flat()));
 JVM_END
 
-JVM_ENTRY(void, JVM_RecordCRaCScore(JNIEnv *env, jobjectArray metrics, jdoubleArray values))
+JVM_ENTRY(void, JVM_RecordCRaCScores(JNIEnv *env, jobjectArray metrics, jdoubleArray values))
   // Not supported is ok: this is used internally, helps avoid another JNI call checking the support
-  if (crac::is_image_score_supported() && !crac::record_image_score(metrics, values)) {
-    THROW_MSG(vmSymbols::java_lang_RuntimeException(), err_msg("CRaC engine failed to record score"));
+  if (crac::is_image_score_supported() && !crac::record_image_scores(metrics, values)) {
+    THROW_MSG(vmSymbols::java_lang_RuntimeException(), err_msg("CRaC engine failed to record scores"));
   }
 JVM_END
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3676,8 +3676,30 @@ JVM_ENTRY(jboolean, JVM_IsCRaCScoreSupported(JNIEnv *env))
   return crac::is_image_score_supported();
 JVM_END
 
-JVM_ENTRY(jboolean, JVM_RecordCRaCScore(JNIEnv *env, jobjectArray metrics, jdoubleArray values))
-  return crac::record_image_score(metrics, values);
+JVM_ENTRY(jobjectArray, JVM_GetJVMCRaCScore(JNIEnv *env))
+  ResourceMark rm;
+  const GrowableArray<crac::score> score = crac::collect_image_score_from_jvm();
+  const objArrayHandle score_pairs = oopFactory::new_objArray_handle(Universe::objectArrayKlass(), score.length(), CHECK_NULL);
+  for (int i = 0; i < score.length(); i++) {
+    const crac::score &score_i = score.at(i);
+    Handle metric = java_lang_String::create_from_str(score_i.metric, CHECK_NULL);
+    jvalue value_jval;
+    value_jval.d = score_i.value;
+    oop value_oop = java_lang_boxing_object::create(T_DOUBLE, &value_jval, CHECK_NULL);
+    Handle value(THREAD, value_oop);
+    objArrayOop score_pair = oopFactory::new_objectArray(2, CHECK_NULL);
+    score_pair->obj_at_put(0, metric());
+    score_pair->obj_at_put(1, value());
+    score_pairs->obj_at_put(i, score_pair);
+  }
+  return checked_cast<jobjectArray>(JNIHandles::make_local(THREAD, score_pairs()));
+JVM_END
+
+JVM_ENTRY(void, JVM_RecordJavaCRaCScore(JNIEnv *env, jobjectArray metrics, jdoubleArray values))
+  // Not supported is ok: this is used internally, helps avoid another JNI call checking the support
+  if (crac::is_image_score_supported() && !crac::record_image_score_from_java(metrics, values)) {
+    THROW_MSG(vmSymbols::java_lang_RuntimeException(), err_msg("CRaC engine failed to record score"));
+  }
 JVM_END
 
 JVM_ENTRY(void, JVM_VirtualThreadEndFirstTransition(JNIEnv* env, jobject vthread))

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3679,20 +3679,18 @@ JVM_END
 JVM_ENTRY(jobjectArray, JVM_GetCRaCScore(JNIEnv *env))
   ResourceMark rm;
   const GrowableArray<crac::score> score = crac::collect_image_score_from_jvm();
-  const objArrayHandle score_pairs = oopFactory::new_objArray_handle(Universe::objectArrayKlass(), score.length(), CHECK_NULL);
+  const objArrayOop score_flat_oop = oopFactory::new_objectArray(2 * score.length(), CHECK_NULL);
+  const objArrayHandle score_flat(THREAD, score_flat_oop);
   for (int i = 0; i < score.length(); i++) {
     const crac::score &score_i = score.at(i);
     Handle metric = java_lang_String::create_from_str(score_i.metric, CHECK_NULL);
     jvalue value_jval;
     value_jval.d = score_i.value;
-    oop value_oop = java_lang_boxing_object::create(T_DOUBLE, &value_jval, CHECK_NULL);
-    Handle value(THREAD, value_oop);
-    objArrayOop score_pair = oopFactory::new_objectArray(2, CHECK_NULL);
-    score_pair->obj_at_put(0, metric());
-    score_pair->obj_at_put(1, value());
-    score_pairs->obj_at_put(i, score_pair);
+    oop value = java_lang_boxing_object::create(T_DOUBLE, &value_jval, CHECK_NULL);
+    score_flat->obj_at_put(2 * i, metric());
+    score_flat->obj_at_put(2 * i + 1, value);
   }
-  return checked_cast<jobjectArray>(JNIHandles::make_local(THREAD, score_pairs()));
+  return checked_cast<jobjectArray>(JNIHandles::make_local(THREAD, score_flat()));
 JVM_END
 
 JVM_ENTRY(void, JVM_RecordCRaCScore(JNIEnv *env, jobjectArray metrics, jdoubleArray values))

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3676,7 +3676,7 @@ JVM_ENTRY(jboolean, JVM_IsCRaCScoreSupported(JNIEnv *env))
   return crac::is_image_score_supported();
 JVM_END
 
-JVM_ENTRY(jobjectArray, JVM_GetJVMCRaCScore(JNIEnv *env))
+JVM_ENTRY(jobjectArray, JVM_GetCRaCScore(JNIEnv *env))
   ResourceMark rm;
   const GrowableArray<crac::score> score = crac::collect_image_score_from_jvm();
   const objArrayHandle score_pairs = oopFactory::new_objArray_handle(Universe::objectArrayKlass(), score.length(), CHECK_NULL);
@@ -3695,9 +3695,9 @@ JVM_ENTRY(jobjectArray, JVM_GetJVMCRaCScore(JNIEnv *env))
   return checked_cast<jobjectArray>(JNIHandles::make_local(THREAD, score_pairs()));
 JVM_END
 
-JVM_ENTRY(void, JVM_RecordJavaCRaCScore(JNIEnv *env, jobjectArray metrics, jdoubleArray values))
+JVM_ENTRY(void, JVM_RecordCRaCScore(JNIEnv *env, jobjectArray metrics, jdoubleArray values))
   // Not supported is ok: this is used internally, helps avoid another JNI call checking the support
-  if (crac::is_image_score_supported() && !crac::record_image_score_from_java(metrics, values)) {
+  if (crac::is_image_score_supported() && !crac::record_image_score(metrics, values)) {
     THROW_MSG(vmSymbols::java_lang_RuntimeException(), err_msg("CRaC engine failed to record score"));
   }
 JVM_END

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -771,47 +771,47 @@ void crac::set_image_score(const char *metric, double value, TRAPS) {
                          CHECK);
 }
 
-GrowableArray<crac::score> crac::collect_image_score_from_jvm() {
-  GrowableArray<crac::score> score(21);
+GrowableArray<crac::score> crac::get_image_scores_from_jvm() {
+  GrowableArray<crac::score> scores(21);
 
-  score.append({"java.lang.Runtime.availableProcessors", static_cast<double>(os::active_processor_count())});
-  score.append({"java.lang.Runtime.totalMemory", static_cast<double>(Universe::heap()->capacity())});
-  score.append({"java.lang.Runtime.maxMemory", static_cast<double>(Universe::heap()->max_capacity())});
+  scores.append({"java.lang.Runtime.availableProcessors", static_cast<double>(os::active_processor_count())});
+  scores.append({"java.lang.Runtime.totalMemory", static_cast<double>(Universe::heap()->capacity())});
+  scores.append({"java.lang.Runtime.maxMemory", static_cast<double>(Universe::heap()->max_capacity())});
 
   const double uptime = TimeHelper::counter_to_millis(os::elapsed_counter());
-  score.append({"vm.boot_time", os::javaTimeMillis() - uptime});
-  score.append({"vm.uptime", uptime});
-  score.append({"vm.uptime_since_restore", TimeHelper::counter_to_millis(os::elapsed_counter_since_restore())});
+  scores.append({"vm.boot_time", os::javaTimeMillis() - uptime});
+  scores.append({"vm.uptime", uptime});
+  scores.append({"vm.uptime_since_restore", TimeHelper::counter_to_millis(os::elapsed_counter_since_restore())});
 
 #if INCLUDE_MANAGEMENT
   const jlong shared_loaded_classes = ClassLoadingService::loaded_shared_class_count();
   const jlong shared_unloaded_classes = ClassLoadingService::unloaded_shared_class_count();
   // The keys match what jcmd <pid> PerfCounter.print would use
-  score.append({"java.cls.loadedClasses", static_cast<double>(ClassLoadingService::loaded_class_count() - shared_loaded_classes)});
-  score.append({"java.cls.sharedLoadedClasses", static_cast<double>(shared_loaded_classes)});
-  score.append({"java.cls.unloadedClasses", static_cast<double>(ClassLoadingService::unloaded_class_count() - shared_unloaded_classes)});
-  score.append({"java.cls.sharedUnloadedClasses", static_cast<double>(shared_unloaded_classes)});
+  scores.append({"java.cls.loadedClasses", static_cast<double>(ClassLoadingService::loaded_class_count() - shared_loaded_classes)});
+  scores.append({"java.cls.sharedLoadedClasses", static_cast<double>(shared_loaded_classes)});
+  scores.append({"java.cls.unloadedClasses", static_cast<double>(ClassLoadingService::unloaded_class_count() - shared_unloaded_classes)});
+  scores.append({"java.cls.sharedUnloadedClasses", static_cast<double>(shared_unloaded_classes)});
 #endif // INCLUDE_MANAGEMENT
   if (ClassLoader::perf_app_classload_count() != nullptr) {
-    score.append({"sun.cls.appClassLoadCount", static_cast<double>(ClassLoader::perf_app_classload_count()->get_value())});
+    scores.append({"sun.cls.appClassLoadCount", static_cast<double>(ClassLoader::perf_app_classload_count()->get_value())});
   }
 
-  score.append({"sun.ci.totalCompiles", static_cast<double>(CompileBroker::get_total_compile_count())});
-  score.append({"sun.ci.totalBailouts", static_cast<double>(CompileBroker::get_total_bailout_count())});
-  score.append({"sun.ci.totalInvalidates", static_cast<double>(CompileBroker::get_total_invalidated_count())});
+  scores.append({"sun.ci.totalCompiles", static_cast<double>(CompileBroker::get_total_compile_count())});
+  scores.append({"sun.ci.totalBailouts", static_cast<double>(CompileBroker::get_total_bailout_count())});
+  scores.append({"sun.ci.totalInvalidates", static_cast<double>(CompileBroker::get_total_invalidated_count())});
   // CompileBroker::get_total_native_compile_count() is never incremented?
-  score.append({"sun.ci.osrCompiles", static_cast<double>(CompileBroker::get_total_osr_compile_count())});
-  score.append({"sun.ci.standardCompiles", static_cast<double>(CompileBroker::get_total_standard_compile_count())});
-  score.append({"sun.ci.osrBytes", static_cast<double>(CompileBroker::get_sum_osr_bytes_compiled())});
-  score.append({"sun.ci.standardBytes", static_cast<double>(CompileBroker::get_sum_standard_bytes_compiled())});
-  score.append({"sun.ci.nmethodSize", static_cast<double>(CompileBroker::get_sum_nmethod_size())});
-  score.append({"sun.ci.nmethodCodeSize", static_cast<double>(CompileBroker::get_sum_nmethod_code_size())});
-  score.append({"java.ci.totalTime", static_cast<double>(CompileBroker::get_total_compilation_time())});
+  scores.append({"sun.ci.osrCompiles", static_cast<double>(CompileBroker::get_total_osr_compile_count())});
+  scores.append({"sun.ci.standardCompiles", static_cast<double>(CompileBroker::get_total_standard_compile_count())});
+  scores.append({"sun.ci.osrBytes", static_cast<double>(CompileBroker::get_sum_osr_bytes_compiled())});
+  scores.append({"sun.ci.standardBytes", static_cast<double>(CompileBroker::get_sum_standard_bytes_compiled())});
+  scores.append({"sun.ci.nmethodSize", static_cast<double>(CompileBroker::get_sum_nmethod_size())});
+  scores.append({"sun.ci.nmethodCodeSize", static_cast<double>(CompileBroker::get_sum_nmethod_code_size())});
+  scores.append({"java.ci.totalTime", static_cast<double>(CompileBroker::get_total_compilation_time())});
 
-  return score;
+  return scores;
 }
 
-bool crac::record_image_score(jobjectArray metrics, jdoubleArray values) {
+bool crac::record_image_scores(jobjectArray metrics, jdoubleArray values) {
   assert(crac::is_image_score_supported(), "CRaC engine does not support score recording");
   ResourceMark rm;
   objArrayOop metrics_oops = oop_cast<objArrayOop>(JNIHandles::resolve_non_null(metrics));

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -22,6 +22,8 @@
  */
 
 #include "classfile/classLoader.hpp"
+#include "classfile/systemDictionary.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "compiler/compileBroker.hpp"
 #include "jfr/jfr.hpp"
 #include "jvm.h"
@@ -30,6 +32,7 @@
 #include "logging/logConfiguration.hpp"
 #include "memory/allocation.hpp"
 #include "memory/oopFactory.hpp"
+#include "memory/resourceArea.hpp"
 #include "nmt/memTag.hpp"
 #include "oops/oopCast.inline.hpp"
 #include "oops/typeArrayOop.inline.hpp"
@@ -38,8 +41,10 @@
 #include "runtime/crac_engine.hpp"
 #include "runtime/crac_structs.hpp"
 #include "runtime/globals.hpp"
+#include "runtime/handles.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/java.hpp"
+#include "runtime/javaCalls.hpp"
 #include "runtime/jniHandles.hpp"
 #include "runtime/jniHandles.inline.hpp"
 #include "runtime/os.inline.hpp"
@@ -51,6 +56,7 @@
 #include "utilities/debug.hpp"
 #include "utilities/decoder.hpp"
 #include "utilities/defaultStream.hpp"
+#include "utilities/exceptions.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/ostream.hpp"
@@ -648,6 +654,15 @@ Handle crac::checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong
     return ret_cr(JVM_CHECKPOINT_NONE, Handle(), Handle(), Handle(), Handle(), THREAD);
   }
 
+  if (is_image_score_supported()) {
+    ResourceMark rm;
+    for (const auto &s : collect_image_score_from_jvm()) {
+      if (!_engine->set_score(s.metric, s.value)) {
+        return ret_cr(JVM_CHECKPOINT_ERROR, Handle(), Handle(), Handle(), Handle(), THREAD);
+      }
+    }
+  }
+
 #if INCLUDE_JVMTI
   JvmtiExport::post_crac_before_checkpoint();
 #endif
@@ -750,10 +765,63 @@ bool crac::is_image_score_supported() {
   return _engine != nullptr && _engine->prepare_image_score_api() == CracEngine::ApiStatus::OK;
 }
 
-bool crac::record_image_score(jobjectArray metrics, jdoubleArray values) {
-  if (_engine == nullptr || _engine->prepare_image_score_api() != CracEngine::ApiStatus::OK) {
-    return false;
+void crac::set_image_score(const char *metric, double value, TRAPS) {
+  Klass* const k = SystemDictionary::resolve_or_fail(vmSymbols::jdk_internal_crac_Score(), true, CHECK);
+
+  JavaCallArguments args;
+  const Handle metric_h = java_lang_String::create_from_str(metric, CHECK);
+  args.push_oop(metric_h);
+  args.push_double(value);
+
+  JavaValue result(T_VOID);
+  JavaCalls::call_static(&result,
+                         k, vmSymbols::setScore_name(), vmSymbols::setScore_signature(),
+                         &args,
+                         CHECK);
+}
+
+GrowableArray<crac::score> crac::collect_image_score_from_jvm() {
+  GrowableArray<crac::score> score(21);
+
+  score.append({"java.lang.Runtime.availableProcessors", static_cast<double>(os::active_processor_count())});
+  score.append({"java.lang.Runtime.totalMemory", static_cast<double>(Universe::heap()->capacity())});
+  score.append({"java.lang.Runtime.maxMemory", static_cast<double>(Universe::heap()->max_capacity())});
+
+  const double uptime = TimeHelper::counter_to_millis(os::elapsed_counter());
+  score.append({"vm.boot_time", os::javaTimeMillis() - uptime});
+  score.append({"vm.uptime", uptime});
+  score.append({"vm.uptime_since_restore", TimeHelper::counter_to_millis(os::elapsed_counter_since_restore())});
+
+#if INCLUDE_MANAGEMENT
+  const jlong shared_loaded_classes = ClassLoadingService::loaded_shared_class_count();
+  const jlong shared_unloaded_classes = ClassLoadingService::unloaded_shared_class_count();
+  // The keys match what jcmd <pid> PerfCounter.print would use
+  score.append({"java.cls.loadedClasses", static_cast<double>(ClassLoadingService::loaded_class_count() - shared_loaded_classes)});
+  score.append({"java.cls.sharedLoadedClasses", static_cast<double>(shared_loaded_classes)});
+  score.append({"java.cls.unloadedClasses", static_cast<double>(ClassLoadingService::unloaded_class_count() - shared_unloaded_classes)});
+  score.append({"java.cls.sharedUnloadedClasses", static_cast<double>(shared_unloaded_classes)});
+#endif // INCLUDE_MANAGEMENT
+  if (ClassLoader::perf_app_classload_count() != nullptr) {
+    score.append({"sun.cls.appClassLoadCount", static_cast<double>(ClassLoader::perf_app_classload_count()->get_value())});
   }
+
+  score.append({"sun.ci.totalCompiles", static_cast<double>(CompileBroker::get_total_compile_count())});
+  score.append({"sun.ci.totalBailouts", static_cast<double>(CompileBroker::get_total_bailout_count())});
+  score.append({"sun.ci.totalInvalidates", static_cast<double>(CompileBroker::get_total_invalidated_count())});
+  // CompileBroker::get_total_native_compile_count() is never incremented?
+  score.append({"sun.ci.osrCompiles", static_cast<double>(CompileBroker::get_total_osr_compile_count())});
+  score.append({"sun.ci.standardCompiles", static_cast<double>(CompileBroker::get_total_standard_compile_count())});
+  score.append({"sun.ci.osrBytes", static_cast<double>(CompileBroker::get_sum_osr_bytes_compiled())});
+  score.append({"sun.ci.standardBytes", static_cast<double>(CompileBroker::get_sum_standard_bytes_compiled())});
+  score.append({"sun.ci.nmethodSize", static_cast<double>(CompileBroker::get_sum_nmethod_size())});
+  score.append({"sun.ci.nmethodCodeSize", static_cast<double>(CompileBroker::get_sum_nmethod_code_size())});
+  score.append({"java.ci.totalTime", static_cast<double>(CompileBroker::get_total_compilation_time())});
+
+  return score;
+}
+
+bool crac::record_image_score_from_java(jobjectArray metrics, jdoubleArray values) {
+  assert(crac::is_image_score_supported(), "CRaC engine does not support score recording");
   ResourceMark rm;
   objArrayOop metrics_oops = oop_cast<objArrayOop>(JNIHandles::resolve_non_null(metrics));
   typeArrayOop values_oops = oop_cast<typeArrayOop>(JNIHandles::resolve_non_null(values));
@@ -767,49 +835,7 @@ bool crac::record_image_score(jobjectArray metrics, jdoubleArray values) {
       return false;
     }
   }
-
-  bool result = true;
-  result = result && _engine->set_score("java.lang.Runtime.availableProcessors", os::active_processor_count());
-  result = result && _engine->set_score("java.lang.Runtime.totalMemory", Universe::heap()->capacity());
-  result = result && _engine->set_score("java.lang.Runtime.maxMemory", Universe::heap()->max_capacity());
-
-  double uptime = TimeHelper::counter_to_millis(os::elapsed_counter());
-  result = result && _engine->set_score("vm.boot_time", os::javaTimeMillis() - uptime);
-  result = result && _engine->set_score("vm.uptime", uptime);
-  result = result && _engine->set_score("vm.uptime_since_restore", TimeHelper::counter_to_millis(os::elapsed_counter_since_restore()));
-
-#if INCLUDE_MANAGEMENT
-  jlong shared_loaded_classes = ClassLoadingService::loaded_shared_class_count();
-  jlong shared_unloaded_classes = ClassLoadingService::unloaded_shared_class_count();
-  // The keys match what jcmd <pid> PerfCounter.print would use
-  result = result && _engine->set_score("java.cls.loadedClasses", ClassLoadingService::loaded_class_count() - shared_loaded_classes);
-  result = result && _engine->set_score("java.cls.sharedLoadedClasses", shared_loaded_classes);
-  result = result && _engine->set_score("java.cls.unloadedClasses", ClassLoadingService::unloaded_class_count() - shared_unloaded_classes);
-  result = result && _engine->set_score("java.cls.sharedUnloadedClasses", shared_unloaded_classes);
-#endif // INCLUDE_MANAGEMENT
-  if (ClassLoader::perf_app_classload_count() != nullptr) {
-    result = result && _engine->set_score("sun.cls.appClassLoadCount", ClassLoader::perf_app_classload_count()->get_value());
-  }
-
-  result = result && _engine->set_score("sun.ci.totalCompiles", CompileBroker::get_total_compile_count());
-  result = result && _engine->set_score("sun.ci.totalBailouts", CompileBroker::get_total_bailout_count());
-  result = result && _engine->set_score("sun.ci.totalInvalidates", CompileBroker::get_total_invalidated_count());
-  // CompileBroker::get_total_native_compile_count() is never incremented?
-  result = result && _engine->set_score("sun.ci.osrCompiles", CompileBroker::get_total_osr_compile_count());
-  result = result && _engine->set_score("sun.ci.standardCompiles", CompileBroker::get_total_standard_compile_count());
-  result = result && _engine->set_score("sun.ci.osrBytes", CompileBroker::get_sum_osr_bytes_compiled());
-  result = result && _engine->set_score("sun.ci.standardBytes", CompileBroker::get_sum_standard_bytes_compiled());
-  result = result && _engine->set_score("sun.ci.nmethodSize", CompileBroker::get_sum_nmethod_size());
-  result = result && _engine->set_score("sun.ci.nmethodCodeSize", CompileBroker::get_sum_nmethod_code_size());
-  result = result && _engine->set_score("java.ci.totalTime", CompileBroker::get_total_compilation_time());
-  return result;
-}
-
-bool crac::record_image_score(const char *metric, double value) {
-  if (_engine == nullptr || _engine->prepare_image_score_api() != CracEngine::ApiStatus::OK) {
-    return false;
-  }
-  return _engine->set_score(metric, value);
+  return true;
 }
 
 void crac::prepare_restore(crac_restore_data& restore_data) {

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -654,15 +654,6 @@ Handle crac::checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong
     return ret_cr(JVM_CHECKPOINT_NONE, Handle(), Handle(), Handle(), Handle(), THREAD);
   }
 
-  if (is_image_score_supported()) {
-    ResourceMark rm;
-    for (const auto &s : collect_image_score_from_jvm()) {
-      if (!_engine->set_score(s.metric, s.value)) {
-        return ret_cr(JVM_CHECKPOINT_ERROR, Handle(), Handle(), Handle(), Handle(), THREAD);
-      }
-    }
-  }
-
 #if INCLUDE_JVMTI
   JvmtiExport::post_crac_before_checkpoint();
 #endif
@@ -820,7 +811,7 @@ GrowableArray<crac::score> crac::collect_image_score_from_jvm() {
   return score;
 }
 
-bool crac::record_image_score_from_java(jobjectArray metrics, jdoubleArray values) {
+bool crac::record_image_score(jobjectArray metrics, jdoubleArray values) {
   assert(crac::is_image_score_supported(), "CRaC engine does not support score recording");
   ResourceMark rm;
   objArrayOop metrics_oops = oop_cast<objArrayOop>(JNIHandles::resolve_non_null(metrics));

--- a/src/hotspot/share/runtime/crac.hpp
+++ b/src/hotspot/share/runtime/crac.hpp
@@ -52,7 +52,7 @@ public:
     double value;
   };
   static GrowableArray<score> collect_image_score_from_jvm();
-  static bool record_image_score_from_java(jobjectArray metrics, jdoubleArray values);
+  static bool record_image_score(jobjectArray metrics, jdoubleArray values);
 
   struct crac_restore_data {
     jlong restore_time;

--- a/src/hotspot/share/runtime/crac.hpp
+++ b/src/hotspot/share/runtime/crac.hpp
@@ -51,8 +51,8 @@ public:
     const char *metric;
     double value;
   };
-  static GrowableArray<score> collect_image_score_from_jvm();
-  static bool record_image_score(jobjectArray metrics, jdoubleArray values);
+  static GrowableArray<score> get_image_scores_from_jvm();
+  static bool record_image_scores(jobjectArray metrics, jdoubleArray values);
 
   struct crac_restore_data {
     jlong restore_time;

--- a/src/hotspot/share/runtime/crac.hpp
+++ b/src/hotspot/share/runtime/crac.hpp
@@ -28,6 +28,7 @@
 #include "runtime/crac_engine.hpp"
 #include "runtime/handles.hpp"
 #include "utilities/exceptions.hpp"
+#include "utilities/growableArray.hpp"
 
 // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 #define UUID_LENGTH 36
@@ -45,8 +46,13 @@ public:
   static bool record_image_label(const char *label, const char *value);
 
   static bool is_image_score_supported();
-  static bool record_image_score(jobjectArray metrics, jdoubleArray values);
-  static bool record_image_score(const char *metric, double value);
+  static void set_image_score(const char *metric, double value, TRAPS);
+  struct score {
+    const char *metric;
+    double value;
+  };
+  static GrowableArray<score> collect_image_score_from_jvm();
+  static bool record_image_score_from_java(jobjectArray metrics, jdoubleArray values);
 
   struct crac_restore_data {
     jlong restore_time;

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -1113,13 +1113,9 @@ void CheckpointDCmd::execute(DCmdSource source, TRAPS) {
       // with '.' as the decimal point (some other locales use ',')
       LocaleGuard lg;
       if (metrics[0] == '@') {
-        if (!parse_pairs_from_file("metric", metrics + 1, CheckpointDCmd::accept_metric)) {
-          return;
-        }
+        parse_pairs_from_file("metric", metrics + 1, CheckpointDCmd::accept_metric, CHECK);
       } else {
-        if (!parse_pairs("metric", metrics, CheckpointDCmd::accept_metric)) {
-          return;
-        }
+        parse_pairs("metric", metrics, CheckpointDCmd::accept_metric, CHECK);
       }
     } else {
       output()->print_cr("Warning: metrics are not supported by current C/R engine");
@@ -1129,13 +1125,9 @@ void CheckpointDCmd::execute(DCmdSource source, TRAPS) {
   if (labels != nullptr) {
     if (crac::is_image_constraints_supported()) {
       if (labels[0] == '@') {
-        if (!parse_pairs_from_file("label", labels + 1, CheckpointDCmd::accept_label)) {
-          return;
-        }
+        parse_pairs_from_file("label", labels + 1, CheckpointDCmd::accept_label, CHECK);
       } else {
-        if (!parse_pairs("label", labels, CheckpointDCmd::accept_label)) {
-          return;
-        }
+        parse_pairs("label", labels, CheckpointDCmd::accept_label, CHECK);
       }
     } else {
       output()->print_cr("Warning: labels are not supported by current C/R engine");
@@ -1167,22 +1159,18 @@ void CheckpointDCmd::execute(DCmdSource source, TRAPS) {
   }
 }
 
-bool CheckpointDCmd::accept_metric(CheckpointDCmd* self, const char* key, char* str) {
+void CheckpointDCmd::accept_metric(const char* key, char* str, TRAPS) {
   char *endptr;
   double value = strtod(str, &endptr);
   while (isspace(*endptr)) ++endptr;
   if (*endptr) {
-    self->output()->print_cr("Cannot convert '%s' into double value for metric '%s'", str, key);
-    return false;
+    THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
+              err_msg("Cannot convert '%s' into double value for metric '%s'", str, key));
   }
-  if (!crac::record_image_score(key, value)) {
-    self->output()->print_cr("Cannot record metric %s=%f", key, value);
-    return false;
-  }
-  return true;
+  crac::set_image_score(key, value, CHECK);
 }
 
-bool CheckpointDCmd::accept_label(CheckpointDCmd* self, const char* key, char* str) {
+void CheckpointDCmd::accept_label(const char* key, char* str, TRAPS) {
   while (isspace(*str)) ++str;
   char *end = str + strlen(str) - 1;
   while (end >= str && isspace(*end)) {
@@ -1190,39 +1178,34 @@ bool CheckpointDCmd::accept_label(CheckpointDCmd* self, const char* key, char* s
     --end;
   }
   if (!crac::record_image_label(key, str)) {
-    self->output()->print_cr("Cannot record label %s=%s", key, str);
-    return false;
+    THROW_MSG(vmSymbols::java_lang_RuntimeException(),
+              err_msg("Cannot record label %s=%s", key, str));
   }
-  return true;
 }
 
-bool CheckpointDCmd::parse_pairs(const char* what, const char* str, accept_func accept) {
+void CheckpointDCmd::parse_pairs(const char* what, const char* pairs, accept_func accept, TRAPS) {
   ResourceMark rm;
-  size_t len = strlen(str);
-  char *copy = strcpy(NEW_RESOURCE_ARRAY(char, len + 1), str);
+  size_t len = strlen(pairs);
+  char *copy = strcpy(NEW_RESOURCE_ARRAY(char, len + 1), pairs);
   char *key_value;
   while ((key_value = strsep(&copy, ",")) != nullptr) {
     char *key = strsep(&key_value, "=");
     if (*key == '\0') {
-      output()->print_cr("Empty %s name", what);
-      return false;
+      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), err_msg("Empty %s name", what));
     }
     if (key_value == nullptr) {
-      output()->print_cr("Missing value for %s '%s'", what, key);
-      return false;
+      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
+                err_msg("Missing value for %s '%s'", what, key));
     }
-    if (!accept(this, key, key_value)) {
-      return false;
-    }
+    accept(key, key_value, CHECK);
   }
-  return true;
 }
 
-bool CheckpointDCmd::parse_pairs_from_file(const char* what, const char* path, accept_func accept) {
+void CheckpointDCmd::parse_pairs_from_file(const char* what, const char* path, accept_func accept, TRAPS) {
   FILE *file = os::fopen(path, "r");
   if (file == nullptr) {
-    output()->print_cr("Cannot open %s: %s", path, os::strerror(errno));
-    return false;
+    THROW_MSG(vmSymbols::java_io_IOException(),
+              err_msg("Cannot open %s: %s", path, os::strerror(errno)));
   }
   struct FileCloser: StackObj {
     FILE *_file;
@@ -1234,29 +1217,25 @@ bool CheckpointDCmd::parse_pairs_from_file(const char* what, const char* path, a
     char *line = linebuf;
     size_t line_length = strlen(line);
     if (line_length >= sizeof(linebuf) - 1 && line[line_length - 1] != '\n') {
-      output()->print_cr("Line %d starting with '%s' is too long", linenum, line);
-      return false;
+      THROW_MSG(vmSymbols::java_io_IOException(),
+                err_msg("Line %d starting with '%s' is too long", linenum, line));
     } else if (line[line_length - 1] == '\n') {
       // don't print newline in error message
       line[line_length - 1] = '\0';
     }
     char *key = strsep(&line, "=");
     if (line == nullptr) {
-      output()->print_cr("Invalid line %d in %s (no '=' separator)", linenum, path);
-      return false;
+      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
+                err_msg("Invalid line %d in %s (no '=' separator)", linenum, path));
     }
     // truncate whitespace in key
     while (isspace(*key)) ++key;
     for (char *end = line - 2; end >= key && isspace(*end); --end) *end = '\0';
     if (*key == '\0') {
-      output()->print_cr("Empty %s name", what);
-      return false;
+      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), err_msg("Empty %s name", what));
     }
-    if (!accept(this, key, line)) {
-      return false;
-    }
+    accept(key, line, CHECK);
   }
-  return true;
 }
 
 ThreadDumpToFileDCmd::ThreadDumpToFileDCmd(outputStream* output, bool heap) :

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -1084,9 +1084,9 @@ void DumpSharedArchiveDCmd::execute(DCmdSource source, TRAPS) {
 
 CheckpointDCmd::CheckpointDCmd(outputStream* output, bool heap) :
   DCmdWithParser(output, heap),
-  _metrics("metrics", "Extra image metrics to record (key1=value2,key2=value2,... or @/path/to/file)", "STRING", false),
+  _scores("scores", "Extra image scores to record (metric1=value2,metric2=value2,... or @/path/to/file)", "STRING", false),
   _labels("labels", "Extra labels to record (label1=value1,label2=value2,... or @/path/to/file)", "STRING", false) {
-  _dcmdparser.add_dcmd_option(&_metrics);
+  _dcmdparser.add_dcmd_option(&_scores);
   _dcmdparser.add_dcmd_option(&_labels);
 }
 
@@ -1106,28 +1106,28 @@ struct LocaleGuard {
 };
 
 void CheckpointDCmd::execute(DCmdSource source, TRAPS) {
-  const char *metrics = _metrics.value();
-  if (metrics != nullptr) {
+  const char *scores = _scores.value();
+  if (scores != nullptr) {
     if (crac::is_image_score_supported()) {
       // This guard ensures that we are parsing the floating point values
       // with '.' as the decimal point (some other locales use ',')
       LocaleGuard lg;
-      if (metrics[0] == '@') {
-        parse_pairs_from_file("metric", metrics + 1, CheckpointDCmd::accept_metric, CHECK);
+      if (scores[0] == '@') {
+        parse_pairs_from_file("scores", scores + 1, CheckpointDCmd::accept_score, CHECK);
       } else {
-        parse_pairs("metric", metrics, CheckpointDCmd::accept_metric, CHECK);
+        parse_pairs("scores", scores, CheckpointDCmd::accept_score, CHECK);
       }
     } else {
-      output()->print_cr("Warning: metrics are not supported by current C/R engine");
+      output()->print_cr("Warning: scores are not supported by current C/R engine");
     }
   }
   const char *labels = _labels.value();
   if (labels != nullptr) {
     if (crac::is_image_constraints_supported()) {
       if (labels[0] == '@') {
-        parse_pairs_from_file("label", labels + 1, CheckpointDCmd::accept_label, CHECK);
+        parse_pairs_from_file("labels", labels + 1, CheckpointDCmd::accept_label, CHECK);
       } else {
-        parse_pairs("label", labels, CheckpointDCmd::accept_label, CHECK);
+        parse_pairs("labels", labels, CheckpointDCmd::accept_label, CHECK);
       }
     } else {
       output()->print_cr("Warning: labels are not supported by current C/R engine");
@@ -1159,7 +1159,7 @@ void CheckpointDCmd::execute(DCmdSource source, TRAPS) {
   }
 }
 
-void CheckpointDCmd::accept_metric(const char* key, char* str, TRAPS) {
+void CheckpointDCmd::accept_score(const char* key, char* str, TRAPS) {
   char *endptr;
   double value = strtod(str, &endptr);
   while (isspace(*endptr)) ++endptr;
@@ -1191,11 +1191,11 @@ void CheckpointDCmd::parse_pairs(const char* what, const char* pairs, accept_fun
   while ((key_value = strsep(&copy, ",")) != nullptr) {
     char *key = strsep(&key_value, "=");
     if (*key == '\0') {
-      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), err_msg("Empty %s name", what));
+      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), err_msg("Empty key in %s", what));
     }
     if (key_value == nullptr) {
       THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                err_msg("Missing value for %s '%s'", what, key));
+                err_msg("Missing value for key '%s' in %s", key, what));
     }
     accept(key, key_value, CHECK);
   }
@@ -1232,7 +1232,7 @@ void CheckpointDCmd::parse_pairs_from_file(const char* what, const char* path, a
     while (isspace(*key)) ++key;
     for (char *end = line - 2; end >= key && isspace(*end); --end) *end = '\0';
     if (*key == '\0') {
-      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), err_msg("Empty %s name", what));
+      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), err_msg("Empty key in %s", what));
     }
     accept(key, line, CHECK);
   }

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -886,12 +886,12 @@ public:
   virtual void execute(DCmdSource source, TRAPS);
 
 private:
-  typedef bool (*accept_func)(CheckpointDCmd*, const char*, char*);
+  using accept_func = void (*)(const char*, char*, TRAPS);
 
-  bool parse_pairs(const char* what, const char* pairs, accept_func accept);
-  bool parse_pairs_from_file(const char* what, const char* path, accept_func accept);
-  static bool accept_metric(CheckpointDCmd* self, const char* key, char* str);
-  static bool accept_label(CheckpointDCmd* self, const char* key, char* str);
+  void parse_pairs(const char* what, const char* pairs, accept_func accept, TRAPS);
+  void parse_pairs_from_file(const char* what, const char* path, accept_func accept, TRAPS);
+  static void accept_metric(const char* key, char* str, TRAPS);
+  static void accept_label(const char* key, char* str, TRAPS);
 };
 
 #endif // SHARE_SERVICES_DIAGNOSTICCOMMAND_HPP

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -870,7 +870,7 @@ public:
 #endif // LINUX, WINDOWS or MACOS
 
 class CheckpointDCmd : public DCmdWithParser {
-  DCmdArgument<char*> _metrics;
+  DCmdArgument<char*> _scores;
   DCmdArgument<char*> _labels;
 
 public:
@@ -888,9 +888,9 @@ public:
 private:
   using accept_func = void (*)(const char*, char*, TRAPS);
 
-  void parse_pairs(const char* what, const char* pairs, accept_func accept, TRAPS);
-  void parse_pairs_from_file(const char* what, const char* path, accept_func accept, TRAPS);
-  static void accept_metric(const char* key, char* str, TRAPS);
+  static void parse_pairs(const char* what, const char* pairs, accept_func accept, TRAPS);
+  static void parse_pairs_from_file(const char* what, const char* path, accept_func accept, TRAPS);
+  static void accept_score(const char* key, char* str, TRAPS);
   static void accept_label(const char* key, char* str, TRAPS);
 };
 

--- a/src/java.base/share/classes/jdk/internal/crac/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/Core.java
@@ -33,18 +33,6 @@ import jdk.internal.crac.mirror.impl.OrderedContext;
 public class Core {
     private static ClaimedFDs claimedFDs;
     private static final JfrResource jfrResource = new JfrResource();
-    private static final Runnable internalResourceCounter = () -> {
-        int resources = 0;
-        for (var p : Priority.values()) {
-            if (p.getContext() instanceof OrderedContext<?> octx) {
-                resources += octx.size();
-            }
-        }
-        Score.setScore("jdk.crac.internalResources", resources);
-    };
-    static {
-        Score.addScoreProvider(internalResourceCounter);
-    }
 
     /**
      * Called by JDK FD resources
@@ -102,6 +90,23 @@ public class Core {
         NORMAL(new BlockingOrderedContext<>());
 
         private final Context<JDKResource> context;
+        // CDS assert fails during VM initialization if this is a lambda
+        private static final Runnable internalResourceCounter = new Runnable() {
+            @Override
+            public void run() {
+                int resources = 0;
+                for (var p : Priority.values()) {
+                    if (p.getContext() instanceof OrderedContext<?> octx) {
+                        resources += octx.size();
+                    }
+                }
+                Score.setScore("jdk.crac.internalContext.size", resources);
+            }
+        };
+        static {
+            Score.addScoreProvider(internalResourceCounter);
+        }
+
         Priority(Context<JDKResource> context) {
             Context.getGlobalContext().register(context);
             this.context = context;

--- a/src/java.base/share/classes/jdk/internal/crac/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/Core.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Azul Systems, Inc. All rights reserved.
+ * Copyright (c) 2019, 2026, Azul Systems, Inc. All rights reserved.
  * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -33,6 +33,20 @@ import jdk.internal.crac.mirror.impl.OrderedContext;
 public class Core {
     private static ClaimedFDs claimedFDs;
     private static final JfrResource jfrResource = new JfrResource();
+    private static final Runnable internalResourceCounter = () -> {
+        int resources = 0;
+        for (var p : Priority.values()) {
+            if (p.getContext() instanceof OrderedContext<?> octx) {
+                resources += octx.size();
+            } else {
+                throw new InternalError("Unexpected internal context type: " + p.getContext().getClass());
+            }
+        }
+        Score.setScore("jdk.crac.internalResources", resources);
+    };
+    static {
+        Score.addScoreProvider(internalResourceCounter);
+    }
 
     /**
      * Called by JDK FD resources
@@ -67,8 +81,6 @@ public class Core {
      * Most resources should use priority NORMAL (the lowest priority).
      */
     public enum Priority {
-        // Other resources can record score in the beforeCheckpoint
-        SCORE(Score.getContext()),
         FILE_DESCRIPTORS(new BlockingOrderedContext<>()),
         PRE_FILE_DESCRIPTORS(new BlockingOrderedContext<>()),
         // We use OrderedContext to not cause failure when PlatformRecorder tries to

--- a/src/java.base/share/classes/jdk/internal/crac/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/Core.java
@@ -38,8 +38,6 @@ public class Core {
         for (var p : Priority.values()) {
             if (p.getContext() instanceof OrderedContext<?> octx) {
                 resources += octx.size();
-            } else {
-                throw new InternalError("Unexpected internal context type: " + p.getContext().getClass());
             }
         }
         Score.setScore("jdk.crac.internalResources", resources);
@@ -81,6 +79,9 @@ public class Core {
      * Most resources should use priority NORMAL (the lowest priority).
      */
     public enum Priority {
+        // Collect score as close to checkpoint as possible for the most up-to-date
+        // values.
+        SCORE(Score.getContext()),
         FILE_DESCRIPTORS(new BlockingOrderedContext<>()),
         PRE_FILE_DESCRIPTORS(new BlockingOrderedContext<>()),
         // We use OrderedContext to not cause failure when PlatformRecorder tries to

--- a/src/java.base/share/classes/jdk/internal/crac/Score.java
+++ b/src/java.base/share/classes/jdk/internal/crac/Score.java
@@ -40,14 +40,47 @@ import java.util.*;
  * use does not support storing metadata. In such case score will be ignored.
  */
 public class Score {
-    /**
-     * Values of metrics provided by the user and Java classes of JDK.
-     * <p>
-     * JVM provides some metrics as well - they are not stored here,
-     * {@link #getJvmScore()} is used to retrieve those.
-     */
     private static final Map<String, Double> score = new HashMap<>();
     private static final Set<Runnable> scoreProviders = Collections.newSetFromMap(new WeakHashMap<>());
+    // CDS assert fails during VM initialization if this is a lambda
+    private static final Runnable jvmScoreProvider = new Runnable() {
+        @Override
+        public void run() {
+            final var jvmScore = getJvmScore();
+            for (final var pair : jvmScore) {
+                setScore((String) pair[0], (Double) pair[1]);
+            }
+        }
+    };
+
+    static {
+        addScoreProvider(jvmScoreProvider);
+    }
+
+    private static final Context<JDKResource> context = new Context<>() {
+        @Override
+        public void beforeCheckpoint(Context<? extends Resource> context) {
+            final var scoreSnapshot = getScore();
+            final var metrics = new String[scoreSnapshot.size()];
+            final var values = new double[scoreSnapshot.size()];
+            int i = 0;
+            for (var e : scoreSnapshot.entrySet()) {
+                metrics[i] = e.getKey();
+                values[i] = e.getValue();
+                ++i;
+            }
+            record(metrics, values);
+        }
+
+        @Override
+        public void afterRestore(Context<? extends Resource> context) {
+        }
+
+        @Override
+        public void register(JDKResource resource) {
+            throw new UnsupportedOperationException("Score is a singleton context");
+        }
+    };
 
     private Score() {
     }
@@ -67,11 +100,10 @@ public class Score {
      * On checkpoint the metrics are not reset; if that is desired use
      * {@link #removeScore(String)}.
      *
-     * @implNote Metrics {@code java.*}, {@code jdk.*}, {@code sun.*},
-     * {@code vm.*} are reserved to be set by the JDK itself.
-     *
      * @param metric Name of the metric.
      * @param value  Numeric value of the metric.
+     * @implNote Metrics {@code java.*}, {@code jdk.*}, {@code sun.*},
+     * {@code vm.*} are reserved to be set by the JDK itself.
      */
     public static synchronized void setScore(String metric, double value) {
         score.put(metric, value);
@@ -112,18 +144,6 @@ public class Score {
      * @return snapshot of the recorded score.
      */
     public static Map<String, Double> getScore() {
-        // The same JVM after Java order is used for the actual score recording. It matters when there are collisions,
-        // i.e. when custom metrics use reserved names. Technically that would be a user's fault but better to be
-        // consistent.
-        final Map<String, Double> scoreSnapshot = getJavaScore();
-        final var jvmScore = getJvmScore();
-        for (final var pair : jvmScore) {
-            scoreSnapshot.put((String) pair[0], (Double) pair[1]);
-        }
-        return scoreSnapshot;
-    }
-
-    private static Map<String, Double> getJavaScore() {
         // Take a snapshot in case a provider adds new providers
         final Set<Runnable> providersSnapshot;
         synchronized (Score.class) {
@@ -140,38 +160,11 @@ public class Score {
         return scoreSnapshot;
     }
 
-    /**
-     * @return Pairs of {@link String} and {@link Double}.
-     */
     private static native Object[][] getJvmScore();
 
-    private static final JDKResource resource = new JDKResource() {
-        @Override
-        public void beforeCheckpoint(Context<? extends Resource> context) {
-            recordJavaScore(); // JVM score will be recorded by JVM itself
-        }
+    private static native void record(String[] metrics, double[] values);
 
-        @Override
-        public void afterRestore(Context<? extends Resource> context) {
-        }
-    };
-
-    static {
-        Core.Priority.NORMAL.getContext().register(resource);
+    static Context<JDKResource> getContext() {
+        return context;
     }
-
-    private static void recordJavaScore() {
-        final var scoreSnapshot = getJavaScore();
-        final var metrics = new String[scoreSnapshot.size()];
-        final var values = new double[scoreSnapshot.size()];
-        int i = 0;
-        for (var e : scoreSnapshot.entrySet()) {
-            metrics[i] = e.getKey();
-            values[i] = e.getValue();
-            ++i;
-        }
-        recordJavaScore(metrics, values);
-    }
-
-    private static native void recordJavaScore(String[] metrics, double[] values);
 }

--- a/src/java.base/share/classes/jdk/internal/crac/Score.java
+++ b/src/java.base/share/classes/jdk/internal/crac/Score.java
@@ -37,18 +37,18 @@ import java.util.*;
  * expected to perform best.
  * <p>
  * All methods of this class can be safely called even if the CRaC Engine in
- * use does not support storing metadata. In such case score will be ignored.
+ * use does not support storing metadata. In such case scores will be ignored.
  */
 public class Score {
-    private static final Map<String, Double> score = new HashMap<>();
+    private static final Map<String, Double> scores = new HashMap<>();
     private static final Set<Runnable> scoreProviders = Collections.newSetFromMap(new WeakHashMap<>());
     // CDS assert fails during VM initialization if this is a lambda
     private static final Runnable jvmScoreProvider = new Runnable() {
         @Override
         public void run() {
-            final var jvmScore = getJvmScore();
-            for (var i = 0; i < jvmScore.length; i++) {
-                setScore((String) jvmScore[2 * i], (Double) jvmScore[2 * i + 1]);
+            final var jvmScores = getJvmScores();
+            for (var i = 0; i < jvmScores.length; i++) {
+                setScore((String) jvmScores[2 * i], (Double) jvmScores[2 * i + 1]);
             }
         }
     };
@@ -60,11 +60,11 @@ public class Score {
     private static final Context<JDKResource> context = new Context<>() {
         @Override
         public void beforeCheckpoint(Context<? extends Resource> context) {
-            final var scoreSnapshot = getScore();
-            final var metrics = new String[scoreSnapshot.size()];
-            final var values = new double[scoreSnapshot.size()];
+            final var scoresSnapshot = getScores();
+            final var metrics = new String[scoresSnapshot.size()];
+            final var values = new double[scoresSnapshot.size()];
             int i = 0;
-            for (var e : scoreSnapshot.entrySet()) {
+            for (var e : scoresSnapshot.entrySet()) {
                 metrics[i] = e.getKey();
                 values[i] = e.getValue();
                 ++i;
@@ -93,11 +93,11 @@ public class Score {
     public static native boolean isSupported();
 
     /**
-     * Records a value to be stored in the image metadata on checkpoint.
-     * Repeated invocations with the same {@code metric} overwrite previous
+     * Records a score to be stored in the image metadata on checkpoint.
+     * Repeated invocations with the same {@code metric} overwrite the previous
      * value.
      * <p>
-     * On checkpoint the metrics are not reset; if that is desired use
+     * On checkpoint the scores are not reset; if that is desired use
      * {@link #removeScore(String)}.
      *
      * @param metric Name of the metric.
@@ -106,7 +106,7 @@ public class Score {
      * {@code vm.*} are reserved to be set by the JDK itself.
      */
     public static synchronized void setScore(String metric, double value) {
-        score.put(metric, value);
+        scores.put(metric, value);
     }
 
     /**
@@ -116,14 +116,14 @@ public class Score {
      * @return {@code true} if the metric was present.
      */
     public static synchronized boolean removeScore(String metric) {
-        return score.remove(metric) != null;
+        return scores.remove(metric) != null;
     }
 
     /**
-     * Adds a runnable which will be invoked each time just before a score is
-     * read to provide an up-to-date value of some metrics.
+     * Adds a runnable which will be invoked each time just before scores are
+     * read to provide up-to-date scores.
      * <p>
-     * The provider is expected to add or update the score by invoking
+     * The provider is expected to add or update the scores by invoking
      * {@link #setScore(String, double)}, possibly multiple times.
      * <p>
      * The provider is recorded through a weak reference. The caller is
@@ -143,12 +143,12 @@ public class Score {
     }
 
     /**
-     * Returns a snapshot of the recorded score. Future changes to the score
+     * Returns a snapshot of the recorded scores. Future changes to the scores
      * will not be reflected in the snapshot and vice versa.
      *
-     * @return snapshot of the recorded score.
+     * @return current snapshot of the recorded scores.
      */
-    public static Map<String, Double> getScore() {
+    public static Map<String, Double> getScores() {
         // Take a snapshot in case a provider adds new providers
         final Set<Runnable> providersSnapshot;
         synchronized (Score.class) {
@@ -161,14 +161,14 @@ public class Score {
             }
         }
 
-        final Map<String, Double> scoreSnapshot;
+        final Map<String, Double> scoresSnapshot;
         synchronized (Score.class) {
-            scoreSnapshot = new HashMap<>(score);
+            scoresSnapshot = new HashMap<>(scores);
         }
-        return scoreSnapshot;
+        return scoresSnapshot;
     }
 
-    private static native Object[] getJvmScore();
+    private static native Object[] getJvmScores();
 
     private static native void record(String[] metrics, double[] values);
 

--- a/src/java.base/share/classes/jdk/internal/crac/Score.java
+++ b/src/java.base/share/classes/jdk/internal/crac/Score.java
@@ -27,93 +27,151 @@ package jdk.internal.crac;
 
 import jdk.internal.crac.mirror.Context;
 import jdk.internal.crac.mirror.Resource;
-import jdk.internal.crac.mirror.impl.OrderedContext;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
- * CRaC Engine can support storing additional metadata about the image.
- * This can help the infrastructure to further refine the set of feasible images
- * (constrained by CPU architecture and features) and select the image that is expected to perform best.
+ * CRaC Engine can support storing additional metadata about the image. This
+ * can help the infrastructure to further refine the set of feasible images
+ * (constrained by CPU architecture and features) and select the image that is
+ * expected to perform best.
+ * <p>
+ * All methods of this class can be safely called even if the CRaC Engine in
+ * use does not support storing metadata. In such case score will be ignored.
  */
 public class Score {
+    /**
+     * Values of metrics provided by the user and Java classes of JDK.
+     * <p>
+     * JVM provides some metrics as well - they are not stored here,
+     * {@link #getJvmScore()} is used to retrieve those.
+     */
     private static final Map<String, Double> score = new HashMap<>();
+    private static final Set<Runnable> scoreProviders = Collections.newSetFromMap(new WeakHashMap<>());
 
-    // There shouldn't be anyone else to register at Core.Priority.SCORE.
-    // We need to class-load this class every time, to store common metrics.
-    private static final Context<JDKResource> resource = new Context<>() {
-        @Override
-        public void beforeCheckpoint(Context<? extends Resource> context) {
-            if (isSupported()) {
-                setJdkResourceScore();
-                record();
-            }
-        }
-
-        @Override
-        public void afterRestore(Context<? extends Resource> context) {
-        }
-
-        @Override
-        public void register(JDKResource resource) {
-            throw new UnsupportedOperationException("Score is a singleton resource");
-        }
-    };
-
-    private static void setJdkResourceScore() {
-        int resources = 0;
-        for (var p : Core.Priority.values()) {
-            if (p.getContext() instanceof OrderedContext<?> octx) {
-                resources += octx.size();
-            }
-        }
-        setScore("jdk.crac.internalResources", resources);
-    }
-
-    private Score() {}
-
-    public static native boolean isSupported();
-
-    private static native boolean record(String[] metrics, double[] values);
-
-    private static synchronized void record() {
-        String[] metrics = new String[score.size()];
-        double[] values = new double[score.size()];
-        int i = 0;
-        for (var e : score.entrySet()) {
-            metrics[i] = e.getKey();
-            values[i] = e.getValue();
-            ++i;
-        }
-        if (!record(metrics, values)) {
-            throw new RuntimeException("Cannot record image score");
-        }
+    private Score() {
     }
 
     /**
-     * Record value to be stored in the image metadata on checkpoint. Repeated invocations
-     * with the same {@code metric} overwrite previous value. This method can be safely
-     * called even if the C/R engine does not support recording metadata.
-     * On checkpoint the metrics are not reset; if that is desired invoke {@link #resetAll()}
-     * manually.
+     * Returns {@code true} if the CRaC Engine in use supports score recording.
+     *
+     * @return {@code true} if the CRaC Engine in use supports score recording.
+     */
+    public static native boolean isSupported();
+
+    /**
+     * Records a value to be stored in the image metadata on checkpoint.
+     * Repeated invocations with the same {@code metric} overwrite previous
+     * value.
+     * <p>
+     * On checkpoint the metrics are not reset; if that is desired use
+     * {@link #removeScore(String)}.
+     *
+     * @implNote Metrics {@code java.*}, {@code jdk.*}, {@code sun.*},
+     * {@code vm.*} are reserved to be set by the JDK itself.
      *
      * @param metric Name of the metric.
-     * @param value Numeric value of the metric.
+     * @param value  Numeric value of the metric.
      */
     public static synchronized void setScore(String metric, double value) {
         score.put(metric, value);
     }
 
     /**
-     * Drop all currently stored metrics. This method can be safely called
-     * even if the C/R engine does not support recording metadata.
+     * Drops the value of the specified metric, if one is recorded.
+     *
+     * @param metric Name of the metric.
      */
-    public static synchronized void resetAll() {
-        score.clear();
+    public static synchronized void removeScore(String metric) {
+        score.remove(metric);
     }
 
-    static Context<JDKResource> getContext() {
-        return resource;
+    /**
+     * Adds a runnable which will be invoked each time just before a score is
+     * read to provide an up-to-date value of some metrics.
+     * <p>
+     * The provider is expected to add or update the score by invoking
+     * {@link #setScore(String, double)}, possibly multiple times.
+     * <p>
+     * The provider is recorded through a weak reference. The caller is
+     * responsible for storing a strong reference while the provider functions.
+     * <p>
+     * The order in which the providers are called is indeterminate and can
+     * change.
+     *
+     * @param provider The score provider to be recorded.
+     */
+    public static synchronized void addScoreProvider(Runnable provider) {
+        scoreProviders.add(provider);
     }
+
+    /**
+     * Returns a snapshot of the recorded score. Future changes to the score
+     * will not be reflected in the snapshot and vice versa.
+     *
+     * @return snapshot of the recorded score.
+     */
+    public static Map<String, Double> getScore() {
+        // The same JVM after Java order is used for the actual score recording. It matters when there are collisions,
+        // i.e. when custom metrics use reserved names. Technically that would be a user's fault but better to be
+        // consistent.
+        final Map<String, Double> scoreSnapshot = getJavaScore();
+        final var jvmScore = getJvmScore();
+        for (final var pair : jvmScore) {
+            scoreSnapshot.put((String) pair[0], (Double) pair[1]);
+        }
+        return scoreSnapshot;
+    }
+
+    private static Map<String, Double> getJavaScore() {
+        // Take a snapshot in case a provider adds new providers
+        final Set<Runnable> providersSnapshot;
+        synchronized (Score.class) {
+            providersSnapshot = new HashSet<>(scoreProviders);
+        }
+        for (final var provider : providersSnapshot) {
+            provider.run();
+        }
+
+        final Map<String, Double> scoreSnapshot;
+        synchronized (Score.class) {
+            scoreSnapshot = new HashMap<>(score);
+        }
+        return scoreSnapshot;
+    }
+
+    /**
+     * @return Pairs of {@link String} and {@link Double}.
+     */
+    private static native Object[][] getJvmScore();
+
+    private static final JDKResource resource = new JDKResource() {
+        @Override
+        public void beforeCheckpoint(Context<? extends Resource> context) {
+            recordJavaScore(); // JVM score will be recorded by JVM itself
+        }
+
+        @Override
+        public void afterRestore(Context<? extends Resource> context) {
+        }
+    };
+
+    static {
+        Core.Priority.NORMAL.getContext().register(resource);
+    }
+
+    private static void recordJavaScore() {
+        final var scoreSnapshot = getJavaScore();
+        final var metrics = new String[scoreSnapshot.size()];
+        final var values = new double[scoreSnapshot.size()];
+        int i = 0;
+        for (var e : scoreSnapshot.entrySet()) {
+            metrics[i] = e.getKey();
+            values[i] = e.getValue();
+            ++i;
+        }
+        recordJavaScore(metrics, values);
+    }
+
+    private static native void recordJavaScore(String[] metrics, double[] values);
 }

--- a/src/java.base/share/classes/jdk/internal/crac/Score.java
+++ b/src/java.base/share/classes/jdk/internal/crac/Score.java
@@ -47,8 +47,8 @@ public class Score {
         @Override
         public void run() {
             final var jvmScore = getJvmScore();
-            for (final var pair : jvmScore) {
-                setScore((String) pair[0], (Double) pair[1]);
+            for (var i = 0; i < jvmScore.length; i++) {
+                setScore((String) jvmScore[2 * i], (Double) jvmScore[2 * i + 1]);
             }
         }
     };
@@ -113,9 +113,10 @@ public class Score {
      * Drops the value of the specified metric, if one is recorded.
      *
      * @param metric Name of the metric.
+     * @return {@code true} if the metric was present.
      */
-    public static synchronized void removeScore(String metric) {
-        score.remove(metric);
+    public static synchronized boolean removeScore(String metric) {
+        return score.remove(metric) != null;
     }
 
     /**
@@ -129,7 +130,11 @@ public class Score {
      * responsible for storing a strong reference while the provider functions.
      * <p>
      * The order in which the providers are called is indeterminate and can
-     * change.
+     * change, they may even be called concurrently.
+     * <p>
+     * If a provider throws an {@link Exception} it is ignored and the score
+     * computation proceeds. Other kinds of {@link Throwable} interrupt the
+     * score computation and are propagated.
      *
      * @param provider The score provider to be recorded.
      */
@@ -150,7 +155,10 @@ public class Score {
             providersSnapshot = new HashSet<>(scoreProviders);
         }
         for (final var provider : providersSnapshot) {
-            provider.run();
+            try {
+                provider.run();
+            } catch (Exception _) {
+            }
         }
 
         final Map<String, Double> scoreSnapshot;
@@ -160,7 +168,7 @@ public class Score {
         return scoreSnapshot;
     }
 
-    private static native Object[][] getJvmScore();
+    private static native Object[] getJvmScore();
 
     private static native void record(String[] metrics, double[] values);
 

--- a/src/java.base/share/classes/jdk/internal/crac/mirror/impl/GlobalContext.java
+++ b/src/java.base/share/classes/jdk/internal/crac/mirror/impl/GlobalContext.java
@@ -54,6 +54,7 @@ public class GlobalContext {
                 // In JDK this should be called only once with a non-null name. If the implementation changes
                 // let's make scoreProvider use a collection of name/ctx pairs.
                 assert sizeProvider == null;
+                assert !name.equals("jdk.crac.internalContext") : "Duplicates internal resources number metric";
                 sizeProvider = () -> Score.setScore(name + ".size", ctx.size());
                 Score.addScoreProvider(sizeProvider);
             }

--- a/src/java.base/share/classes/jdk/internal/crac/mirror/impl/GlobalContext.java
+++ b/src/java.base/share/classes/jdk/internal/crac/mirror/impl/GlobalContext.java
@@ -25,7 +25,7 @@
  */
 package jdk.internal.crac.mirror.impl;
 
-import jdk.internal.crac.JDKResource;
+import jdk.internal.crac.Score;
 import jdk.internal.crac.mirror.Context;
 import jdk.internal.crac.mirror.Resource;
 
@@ -34,27 +34,8 @@ public class GlobalContext {
 
     public static final Context<Resource> instance = createGlobalContextImpl(null);
 
-    // Strong reference to the resource
-    private static Score scoreSingleton;
-
-    public static class Score implements JDKResource {
-        private final String name;
-        private final OrderedContext<?> ctx;
-
-        private Score(String name, OrderedContext<?> ctx) {
-            this.name = name;
-            this.ctx = ctx;
-        }
-
-        @Override
-        public void beforeCheckpoint(Context<? extends Resource> context) {
-            jdk.internal.crac.Score.setScore(name + ".size", ctx.size());
-        }
-
-        @Override
-        public void afterRestore(Context<? extends Resource> context) {
-        }
-    }
+    // Strong reference to the provider
+    private static Runnable sizeProvider;
 
     private GlobalContext() {}
 
@@ -65,19 +46,17 @@ public class GlobalContext {
             case "OrderedContext" -> new OrderedContext<>();
             default -> new OrderedContext<>(); // cannot report as System.out/err are not initialized yet
         };
-        // The 'internal' context from jdk.internal.crac.mirror.Core should host only the Core.Priority contexts
-        // and the context created by jdk.crac.Core (the 'user' global context). We won't record score for
-        // the internal context as if registered here, beforeCheckpoint would be called after Core.Priority.SCORE
-        // and the score would not be recorded.
+        // The null-named context (the 'internal' global context) only hosts jdk.internal.crac.Core.Priority contexts
+        // and the context created by jdk.crac.Core (the 'user' global context). We won't record the size of the
+        // internal context since it is basically fixed and thus not interesting.
         if (name != null) {
-            Score score = new Score(name, ctx);
             synchronized (GlobalContext.class) {
                 // In JDK this should be called only once with a non-null name. If the implementation changes
-                // let's turn scoreSingleton into a map.
-                assert scoreSingleton == null;
-                scoreSingleton = score;
+                // let's make scoreProvider use a collection of name/ctx pairs.
+                assert sizeProvider == null;
+                sizeProvider = () -> Score.setScore(name + ".size", ctx.size());
+                Score.addScoreProvider(sizeProvider);
             }
-            ctx.register(score);
         }
         return ctx;
     }

--- a/src/java.base/share/native/libjava/CracCore.c
+++ b/src/java.base/share/native/libjava/CracCore.c
@@ -56,10 +56,10 @@ Java_jdk_internal_crac_Score_isSupported(JNIEnv *env, jclass ignore) {
 
 JNIEXPORT jobjectArray JNICALL
 Java_jdk_internal_crac_Score_getJvmScore(JNIEnv *env, jclass ignore) {
-    return JVM_GetJVMCRaCScore(env);
+    return JVM_GetCRaCScore(env);
 }
 
 JNIEXPORT void JNICALL
-Java_jdk_internal_crac_Score_recordJavaScore(JNIEnv *env, jclass ignore, jobjectArray metrics, jdoubleArray values) {
-    JVM_RecordJavaCRaCScore(env, metrics, values);
+Java_jdk_internal_crac_Score_record(JNIEnv *env, jclass ignore, jobjectArray metrics, jdoubleArray values) {
+    JVM_RecordCRaCScore(env, metrics, values);
 }

--- a/src/java.base/share/native/libjava/CracCore.c
+++ b/src/java.base/share/native/libjava/CracCore.c
@@ -55,11 +55,11 @@ Java_jdk_internal_crac_Score_isSupported(JNIEnv *env, jclass ignore) {
 }
 
 JNIEXPORT jobjectArray JNICALL
-Java_jdk_internal_crac_Score_getJvmScore(JNIEnv *env, jclass ignore) {
-    return JVM_GetCRaCScore(env);
+Java_jdk_internal_crac_Score_getJvmScores(JNIEnv *env, jclass ignore) {
+    return JVM_GetCRaCScores(env);
 }
 
 JNIEXPORT void JNICALL
 Java_jdk_internal_crac_Score_record(JNIEnv *env, jclass ignore, jobjectArray metrics, jdoubleArray values) {
-    JVM_RecordCRaCScore(env, metrics, values);
+    JVM_RecordCRaCScores(env, metrics, values);
 }

--- a/src/java.base/share/native/libjava/CracCore.c
+++ b/src/java.base/share/native/libjava/CracCore.c
@@ -54,7 +54,12 @@ Java_jdk_internal_crac_Score_isSupported(JNIEnv *env, jclass ignore) {
     return JVM_IsCRaCScoreSupported(env);
 }
 
-JNIEXPORT jboolean JNICALL
-Java_jdk_internal_crac_Score_record(JNIEnv *env, jclass ignore, jobjectArray metrics, jdoubleArray values) {
-    return JVM_RecordCRaCScore(env, metrics, values);
+JNIEXPORT jobjectArray JNICALL
+Java_jdk_internal_crac_Score_getJvmScore(JNIEnv *env, jclass ignore) {
+    return JVM_GetJVMCRaCScore(env);
+}
+
+JNIEXPORT void JNICALL
+Java_jdk_internal_crac_Score_recordJavaScore(JNIEnv *env, jclass ignore, jobjectArray metrics, jdoubleArray values) {
+    JVM_RecordJavaCRaCScore(env, metrics, values);
 }

--- a/test/jdk/jdk/crac/JcmdArgsTest.java
+++ b/test/jdk/jdk/crac/JcmdArgsTest.java
@@ -64,11 +64,11 @@ public class JcmdArgsTest implements CracTest {
         process.waitForStdout(READY, false);
         String[] args;
         if (useFile) {
-            Path metricsPath = createTemp("metrics", "dummy\t=45\n   foo.bar = 123.0 \n");
+            Path scoresPath = createTemp("scores", "dummy\t=45\n   foo.bar = 123.0 \n");
             Path labelsPath = createTemp("labels", " xxx= yyy\naaa=bbb");
-            args = new String[] { "metrics=@" + metricsPath, "labels=@" + labelsPath };
+            args = new String[] { "scores=@" + scoresPath, "labels=@" + labelsPath };
         } else {
-            args = new String[] { "metrics=foo.bar=123", "labels=xxx=yyy" };
+            args = new String[] { "scores=foo.bar=123", "labels=xxx=yyy" };
         }
         new CracBuilder().engine(CracEngine.SIMULATE).checkpointViaJcmd(process.pid(), args);
         process.waitForStdout(CHECKPOINTED, false);

--- a/test/jdk/jdk/crac/engine/ImageScoreTest.java
+++ b/test/jdk/jdk/crac/engine/ImageScoreTest.java
@@ -30,8 +30,9 @@ import jdk.test.lib.crac.*;
 import java.io.File;
 import java.lang.ref.Reference;
 import java.nio.file.Files;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 
 import static jdk.test.lib.Asserts.*;
 
@@ -46,9 +47,17 @@ import static jdk.test.lib.Asserts.*;
  * @run driver jdk.test.lib.crac.CracTest false
  */
 public class ImageScoreTest implements CracTest {
+    private static final String VM_UPTIME = "vm.uptime";
     private static final String JDK_CRAC_GLOBAL_CONTEXT_SIZE = "jdk.crac.globalContext.size";
     private static final String TEST_SCORE_AAA = "test.score.aaa";
     private static final String TEST_SCORE_BBB = "test.score.bbb";
+    private static final String TEST_SCORE_CCC = "test.score.ccc";
+
+    private static final double TEST_SCORE_AAA_VALUE_1 = 123.456;
+    private static final double TEST_SCORE_BBB_VALUE_1 = 42.0;
+    private static final double TEST_SCORE_CCC_VALUE_1 = 1.0;
+    private static final double TEST_SCORE_AAA_VALUE_2 = 456.789;
+    private static final double TEST_SCORE_CCC_VALUE_2 = 2.0;
 
     @CracTestArg
     boolean usePerfData;
@@ -68,36 +77,21 @@ public class ImageScoreTest implements CracTest {
             builder.clearVmOptions();
             process.waitForPausePid();
 
-            List<String> score1 = Files.readAllLines(builder.imageDir().resolve("score"));
-            assertGT(score1.size(), 10); // at least 10 items
-            assertEquals(1L, score1.stream().filter(line -> line.startsWith("vm.uptime=")).count());
-            int context1 = getScore(score1, JDK_CRAC_GLOBAL_CONTEXT_SIZE).intValue();
-            // overwritten value should be there only once
-            assertEquals(1L, score1.stream().filter(line-> line.startsWith(TEST_SCORE_AAA)).count());
-            assertEquals(123.456, getScore(score1, TEST_SCORE_AAA));
-            assertEquals(42.0   , getScore(score1, TEST_SCORE_BBB));
+            final var score1 = parseRecordedScore(Files.readAllLines(builder.imageDir().resolve("score")));
+            checkScore1(score1);
 
             builder.doRestore();
             process.clearPausePid();
             process.sendNewline();
             process.waitForPausePid();
 
-            List<String> score2 = Files.readAllLines(builder.imageDir().resolve("score"));
-            int context2 = getScore(score2, JDK_CRAC_GLOBAL_CONTEXT_SIZE).intValue();
-            assertEquals(context1 + 1, context2);
-            assertEquals(456.789, getScore(score2, TEST_SCORE_AAA));
-            assertTrue(score2.stream().noneMatch(line -> line.startsWith(TEST_SCORE_BBB)));
+            final var score2 = parseRecordedScore(Files.readAllLines(builder.imageDir().resolve("score")));
+            checkScore2(score2);
+            assertEquals(score1.get(JDK_CRAC_GLOBAL_CONTEXT_SIZE).intValue() + 1, score2.get(JDK_CRAC_GLOBAL_CONTEXT_SIZE).intValue());
 
             builder.doRestore();
             process.waitForSuccess();
         }
-    }
-
-    private static Double getScore(List<String> score1, String metric) {
-        Optional<Double> contextSize = score1.stream().filter(line -> line.startsWith(metric + '='))
-                .findFirst().map(line -> Double.parseDouble(line.substring(line.indexOf('=') + 1)));
-        assertTrue(contextSize.isPresent());
-        return contextSize.orElseThrow(() -> new AssertionError("context size not found"));
     }
 
     @Override
@@ -105,14 +99,19 @@ public class ImageScoreTest implements CracTest {
         Score.setScore(TEST_SCORE_AAA, 0.001); // should be overwritten
         Score.setScore(TEST_SCORE_AAA, 123.456);
         Score.setScore(TEST_SCORE_BBB, 42);
+        final double[] cccValue = new double[] {1};
+        final Runnable cccProvider = () -> Score.setScore(TEST_SCORE_CCC, cccValue[0]);
+        Score.addScoreProvider(cccProvider);
         // Force user-facing global context instantiation
         Context<Resource> globalContext = Context.getGlobalContext();
+        checkScore1(Score.getScore());
         CRaCMXBean.getCRaCMXBean().checkpointRestore();
 
         assertEquals(System.in.read(), (int) '\n');
 
-        Score.resetAll();
+        Score.removeScore(TEST_SCORE_BBB);
         Score.setScore(TEST_SCORE_AAA, 456.789);
+        cccValue[0] = 2; // Provider should set the updated value
         Resource dummy = new Resource() {
             @Override
             public void beforeCheckpoint(Context<? extends Resource> context) {
@@ -123,8 +122,36 @@ public class ImageScoreTest implements CracTest {
             }
         };
         globalContext.register(dummy);
+        checkScore2(Score.getScore());
         CRaCMXBean.getCRaCMXBean().checkpointRestore();
 
+        Reference.reachabilityFence(cccProvider);
         Reference.reachabilityFence(dummy);
+    }
+
+    private static Map<String, Double> parseRecordedScore(List<String> lines) {
+        final var score = new HashMap<String, Double>();
+        for (var line : lines) {
+            final var metric = line.substring(0, line.indexOf('='));
+            final var value = Double.parseDouble(line.substring(line.indexOf('=') + 1));
+            assertNull(score.put(metric, value), metric + " recorded multiple times");
+        }
+        return score;
+    }
+
+    private static void checkScore1(Map<String, Double> score) {
+        assertGT(score.size(), 10); // at least 10 items
+        assertTrue(score.containsKey(VM_UPTIME));
+        assertEquals(TEST_SCORE_AAA_VALUE_1, score.get(TEST_SCORE_AAA));
+        assertEquals(TEST_SCORE_BBB_VALUE_1, score.get(TEST_SCORE_BBB));
+        assertEquals(TEST_SCORE_CCC_VALUE_1, score.get(TEST_SCORE_CCC));
+    }
+
+    private static void checkScore2(Map<String, Double> score) {
+        assertGT(score.size(), 10); // at least 10 items
+        assertTrue(score.containsKey(VM_UPTIME));
+        assertEquals(TEST_SCORE_AAA_VALUE_2, score.get(TEST_SCORE_AAA));
+        assertTrue(score.keySet().stream().noneMatch(m -> m.startsWith(TEST_SCORE_BBB)));
+        assertEquals(TEST_SCORE_CCC_VALUE_2, score.get(TEST_SCORE_CCC));
     }
 }

--- a/test/jdk/jdk/crac/score/FailingScoreProviderTest.java
+++ b/test/jdk/jdk/crac/score/FailingScoreProviderTest.java
@@ -29,7 +29,7 @@ import static jdk.test.lib.Asserts.*;
 
 /*
  * @test
- * @summary Tests score computation in presence of failing score providers.
+ * @summary Tests scores computation in presence of failing score providers.
  * @modules java.base/jdk.internal.crac:+open
  * @library /test/lib
  */
@@ -52,18 +52,18 @@ public class FailingScoreProviderTest {
         // Provider exceptions should be ignored
         Score.addScoreProvider(FAILING_PROVIDER);
         Score.addScoreProvider(NORMAL_PROVIDER);
-        checkScore(Score.getScore());
+        checkScores(Score.getScores());
 
         // Provider errors should be propagated
         Score.addScoreProvider(CRASHING_PROVIDER);
-        assertThrows(ExpectedError.class, Score::getScore);
+        assertThrows(ExpectedError.class, Score::getScores);
     }
 
-    private static void checkScore(Map<String, Double> score) {
-        assertGT(score.size(), 10, score.toString()); // at least 10 items
-        assertTrue(score.containsKey(VM_UPTIME), score.toString());
-        assertTrue(score.containsKey(JDK_CRAC_INTERNAL_CONTEXT_SIZE), score.toString());
-        assertEquals(TEST_SCORE_VALUE, score.get(TEST_SCORE), score.toString());
+    private static void checkScores(Map<String, Double> scores) {
+        assertGT(scores.size(), 10, scores.toString()); // at least 10 items
+        assertTrue(scores.containsKey(VM_UPTIME), scores.toString());
+        assertTrue(scores.containsKey(JDK_CRAC_INTERNAL_CONTEXT_SIZE), scores.toString());
+        assertEquals(TEST_SCORE_VALUE, scores.get(TEST_SCORE), scores.toString());
     }
 
     private static class ExpectedError extends Error {

--- a/test/jdk/jdk/crac/score/FailingScoreProviderTest.java
+++ b/test/jdk/jdk/crac/score/FailingScoreProviderTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Azul Systems, 385 Moffett Park Drive, Suite 115, Sunnyvale
+ * CA 94089 USA or visit www.azul.com if you need additional information or
+ * have any questions.
+ */
+
+import jdk.internal.crac.Score;
+
+import java.util.Map;
+
+import static jdk.test.lib.Asserts.*;
+
+/*
+ * @test
+ * @summary Tests score computation in presence of failing score providers.
+ * @modules java.base/jdk.internal.crac:+open
+ * @library /test/lib
+ */
+public class FailingScoreProviderTest {
+    private static final String VM_UPTIME = "vm.uptime";
+    private static final String JDK_CRAC_INTERNAL_CONTEXT_SIZE = "jdk.crac.internalContext.size";
+    private static final String TEST_SCORE = "test.score";
+    private static final double TEST_SCORE_VALUE = 123.456;
+
+    // Strong references
+    private static final Runnable NORMAL_PROVIDER = () -> Score.setScore(TEST_SCORE, TEST_SCORE_VALUE);
+    private static final Runnable FAILING_PROVIDER = () -> {
+        throw new RuntimeException("");
+    };
+    private static final Runnable CRASHING_PROVIDER = () -> {
+        throw new ExpectedError();
+    };
+
+    public static void main(String[] args) {
+        // Provider exceptions should be ignored
+        Score.addScoreProvider(FAILING_PROVIDER);
+        Score.addScoreProvider(NORMAL_PROVIDER);
+        checkScore(Score.getScore());
+
+        // Provider errors should be propagated
+        Score.addScoreProvider(CRASHING_PROVIDER);
+        assertThrows(ExpectedError.class, Score::getScore);
+    }
+
+    private static void checkScore(Map<String, Double> score) {
+        assertGT(score.size(), 10, score.toString()); // at least 10 items
+        assertTrue(score.containsKey(VM_UPTIME), score.toString());
+        assertTrue(score.containsKey(JDK_CRAC_INTERNAL_CONTEXT_SIZE), score.toString());
+        assertEquals(TEST_SCORE_VALUE, score.get(TEST_SCORE), score.toString());
+    }
+
+    private static class ExpectedError extends Error {
+    }
+}

--- a/test/jdk/jdk/crac/score/ImageScoreTest.java
+++ b/test/jdk/jdk/crac/score/ImageScoreTest.java
@@ -77,17 +77,20 @@ public class ImageScoreTest implements CracTest {
             builder.clearVmOptions();
             process.waitForPausePid();
 
-            final var score1 = parseRecordedScore(Files.readAllLines(builder.imageDir().resolve("score")));
-            checkScore1(score1);
+            final var scores1 = parseRecordedScores(Files.readAllLines(builder.imageDir().resolve("score")));
+            checkScores1(scores1);
 
             builder.doRestore();
             process.clearPausePid();
             process.sendNewline();
             process.waitForPausePid();
 
-            final var score2 = parseRecordedScore(Files.readAllLines(builder.imageDir().resolve("score")));
-            checkScore2(score2);
-            assertEquals(score1.get(JDK_CRAC_GLOBAL_CONTEXT_SIZE).intValue() + 1, score2.get(JDK_CRAC_GLOBAL_CONTEXT_SIZE).intValue());
+            final var scores2 = parseRecordedScores(Files.readAllLines(builder.imageDir().resolve("score")));
+            checkScores2(scores2);
+            assertEquals(
+                    scores1.get(JDK_CRAC_GLOBAL_CONTEXT_SIZE).intValue() + 1,
+                    scores2.get(JDK_CRAC_GLOBAL_CONTEXT_SIZE).intValue()
+            );
 
             builder.doRestore();
             process.waitForSuccess();
@@ -104,7 +107,7 @@ public class ImageScoreTest implements CracTest {
         Score.addScoreProvider(cccProvider);
         // Force user-facing global context instantiation
         Context<Resource> globalContext = Context.getGlobalContext();
-        checkScore1(Score.getScore());
+        checkScores1(Score.getScores());
         CRaCMXBean.getCRaCMXBean().checkpointRestore();
 
         assertEquals(System.in.read(), (int) '\n');
@@ -122,36 +125,36 @@ public class ImageScoreTest implements CracTest {
             }
         };
         globalContext.register(dummy);
-        checkScore2(Score.getScore());
+        checkScores2(Score.getScores());
         CRaCMXBean.getCRaCMXBean().checkpointRestore();
 
         Reference.reachabilityFence(cccProvider);
         Reference.reachabilityFence(dummy);
     }
 
-    private static Map<String, Double> parseRecordedScore(List<String> lines) {
-        final var score = new HashMap<String, Double>();
+    private static Map<String, Double> parseRecordedScores(List<String> lines) {
+        final var scores = new HashMap<String, Double>();
         for (var line : lines) {
             final var metric = line.substring(0, line.indexOf('='));
             final var value = Double.parseDouble(line.substring(line.indexOf('=') + 1));
-            assertNull(score.put(metric, value), metric + " recorded multiple times");
+            assertNull(scores.put(metric, value), metric + " recorded multiple times");
         }
-        return score;
+        return scores;
     }
 
-    private static void checkScore1(Map<String, Double> score) {
-        assertGT(score.size(), 10, score.toString()); // at least 10 items
-        assertTrue(score.containsKey(VM_UPTIME), score.toString());
-        assertEquals(TEST_SCORE_AAA_VALUE_1, score.get(TEST_SCORE_AAA), score.toString());
-        assertEquals(TEST_SCORE_BBB_VALUE_1, score.get(TEST_SCORE_BBB), score.toString());
-        assertEquals(TEST_SCORE_CCC_VALUE_1, score.get(TEST_SCORE_CCC), score.toString());
+    private static void checkScores1(Map<String, Double> scores) {
+        assertGT(scores.size(), 10, scores.toString()); // at least 10 items
+        assertTrue(scores.containsKey(VM_UPTIME), scores.toString());
+        assertEquals(TEST_SCORE_AAA_VALUE_1, scores.get(TEST_SCORE_AAA), scores.toString());
+        assertEquals(TEST_SCORE_BBB_VALUE_1, scores.get(TEST_SCORE_BBB), scores.toString());
+        assertEquals(TEST_SCORE_CCC_VALUE_1, scores.get(TEST_SCORE_CCC), scores.toString());
     }
 
-    private static void checkScore2(Map<String, Double> score) {
-        assertGT(score.size(), 10, score.toString()); // at least 10 items
-        assertTrue(score.containsKey(VM_UPTIME), score.toString());
-        assertEquals(TEST_SCORE_AAA_VALUE_2, score.get(TEST_SCORE_AAA), score.toString());
-        assertTrue(score.keySet().stream().noneMatch(m -> m.startsWith(TEST_SCORE_BBB)), score.toString());
-        assertEquals(TEST_SCORE_CCC_VALUE_2, score.get(TEST_SCORE_CCC), score.toString());
+    private static void checkScores2(Map<String, Double> scores) {
+        assertGT(scores.size(), 10, scores.toString()); // at least 10 items
+        assertTrue(scores.containsKey(VM_UPTIME), scores.toString());
+        assertEquals(TEST_SCORE_AAA_VALUE_2, scores.get(TEST_SCORE_AAA), scores.toString());
+        assertTrue(scores.keySet().stream().noneMatch(m -> m.startsWith(TEST_SCORE_BBB)), scores.toString());
+        assertEquals(TEST_SCORE_CCC_VALUE_2, scores.get(TEST_SCORE_CCC), scores.toString());
     }
 }

--- a/test/jdk/jdk/crac/score/ImageScoreTest.java
+++ b/test/jdk/jdk/crac/score/ImageScoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
+ * Copyright (c) 2025, 2026, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -140,18 +140,18 @@ public class ImageScoreTest implements CracTest {
     }
 
     private static void checkScore1(Map<String, Double> score) {
-        assertGT(score.size(), 10); // at least 10 items
-        assertTrue(score.containsKey(VM_UPTIME));
-        assertEquals(TEST_SCORE_AAA_VALUE_1, score.get(TEST_SCORE_AAA));
-        assertEquals(TEST_SCORE_BBB_VALUE_1, score.get(TEST_SCORE_BBB));
-        assertEquals(TEST_SCORE_CCC_VALUE_1, score.get(TEST_SCORE_CCC));
+        assertGT(score.size(), 10, score.toString()); // at least 10 items
+        assertTrue(score.containsKey(VM_UPTIME), score.toString());
+        assertEquals(TEST_SCORE_AAA_VALUE_1, score.get(TEST_SCORE_AAA), score.toString());
+        assertEquals(TEST_SCORE_BBB_VALUE_1, score.get(TEST_SCORE_BBB), score.toString());
+        assertEquals(TEST_SCORE_CCC_VALUE_1, score.get(TEST_SCORE_CCC), score.toString());
     }
 
     private static void checkScore2(Map<String, Double> score) {
-        assertGT(score.size(), 10); // at least 10 items
-        assertTrue(score.containsKey(VM_UPTIME));
-        assertEquals(TEST_SCORE_AAA_VALUE_2, score.get(TEST_SCORE_AAA));
-        assertTrue(score.keySet().stream().noneMatch(m -> m.startsWith(TEST_SCORE_BBB)));
-        assertEquals(TEST_SCORE_CCC_VALUE_2, score.get(TEST_SCORE_CCC));
+        assertGT(score.size(), 10, score.toString()); // at least 10 items
+        assertTrue(score.containsKey(VM_UPTIME), score.toString());
+        assertEquals(TEST_SCORE_AAA_VALUE_2, score.get(TEST_SCORE_AAA), score.toString());
+        assertTrue(score.keySet().stream().noneMatch(m -> m.startsWith(TEST_SCORE_BBB)), score.toString());
+        assertEquals(TEST_SCORE_CCC_VALUE_2, score.get(TEST_SCORE_CCC), score.toString());
     }
 }


### PR DESCRIPTION
Adds new methods to `Score`:
- `getScore` – read the current score at any moment;
- `addScoreProvider` — subscribe to score reading to update the score just before that; needed because the previous pattern of updating the score in `beforeCheckpoint` is not sufficient now (score can be read not only on checkpoint).

Replaces `resetAll()` with `removeScore(String metric)` — the new method is more traditional and can be more efficient in some cases, the old behavior can be achieved by removing all metrics returned by `getScore`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8383789](https://bugs.openjdk.org/browse/JDK-8383789): [CRaC] Add reading to Java-side score API (**Enhancement** - P2)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/312/head:pull/312` \
`$ git checkout pull/312`

Update a local copy of the PR: \
`$ git checkout pull/312` \
`$ git pull https://git.openjdk.org/crac.git pull/312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 312`

View PR using the GUI difftool: \
`$ git pr show -t 312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/312.diff">https://git.openjdk.org/crac/pull/312.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/312#issuecomment-4370147856)
</details>
