### PR TITLE
8384412: [CRaC] Customizable error message on CPU features check failure

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1355,7 +1355,10 @@ void VM_Version::print_using_features_cr() {
     tty->print_raw_cr("CPU features are being kept intact as requested by -XX:CPUFeatures=ignore");
   } else {
     tty->print_raw("CPU features being used are: -XX:CPUFeatures=");
-    _features.print_numbers(*tty);
+    // Workaround JDK-8311164: CPU_HT is set randomly on hybrid CPUs like Alder Lake.
+    VM_Features features = _features;
+    features.clear_feature(CPU_HT);
+    features.print_numbers(*tty);
     tty->cr();
   }
 }

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -919,11 +919,11 @@ void crac::restore(crac_restore_data& restore_data) {
   }
 
   const int ret = engine.restore();
-  if (ret != 0 && (CheckCPUFeaturesMessage == nullptr || strcmp("quiet", CheckCPUFeaturesMessage))) {
+  if (ret != 0) {
     log_error(crac)("CRaC engine failed to restore from %s: error %d", CRaCRestoreFrom, ret);
     VM_Version::VM_Features current_features;
     VM_Version::cpu_features_binary(&current_features); // ignore return value
-    engine.check_cpuinfo(&current_features, exact, CheckCPUFeaturesMessage);
+    engine.check_cpuinfo(&current_features, exact);
   }
 }
 

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -919,11 +919,11 @@ void crac::restore(crac_restore_data& restore_data) {
   }
 
   const int ret = engine.restore();
-  if (ret != 0) {
+  if (ret != 0 && (CheckCPUFeaturesMessage == nullptr || strcmp("quiet", CheckCPUFeaturesMessage))) {
     log_error(crac)("CRaC engine failed to restore from %s: error %d", CRaCRestoreFrom, ret);
     VM_Version::VM_Features current_features;
     VM_Version::cpu_features_binary(&current_features); // ignore return value
-    engine.check_cpuinfo(&current_features, exact);
+    engine.check_cpuinfo(&current_features, exact, CheckCPUFeaturesMessage);
   }
 }
 

--- a/src/hotspot/share/runtime/crac_engine.cpp
+++ b/src/hotspot/share/runtime/crac_engine.cpp
@@ -568,7 +568,7 @@ void CracEngine::require_cpuinfo(const VM_Version::VM_Features *current_features
     reinterpret_cast<const unsigned char *>(current_features), sizeof(*current_features), exact ? EQUALS : SUBSET);
 }
 
