### PR TITLE
8385158: [CRaC] Make it possible to specify engine options only for checkpoint or restore

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1629,10 +1629,18 @@ bool Arguments::check_vm_args_consistency() {
   }
 #endif
 
-  if (CheckCPUFeatures != nullptr && !strcmp(CheckCPUFeatures, "skip") && !UnlockExperimentalVMOptions) {
-    jio_fprintf(defaultStream::error_stream(),
-                "-XX:CheckCPUFeatures=skip is allowed only with -XX:+UnlockExperimentalVMOptions\n");
-    return false;
+  if (CheckCPUFeatures != nullptr && strcmp(CheckCPUFeatures, "skip") == 0 && !UnlockExperimentalVMOptions) {
+    jio_fprintf(defaultStream::error_stream(), "-XX:CheckCPUFeatures=skip requires -XX:+UnlockExperimentalVMOptions\n");
+    status = false;
+  }
+
+  if (CRaCCheckpointEngineOptions != nullptr && CRaCCheckpointTo == nullptr) {
+    jio_fprintf(defaultStream::error_stream(), "-XX:CRaCCheckpointEngineOptions requires -XX:CRaCCheckpointTo\n");
+    status = false;
+  }
+  if (CRaCRestoreEngineOptions != nullptr && CRaCRestoreFrom == nullptr) {
+    jio_fprintf(defaultStream::error_stream(), "-XX:CRaCRestoreEngineOptions requires -XX:CRaCRestoreFrom\n");
+    status = false;
   }
 
   return status;
@@ -2703,7 +2711,9 @@ static bool should_record_for_restore(const JVMFlag& flag) {
            "unexpected CRaCEngine* flag: %s", flag.name());
     return false;
   }
-  if (strcmp(flag.name(), "IgnoreUnrecognizedVMOptions") == 0) {
+  if (strcmp(flag.name(), "IgnoreUnrecognizedVMOptions") == 0 ||
+      strcmp(flag.name(), "CRaCCheckpointEngineOptions") == 0 ||
+      strcmp(flag.name(), "CRaCRestoreEngineOptions") == 0) {
     return false;
   }
   return true;

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2712,10 +2712,11 @@ static bool should_record_for_restore(const JVMFlag& flag) {
     return false;
   }
   if (strcmp(flag.name(), "IgnoreUnrecognizedVMOptions") == 0 ||
-      strcmp(flag.name(), "CRaCCheckpointEngineOptions") == 0 ||
       strcmp(flag.name(), "CRaCRestoreEngineOptions") == 0) {
     return false;
   }
+  assert(strcmp(flag.name(), "CRaCCheckpointEngineOptions") != 0,
+         "%s is not restore-settable and thus should not reach here", flag.name());
   return true;
 }
 

--- a/src/hotspot/share/runtime/crac_engine.cpp
+++ b/src/hotspot/share/runtime/crac_engine.cpp
@@ -181,6 +181,43 @@ public:
 using CStringSet = HashTable<const char *, bool, 256, AnyObj::C_HEAP, MemTag::mtInternal,
                              CStringUtils::hash, CStringUtils::equals>;
 
