### PR TITLE
8385438: [CRaC] Cleanup after recent engine rework

### DIFF
--- a/src/java.base/linux/native/libcriuengine/criuengine.cpp
+++ b/src/java.base/linux/native/libcriuengine/criuengine.cpp
@@ -823,7 +823,7 @@ int criuengine::checkpoint() {
   } while (sig == -1 && errno == EINTR);
 
 #ifndef F_GET_SEALS
-#define F_GET_SEALS	1034
+#define F_GET_SEALS 1034
 #endif
   for (unsigned i = 0; i < ARRAY_SIZE(fake_fds); ++i) {
     if (fake_fds[i] < 0) {

--- a/src/java.base/linux/native/libcriuengine/criuengine.cpp
+++ b/src/java.base/linux/native/libcriuengine/criuengine.cpp
@@ -57,7 +57,7 @@
 #define UNCHECKED_OPTIONS(OPT) \
   OPT(image_location, const char*, nullptr, CRLIB_OPTION_FLAG_CHECKPOINT | CRLIB_OPTION_FLAG_RESTORE, "path", "no default", \
     "path to a directory with checkpoint/restore files.") \
-  OPT(criu_location, const char*, nullptr, CRLIB_OPTION_FLAG_CHECKPOINT | CRLIB_OPTION_FLAG_RESTORE, "path", "<engine dir>/../lib/criu", \
+  OPT(criu_location, const char*, nullptr, CRLIB_OPTION_FLAG_CHECKPOINT | CRLIB_OPTION_FLAG_RESTORE, "path", "PATH lookup", \
     "path to the CRIU executable.") \
   OPT(args, const char*, nullptr, CRLIB_OPTION_FLAG_CHECKPOINT | CRLIB_OPTION_FLAG_RESTORE, "string", "\"\"", \
     "free space-separated arguments passed directly to the engine executable, e.g. \"--arg1 --arg2 --arg3\".") \
@@ -770,6 +770,15 @@ int criuengine::checkpoint() {
   // we will use those if replaced after restore or just close when not (or when kept running).
   int fake_fds[3] = { -1, -1, -1 };
   if (!legacy_criu()) {
+#ifndef SYS_memfd_create
+#if defined(__x86_64__)
+#define SYS_memfd_create 319
+#elif defined(__aarch64__)
+#define SYS_memfd_create 279
+#else
+#error "Unsupported platform"
+#endif
+#endif // SYS_memfd_create
 #ifndef MFD_CLOEXEC
 #define MFD_CLOEXEC 0x0001U
 #endif
@@ -813,6 +822,9 @@ int criuengine::checkpoint() {
     sig = sigwaitinfo(&waitmask, &info);
   } while (sig == -1 && errno == EINTR);
 
+#ifndef F_GET_SEALS
+#define F_GET_SEALS	1034
+#endif
   for (unsigned i = 0; i < ARRAY_SIZE(fake_fds); ++i) {
     if (fake_fds[i] < 0) {
       continue;

--- a/test/jdk/tools/launcher/HelpFlagsTest.java
+++ b/test/jdk/tools/launcher/HelpFlagsTest.java
@@ -45,9 +45,6 @@ public class HelpFlagsTest extends TestHelper {
 
     // Tools that should not be tested because a usage message is pointless.
     static final String[] TOOLS_NOT_TO_TEST = {
-        "pauseengine", // crac, don't test
-        "simengine", // crac, don't test
-
         "jaccessinspector", // gui, don't test, win only
         "jaccessinspector-32", // gui, don't test, win-32 only
         "jaccesswalker",    // gui, don't test, win only

--- a/test/jdk/tools/launcher/VersionCheck.java
+++ b/test/jdk/tools/launcher/VersionCheck.java
@@ -44,9 +44,6 @@ public class VersionCheck extends TestHelper {
 
     // tools that do not accept -J-option
     static final String[] BLACKLIST_JOPTION = {
-        "pauseengine", // crac, don't test
-        "simengine", // crac, don't test
-
         "controlpanel",
         "jabswitch",
         "java-rmi",
@@ -70,9 +67,6 @@ public class VersionCheck extends TestHelper {
 
     // tools that do not accept -version
     static final String[] BLACKLIST_VERSION = {
-        "pauseengine", // crac, don't test
-        "simengine", // crac, don't test
-
         "controlpanel",
         "jaccessinspector",
         "jaccessinspector-32",


### PR DESCRIPTION
A minor cleanup.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8385438](https://bugs.openjdk.org/browse/JDK-8385438): [CRaC] Cleanup after recent engine rework (**Task** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/319/head:pull/319` \
`$ git checkout pull/319`

Update a local copy of the PR: \
`$ git checkout pull/319` \
`$ git pull https://git.openjdk.org/crac.git pull/319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 319`

View PR using the GUI difftool: \
`$ git pr show -t 319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/319.diff">https://git.openjdk.org/crac/pull/319.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/319#issuecomment-4552328821)
</details>