-void CracEngine::check_cpuinfo(const VM_Version::VM_Features *current_features, bool exact, const char *features_message) const {
+void CracEngine::check_cpuinfo(const VM_Version::VM_Features *current_features, bool exact) const {
   if (_image_constraints_api == nullptr) {
     // When CPU features are ignored
     return;
@@ -580,8 +580,8 @@ void CracEngine::check_cpuinfo(const VM_Version::VM_Features *current_features, 
     const char *error_message;
     VM_Version::VM_Features image_features;
     size_t image_features_size = _image_constraints_api->get_failed_bitmap(_conf, cpufeatures_name, reinterpret_cast<unsigned char *>(&image_features), sizeof(image_features));
-    if (features_message != nullptr) {
-      error_message = features_message;
+    if (CheckCPUFeaturesMessage != nullptr) {
+      error_message = CheckCPUFeaturesMessage;
     } else if (image_features_size == sizeof(image_features)) {
       if (exact) {
         error_message = "Restore failed due to incompatible or missing CPU features, try using -XX:CPUFeatures=%c on checkpoint.";

--- a/src/hotspot/share/runtime/crac_engine.cpp
+++ b/src/hotspot/share/runtime/crac_engine.cpp
@@ -568,7 +568,7 @@ void CracEngine::require_cpuinfo(const VM_Version::VM_Features *current_features
     reinterpret_cast<const unsigned char *>(current_features), sizeof(*current_features), exact ? EQUALS : SUBSET);
 }
 
-void CracEngine::check_cpuinfo(const VM_Version::VM_Features *current_features, bool exact) const {
+void CracEngine::check_cpuinfo(const VM_Version::VM_Features *current_features, bool exact, const char *features_message) const {
   if (_image_constraints_api == nullptr) {
     // When CPU features are ignored
     return;
@@ -577,19 +577,54 @@ void CracEngine::check_cpuinfo(const VM_Version::VM_Features *current_features, 
     log_error(crac)("Restore failed due to wrong or missing CPU architecture (current architecture is " ARCHPROPNAME ")");
   }
   if (_image_constraints_api->is_failed(_conf, cpufeatures_name)) {
+    const char *error_message;
     VM_Version::VM_Features image_features;
     size_t image_features_size = _image_constraints_api->get_failed_bitmap(_conf, cpufeatures_name, reinterpret_cast<unsigned char *>(&image_features), sizeof(image_features));
-    if (image_features_size == sizeof(image_features)) {
-      ResourceMark rm;
-      if (!exact) {
-        image_features &= *current_features;
+    if (features_message != nullptr) {
+      error_message = features_message;
+    } else if (image_features_size == sizeof(image_features)) {
+      if (exact) {
+        error_message = "Restore failed due to incompatible or missing CPU features, try using -XX:CPUFeatures=%c on checkpoint.";
       } else {
-        image_features = *current_features;
+        error_message = "Restore failed due to incompatible or missing CPU features, try using -XX:CPUFeatures=%m on checkpoint.";
       }
-      log_error(crac)("Restore failed due to incompatible or missing CPU features, try using -XX:CPUFeatures=%s on checkpoint.", image_features.print_numbers());
     } else {
-      log_error(crac)("Restore failed due to incompatible or missing CPU features.");
+      error_message = "Restore failed due to incompatible or missing CPU features.";
     }
+    VM_Version::VM_Features common_features = image_features;
+    common_features &= *current_features;
+    // Reparse the message
+    ResourceMark rm;
+    stringStream ss;
+    const char *percent = strchr(error_message, '%');
+    while (percent != nullptr) {
+      ss.print_raw(error_message, percent - error_message);
+      switch (percent[1]) {
+        case '\0':
+          ss.print_raw("<invalid trailing % char>");
+          percent = percent - 1; // next cycle will point at the '\0'
+          break;
+        case '%':
+          ss.put('%');
+          break;
+        case 'c':
+          current_features->print_numbers(ss);
+          break;
+        case 's':
+          image_features.print_numbers(ss);
+          break;
+        case 'm':
+          common_features.print_numbers(ss);
+          break;
+        default:
+          ss.print("<invalid formatting char '%c'>", percent[1]);
+          break;
+      }
+      error_message = &percent[2];
+      percent = strchr(error_message, '%');
+    }
+    ss.print_raw(error_message);
+    log_error(crac)("%s", ss.as_string());
   }
 }
 

--- a/src/hotspot/share/runtime/crac_engine.hpp
+++ b/src/hotspot/share/runtime/crac_engine.hpp
@@ -74,7 +74,7 @@ public:
   bool set_label(const char* label, const char* value);
   bool store_cpuinfo(const VM_Version::VM_Features *current_features) const;
   void require_cpuinfo(const VM_Version::VM_Features *current_features, bool exact) const;
-  void check_cpuinfo(const VM_Version::VM_Features *current_features, bool exact, const char *features_message) const;
+  void check_cpuinfo(const VM_Version::VM_Features *current_features, bool exact) const;
 
   ApiStatus prepare_image_score_api();
   bool set_score(const char* metric, double value);

--- a/src/hotspot/share/runtime/crac_engine.hpp
+++ b/src/hotspot/share/runtime/crac_engine.hpp
@@ -74,7 +74,7 @@ public:
   bool set_label(const char* label, const char* value);
   bool store_cpuinfo(const VM_Version::VM_Features *current_features) const;
   void require_cpuinfo(const VM_Version::VM_Features *current_features, bool exact) const;
-  void check_cpuinfo(const VM_Version::VM_Features *current_features, bool exact) const;
+  void check_cpuinfo(const VM_Version::VM_Features *current_features, bool exact, const char *features_message) const;
 
   ApiStatus prepare_image_score_api();
   bool set_score(const char* metric, double value);

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2031,6 +2031,13 @@ const int ObjectAlignmentInBytes = 8;
           "skip: don't check features at all (requires "                    \
           "-XX:+UnlockExperimentalVMOptions).")                             \
                                                                             \
+  product(ccstr, CheckCPUFeaturesMessage, nullptr, RESTORE_SETTABLE,        \
+          "Message reported when CPU features checks fails. This string "   \
+          "can contain placeholders '%c', '%s' or '%m' for current CPU "    \
+          "features, features stored in the image or common (intersection " \
+          "of current & stored) features respectively. A special value "    \
+          "'quiet' suppresses the failure message entirely.")               \
+                                                                            \
   product(bool, UseObjectMonitorTable, true, DIAGNOSTIC,                    \
           "Use a table to record inflated monitors rather than the first "  \
           "word of the object.")                                            \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2032,8 +2032,7 @@ const int ObjectAlignmentInBytes = 8;
           "Message reported when CPU features checks fails. This string "   \
           "can contain placeholders '%c', '%s' or '%m' for current CPU "    \
           "features, features stored in the image or common (intersection " \
-          "of current & stored) features respectively. A special value "    \
-          "'quiet' suppresses the failure message entirely.")               \
+          "of current & stored) features respectively.")               \
                                                                             \
   product(bool, UseObjectMonitorTable, true, DIAGNOSTIC,                    \
           "Use a table to record inflated monitors rather than the first "  \

--- a/test/jdk/jdk/crac/engine/CheckCPUFeaturesMessageTest.java
+++ b/test/jdk/jdk/crac/engine/CheckCPUFeaturesMessageTest.java
@@ -65,16 +65,16 @@ public class CheckCPUFeaturesMessageTest implements CracTest {
     }
 
     private void testQuiet(CracBuilder builder) throws Exception {
-        builder.vmOption("-XX:CheckCPUFeaturesMessage=quiet")
+        builder.vmOption("-Xlog:crac=Off")
                 .doRestoreToAnalyze()
                 .shouldHaveExitValue(1)
-                .shouldNotContain("quiet")
                 .shouldNotContain("CRaC engine failed to restore");
     }
 
     private CracBuilder mustFail(CracBuilder builder) {
         return builder.clearVmOptions().vmOption("-XX:CheckCPUFeatures=exact");
     }
+
     @Override
     public void test() throws Exception {
         CracBuilder builder = new CracBuilder()

--- a/test/jdk/jdk/crac/engine/CheckCPUFeaturesMessageTest.java
+++ b/test/jdk/jdk/crac/engine/CheckCPUFeaturesMessageTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Azul Systems, 385 Moffett Park Drive, Suite 115, Sunnyvale
+ * CA 94089 USA or visit www.azul.com if you need additional information or
+ * have any questions.
+ */
+
+import jdk.crac.management.CRaCMXBean;
+import jdk.test.lib.Utils;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracEngine;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.util.FileUtils;
+
+import java.lang.reflect.Method;
+
+/*
+ * @test
+ * @summary Check combinations of CPUFeatures and CheckCPUFeatures VM options
+ * @requires (os.family == "linux")
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @library /test/lib
+ * @build CheckCPUFeaturesMessageTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class CheckCPUFeaturesMessageTest implements CracTest {
+
+    private void testDefault(CracBuilder builder) throws Exception {
+        builder.doRestoreToAnalyze()
+                .shouldHaveExitValue(1)
+                .shouldContain("Restore failed due to incompatible or missing CPU features");
+    }
+
+    private void testPatterns(CracBuilder builder) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder(Utils.TEST_JDK + "/bin/java", "-XX:+ShowCPUFeatures", "--version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
+        String currentCpuFeatures = output.getStdout().lines()
+                .filter(line -> line.startsWith("CPU features being used are") && line.contains("="))
+                .map(line -> line.substring(line.lastIndexOf("=") + 1))
+                .findFirst().orElseThrow();
+        String genericFeatures = "0x200000080d7,0x0";
+        builder.vmOption("-XX:CheckCPUFeaturesMessage=%cMyError%sMessageWith%%Common%m")
+                .doRestoreToAnalyze()
+                .shouldHaveExitValue(1)
+                .shouldContain(currentCpuFeatures + "MyError" + genericFeatures + "MessageWith%Common0x");
+    }
+
+    private void testQuiet(CracBuilder builder) throws Exception {
+        builder.vmOption("-XX:CheckCPUFeaturesMessage=quiet")
+                .doRestoreToAnalyze()
+                .shouldHaveExitValue(1)
+                .shouldNotContain("quiet")
+                .shouldNotContain("CRaC engine failed to restore");
+    }
+
+    private CracBuilder mustFail(CracBuilder builder) {
+        return builder.clearVmOptions().vmOption("-XX:CheckCPUFeatures=exact");
+    }
+    @Override
+    public void test() throws Exception {
+        CracBuilder builder = new CracBuilder()
+                .engine(CracEngine.PAUSE)
+                .vmOption("-XX:CPUFeatures=generic");
+        if (builder.imageDir().toFile().exists()) {
+            FileUtils.deleteFileTreeWithRetry(builder.imageDir());
+        }
+
+        try (var checkpoint = builder.startCheckpoint()) {
+            checkpoint.waitForPausePid();
+
+            testDefault(mustFail(builder));
+            testPatterns(mustFail(builder));
+            testQuiet(mustFail(builder));
+
+            builder.clearVmOptions().doRestore();
+            checkpoint.waitForSuccess();
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        CRaCMXBean.getCRaCMXBean().checkpointRestore();
+    }
+}


### PR DESCRIPTION
The author of app distribution embedding a CRaC image can provide further hints when CPU features check does not succeed, for example recommend an alternative app distribution (think e.g. Docker image). 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8384412](https://bugs.openjdk.org/browse/JDK-8384412): [CRaC] Customizable error message on CPU features check failure (**Enhancement** - P4)


### Reviewers
 * [Timofei Pushkin](https://openjdk.org/census#tpushkin) (@TimPushkin - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/314/head:pull/314` \
`$ git checkout pull/314`

Update a local copy of the PR: \
`$ git checkout pull/314` \
`$ git pull https://git.openjdk.org/crac.git pull/314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 314`

View PR using the GUI difftool: \
`$ git pr show -t 314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/314.diff">https://git.openjdk.org/crac/pull/314.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/314#issuecomment-4429222137)
</details>