+static bool apply_engine_options(const crlib_api_t &api, crlib_conf_t *conf, const char *options,
+                                 const CStringSet &vm_keys, CStringSet *applied_keys) {
+  if (options == nullptr || options[0] == '\0' /* possible for ccstrlist */) {
+    return true;
+  }
+
+  char * const options_copy = os::strdup_check_oom(options, mtInternal);
+
+  char *options_copy_iter = options_copy;
+  do {
+    char *key_value = strsep(&options_copy_iter, ",\n"); // '\n' appears when ccstrlist is appended to
+    const char *key = strsep(&key_value, "=");
+    const char *value = key_value != nullptr ? key_value : "";
+    assert(key != nullptr, "Should have terminated before");
+    if (vm_keys.contains(key)) {
+      log_warning(crac)("VM-controlled CRaC engine option provided, skipping: %s", key);
+      continue;
+    }
+    {
+      bool is_new_key;
+      applied_keys->put_if_absent(key, &is_new_key);
+      if (!is_new_key) {
+        log_warning(crac)("CRaC engine option '%s' specified multiple times", key);
+      }
+    }
+    if (!api.configure(conf, key, value)) {
+      log_error(crac)("CRaC engine failed to configure: '%s' = '%s'", key, value);
+      os::free(options_copy);
+      return false;
+    }
+    log_debug(crac)("CRaC engine option: '%s' = '%s'", key, value);
+  } while (options_copy_iter != nullptr);
+
+  os::free(options_copy);
+  return true;
+}
+
 static crlib_conf_t *create_conf(const crlib_api_t &api, bool for_restore) {
   crlib_conf_t * const conf = api.create_conf();
   if (conf == nullptr) {
@@ -203,43 +240,18 @@ static crlib_conf_t *create_conf(const crlib_api_t &api, bool for_restore) {
   }
 #endif // LINUX
 
-  CStringSet keys;
-  char* engine_options_start = nullptr;
-  if (CRaCEngineOptions != nullptr && CRaCEngineOptions[0] != '\0' /* possible for ccstrlist */) {
-    CStringSet vm_controlled_keys;
+  CStringSet vm_controlled_keys;
 #define PUT_CONTROLLED_KEY(opt) vm_controlled_keys.put_when_absent(engine_opt_##opt, false);
-    VM_CONTROLLED_ENGINE_OPTS(PUT_CONTROLLED_KEY)
+  VM_CONTROLLED_ENGINE_OPTS(PUT_CONTROLLED_KEY)
 #undef PUT_CONTROLLED_KEY
 
-    char *engine_options = os::strdup_check_oom(CRaCEngineOptions, mtInternal);
-    engine_options_start = engine_options;
-    do {
-      char *key_value = strsep(&engine_options, ",\n"); // '\n' appears when ccstrlist is appended to
-      const char *key = strsep(&key_value, "=");
-      const char *value = key_value != nullptr ? key_value : "";
-      assert(key != nullptr, "Should have terminated before");
-      if (vm_controlled_keys.contains(key)) {
-        log_warning(crac)("VM-controlled CRaC engine option provided, skipping: %s", key);
-        continue;
-      }
-      {
-        bool is_new_key;
-        keys.put_if_absent(key, &is_new_key);
-        if (!is_new_key) {
-          log_warning(crac)("CRaC engine option '%s' specified multiple times", key);
-        }
-      }
-      if (!api.configure(conf, key, value)) {
-        log_error(crac)("CRaC engine failed to configure: '%s' = '%s'", key, value);
-        os::free(engine_options_start);
-        api.destroy_conf(conf);
-        return nullptr;
-      }
-      log_debug(crac)("CRaC engine option: '%s' = '%s'", key, value);
-    } while (engine_options != nullptr);
+  CStringSet keys;
+  if (!apply_engine_options(api, conf, CRaCEngineOptions, vm_controlled_keys, &keys) ||
+      (!for_restore && !apply_engine_options(api, conf, CRaCCheckpointEngineOptions, vm_controlled_keys, &keys)) ||
+      (for_restore && !apply_engine_options(api, conf, CRaCRestoreEngineOptions, vm_controlled_keys, &keys))) {
+    api.destroy_conf(conf);
+    return nullptr;
   }
-
-  os::free(engine_options_start);
 
   return conf;
 }

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1972,6 +1972,12 @@ const int ObjectAlignmentInBytes = 8;
           "restore this option applies only to the restoring VM, i.e. the " \
           "restored VM keeps the value it had before the checkpoint.")      \
                                                                             \
+  product(ccstrlist, CRaCCheckpointEngineOptions, nullptr,                  \
+          "Options appended to CRaCEngineOptions on checkpoint.")           \
+                                                                            \
+  product(ccstrlist, CRaCRestoreEngineOptions, nullptr, RESTORE_SETTABLE,   \
+          "Options appended to CRaCEngineOptions on restore.")              \
+                                                                            \
   product(bool, CRaCIgnoreRestoreIfUnavailable, false, RESTORE_SETTABLE,    \
           "If the image selected via CRaCRestoreFrom is identified as "     \
           "being unusable, continue initializing the JVM instead of "       \

--- a/test/jdk/jdk/crac/VMOptionsTest.java
+++ b/test/jdk/jdk/crac/VMOptionsTest.java
@@ -94,12 +94,14 @@ public class VMOptionsTest implements CracTest {
     private static final List<VMOptionSpec> OPTIONS_CHECKPOINT = List.of(
         VMOptionSpec.ofStr("CRaCEngine", "criu", false),
         VMOptionSpec.ofStr("CRaCEngineOptions", "args=-v1", false),
+        VMOptionSpec.ofStr("CRaCCheckpointEngineOptions", "print_command=false", false),
         VMOptionSpec.ofStr("CRaCCheckpointTo", new CracBuilder().imageDir().toString(), true),
         VMOptionSpec.ofStr("NativeMemoryTracking", "off", false)
     );
     private static final List<VMOptionSpec> OPTIONS_RESTORE = List.of(
         VMOptionSpec.ofStr("CRaCEngine", "criuengine", false),
         VMOptionSpec.ofStr("CRaCEngineOptions", "args=-v2", false),
+        VMOptionSpec.ofStr("CRaCRestoreEngineOptions", "print_command=true", false),
         VMOptionSpec.ofStr("CRaCCheckpointTo", "another", true),
         VMOptionSpec.ofStr("CRaCIgnoredFileDescriptors", "42,43", true),
         VMOptionSpec.ofBool("UnlockExperimentalVMOptions", true, true)

--- a/test/jdk/jdk/crac/ignoreRestore/CheckpointAfterIgnoredRestoreTest.java
+++ b/test/jdk/jdk/crac/ignoreRestore/CheckpointAfterIgnoredRestoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
+ * Copyright (c) 2025, 2026, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,32 +23,60 @@
  * questions.
  */
 
-import java.nio.file.Files;
-import java.util.List;
-
-import static jdk.test.lib.Asserts.*;
-
 import jdk.crac.management.CRaCMXBean;
 import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracEngine;
+import jdk.test.lib.process.OutputAnalyzer;
+
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+
+import static jdk.test.lib.Asserts.assertFalse;
+import static jdk.test.lib.Asserts.assertTrue;
 
 /**
  * @test
  * @summary If a restore attempt failed and was ignored by
  *          CRaCIgnoreRestoreIfUnavailable the normal execution started instead
  *          should be checkpointable.
+ *          Also tests CRaCCheckpointEngineOptions and CRaCRestoreEngineOptions.
  * @requires (os.family == "linux")
  * @library /test/lib
  */
 public class CheckpointAfterIgnoredRestoreTest {
     public static void main(String[] args) throws Exception {
-        final var builder = new CracBuilder()
-            .vmOption("-XX:+CRaCIgnoreRestoreIfUnavailable")
-            .forwardClasspathOnRestore(true);
+        final var builder = new CracBuilder().engine(CracEngine.CRIU);
         assertTrue(Files.notExists(builder.imageDir()), "Image should not exist yet: " + builder.imageDir());
-        builder
-            .startRestoreWithArgs(List.of(), List.of("-XX:CRaCCheckpointTo=" + builder.imageDir(), Main.class.getName()))
-            .waitForCheckpointed();
-        builder.doRestore();
+        builder.forwardClasspathOnRestore(true)
+                // CRaCRestoreFrom will be added automatically
+                .vmOption("-XX:CRaCCheckpointTo=" + builder.imageDir())
+                .vmOption("-XX:+CRaCIgnoreRestoreIfUnavailable")
+                .vmOption("-XX:CRaCEngineOptions=print_command=true")
+                // -v4 and -v1 are used by default
+                .vmOption("-XX:CRaCCheckpointEngineOptions=args=-v2")
+                .vmOption("-XX:CRaCRestoreEngineOptions=args=-v3");
+
+        final OutputAnalyzer checkpointOut;
+        try (final var p = builder.startRestoreWithArgs(List.of(), List.of(Main.class.getName()))) {
+            p.waitForCheckpointed();
+            checkpointOut = p.outputAnalyzer();
+        }
+        checkpointOut.shouldNotContain("[warning]");
+        checkArgs(checkpointOut, "-v2", "-v3");
+
+        final OutputAnalyzer restoreOut = builder.doRestoreToAnalyze();
+        restoreOut.shouldHaveExitValue(0).shouldNotContain("[warning]");
+        checkArgs(restoreOut, "-v3", "-v2");
+    }
+
+    private static void checkArgs(OutputAnalyzer outputAnalyzer, String expected, String unexpected) {
+        final var commandLog = outputAnalyzer.stderrAsLines().stream()
+                .filter(l -> l.contains("criuengine: Command: "))
+                .findFirst().orElseThrow();
+        final var command = Arrays.asList(commandLog.split("criuengine: Command: ", 2)[1].split("\\s+"));
+        assertTrue(command.contains(expected), "'" + expected + "' not found in " + command);
+        assertFalse(command.contains(unexpected), "'" + unexpected + "' found in " + command);
     }
 
     public static class Main {


### PR DESCRIPTION
Adds `CRaCCheckpointEngineOptions` and `CRaCRestoreEngineOptions` appended to `CRaCEngineOptions` only on checkpoint or restore respectively.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8385158](https://bugs.openjdk.org/browse/JDK-8385158): [CRaC] Make it possible to specify engine options only for checkpoint or restore (**Enhancement** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/316/head:pull/316` \
`$ git checkout pull/316`

Update a local copy of the PR: \
`$ git checkout pull/316` \
`$ git pull https://git.openjdk.org/crac.git pull/316/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 316`

View PR using the GUI difftool: \
`$ git pr show -t 316`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/316.diff">https://git.openjdk.org/crac/pull/316.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/316#issuecomment-4508899615)
</details>
