### PR TITLE
8385923: [CRaC] Option to disable pointer authentication

### DIFF
--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -104,6 +104,8 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(uint, UseSVE, 0,                                              \
           "Highest supported SVE instruction set version")              \
           range(0, 2)                                                   \
+  product(bool, UsePAC, true, RESTORE_SETTABLE,                         \
+          "Enable Pointer Authentication")                              \
   product(bool, UseBlockZeroing, true,                                  \
           "Use DC ZVA for block zeroing")                               \
   product(intx, BlockZeroingLowLimit, 256,                              \

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -898,9 +898,6 @@ VM_Features VM_Version::CPUFeatures_generic() {
   if (_cpu_features.supports_feature(CPU_NOTPACA)) {
     retval.set_feature(CPU_NOTPACA);
   }
-  if (_cpu_features.supports_feature(CPU_LSE)) {
-    retval.set_feature(CPU_LSE);
-  }
   return retval;
 }
 

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -28,6 +28,7 @@
 #include "pauth_aarch64.hpp"
 #include "register_aarch64.hpp"
 #include "runtime/arguments.hpp"
+#include "runtime/globals.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
 #include "runtime/os.inline.hpp"
@@ -921,4 +922,18 @@ const char *VM_Version::restore_failed_check(const VM_Features *image_features, 
   paca.set_feature(VM_Feature_Flag::CPU_PACA);
   ss.print("Restore failed due to incompatible aarch64 CPU feature PACA (%s); these CPUs each require a separate image.", paca.print_numbers());
   return ss.as_string();
+}
+
+void VM_Version::CPUFeatures_apply_arch(VM_Features &parsed, VM_Features &missing) {
+  if (!FLAG_IS_DEFAULT(UsePAC)) {
+    if (UsePAC) {
+      parsed.set_feature(CPU_PACA);
+      parsed.clear_feature(CPU_NOTPACA);
+    } else {
+      parsed.set_feature(CPU_NOTPACA);
+      parsed.clear_feature(CPU_PACA);
+    }
+  }
+  missing.clear_feature(CPU_PACA);
+  missing.clear_feature(CPU_NOTPACA);
 }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -898,6 +898,9 @@ VM_Features VM_Version::CPUFeatures_generic() {
   if (_cpu_features.supports_feature(CPU_NOTPACA)) {
     retval.set_feature(CPU_NOTPACA);
   }
+  if (_cpu_features.supports_feature(CPU_LSE)) {
+    retval.set_feature(CPU_LSE);
+  }
   return retval;
 }
 

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -128,6 +128,8 @@ public:
   static VM_Features CPUFeatures_generic();
   static void glibc_patch(VM_Features &shouldnotuse) {}
   static VM_Features CPUFeatures_parse(const char *str);
+  static VM_Features CPUFeatures_parse_numeric(const char *str);
+  static void CPUFeatures_apply_arch(VM_Features &parsed, VM_Features &missing);
 #ifdef LINUX
   static bool glibc_not_using();
   static bool glibc_env_set(char *disable_str);

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -3634,3 +3634,7 @@ bool VM_Version::verify_aot_code_cache_features(void* features_buffer) {
   VM_Features rt_features = _features.aot_code_cache_features();
   return rt_features.verify_aot_code_cache_features(features_to_test);
 }
+
+void VM_Version::CPUFeatures_apply_arch(VM_Features &parsed, VM_Features &missing) {
+  // noop
+}

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -718,6 +718,8 @@ private:
   static VM_Features CPUFeatures_generic();
   static void glibc_patch(VM_Features &shouldnotuse);
   static VM_Features CPUFeatures_parse(const char *str);
+  static VM_Features CPUFeatures_parse_numeric(const char *str);
+  static void CPUFeatures_apply_arch(VM_Features &parsed, VM_Features &missing);
 #ifdef LINUX
   static bool glibc_not_using();
   static bool glibc_env_set(char *disable_str);

--- a/src/hotspot/share/runtime/abstract_vm_version.inline.hpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.inline.hpp
@@ -27,19 +27,19 @@
 #include "memory/resourceArea.hpp"
 
 VM_Features VM_Version::CPUFeatures_parse(const char *str) {
-#ifndef LINUX
-  _ignore_glibc_not_using = true;
-#endif // !LINUX
   if (str == nullptr || strcmp(str, "native") == 0) {
     return _features;
-  }
-  if (strcmp(str, "ignore") == 0) {
+  } else if (strcmp(str, "ignore") == 0) {
     _ignore_glibc_not_using = true;
     return _features;
-  }
-  if (strcmp(str, "generic") == 0) {
+  } else if (strcmp(str, "generic") == 0) {
     return CPUFeatures_generic();
+  } else {
+    return CPUFeatures_parse_numeric(str);
   }
+}
+
+VM_Features VM_Version::CPUFeatures_parse_numeric(const char *str) {
 #ifndef LINUX
   vm_exit_during_initialization("This OS does not support any arch-specific -XX:CPUFeatures options");
   return {};
@@ -75,7 +75,7 @@ VM_Features VM_Version::CPUFeatures_parse(const char *str) {
 #endif // LINUX
 }
 
-bool VM_Version::_ignore_glibc_not_using = false;
+bool VM_Version::_ignore_glibc_not_using = LINUX_ONLY(false) NOT_LINUX(true);
 #ifdef LINUX
 bool VM_Version::glibc_env_set(char *disable_str) {
 #define TUNABLES_NAME "GLIBC_TUNABLES"
@@ -281,18 +281,9 @@ void VM_Version::cpu_features_init() {
   VM_Features features_missing = CPUFeatures_parsed & ~_features;
   features_missing = features_missing.aot_code_cache_features();
 
+  CPUFeatures_apply_arch(CPUFeatures_parsed, features_missing);
 #ifdef __aarch64__
-  if (!FLAG_IS_DEFAULT(UsePAC)) {
-    if (UsePAC) {
-      CPUFeatures_parsed.set_feature(CPU_PACA);
-      CPUFeatures_parsed.clear_feature(CPU_NOTPACA);
-    } else {
-      CPUFeatures_parsed.set_feature(CPU_NOTPACA);
-      CPUFeatures_parsed.clear_feature(CPU_PACA);
-    }
-  }
-  features_missing.clear_feature(CPU_PACA);
-  features_missing.clear_feature(CPU_NOTPACA);
+
 #endif // __aarch64__
 
   if (!features_missing.empty()) {

--- a/src/hotspot/share/runtime/abstract_vm_version.inline.hpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.inline.hpp
@@ -279,8 +279,21 @@ void VM_Version::cpu_features_init() {
 
   VM_Features CPUFeatures_parsed = CPUFeatures_parse(CPUFeatures);
   VM_Features features_missing = CPUFeatures_parsed & ~_features;
-
   features_missing = features_missing.aot_code_cache_features();
+
+#ifdef __aarch64__
+  if (!FLAG_IS_DEFAULT(UsePAC)) {
+    if (UsePAC) {
+      CPUFeatures_parsed.set_feature(CPU_PACA);
+      CPUFeatures_parsed.clear_feature(CPU_NOTPACA);
+    } else {
+      CPUFeatures_parsed.set_feature(CPU_NOTPACA);
+      CPUFeatures_parsed.clear_feature(CPU_PACA);
+    }
+  }
+  features_missing.clear_feature(CPU_PACA);
+  features_missing.clear_feature(CPU_NOTPACA);
+#endif // __aarch64__
 
   if (!features_missing.empty()) {
     stringStream ss;

--- a/src/hotspot/share/runtime/abstract_vm_version.inline.hpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.inline.hpp
@@ -282,9 +282,6 @@ void VM_Version::cpu_features_init() {
   features_missing = features_missing.aot_code_cache_features();
 
   CPUFeatures_apply_arch(CPUFeatures_parsed, features_missing);
-#ifdef __aarch64__
-
-#endif // __aarch64__
 
   if (!features_missing.empty()) {
     stringStream ss;

--- a/src/java.base/share/native/launcher/main.c
+++ b/src/java.base/share/native/launcher/main.c
@@ -340,7 +340,7 @@ main(int argc, char **argv)
         }
         margv[i] = NULL;
     }
-#else /* *NIXES */
+#else /* if !_WIN32 */
     {
         // accommodate the NULL at the end
         JLI_List args = JLI_List_new(argc + 1);
@@ -453,7 +453,6 @@ main(int argc, char **argv)
             return 1;
         }
     }
-    #endif /* not WIN32 */
 #ifdef __aarch64__
     bool disable_pac = should_disable_pointer_authentication();
     if (disable_pac) {
@@ -466,7 +465,8 @@ main(int argc, char **argv)
         }
     }
 #endif // __aarch64__
-#endif /* LINUX */
+#endif // LINUX
+#endif // !_WIN32
     int exit_code = JLI_Launch(margc, margv,
                    jargc, jargs,
                    0, NULL,

--- a/src/java.base/share/native/launcher/main.c
+++ b/src/java.base/share/native/launcher/main.c
@@ -111,6 +111,7 @@ static bool is_restore = false;
 static const int crac_min_pid_default = 128;
 static int crac_min_pid = 0;
 static bool is_min_pid_set = false;
+static bool disable_pac = false;
 
 static inline const char *find_option(const char *arg, const char *vmoption) {
     const int len = strlen(vmoption);
@@ -121,18 +122,39 @@ static inline const char *find_option(const char *arg, const char *vmoption) {
 }
 
 static void parse_crac(const char *arg) {
+    const char *value;
     if (!is_checkpoint && find_option(arg, "-XX:CRaCCheckpointTo")) {
         is_checkpoint = true;
     } else if (!is_restore && find_option(arg, "-XX:CRaCRestoreFrom")) {
         is_restore = true;
-    } else if (!is_min_pid_set) {
-        const char *value = find_option(arg, "-XX:CRaCMinPid=");
-        if (value != NULL) {
-            crac_min_pid = atoi(value);
-            is_min_pid_set = true;
-        }
+    } else if (!is_min_pid_set && (value = find_option(arg, "-XX:CRaCMinPid=")) != NULL) {
+        crac_min_pid = atoi(value);
+        is_min_pid_set = true;
+#ifdef __aarch64__
+    } else if (find_option(arg, "-XX:-UsePAC")) {
+        disable_pac = true;
+#endif // aarch64
     }
 }
+
+#if defined(LINUX) && defined(__aarch64__)
+#include <sys/prctl.h>
+#ifndef PR_PAC_SET_ENABLED_KEYS
+#define PR_PAC_SET_ENABLED_KEYS 60
+#endif // PR_PAC_SET_ENABLED_KEYS
+#ifndef PR_PAC_APIAKEY
+#define PR_PAC_APIAKEY			(1UL << 0)
+#define PR_PAC_APIBKEY			(1UL << 1)
+#define PR_PAC_APDAKEY			(1UL << 2)
+#define PR_PAC_APDBKEY			(1UL << 3)
+#endif // PR_PAC_APIKEY
+
+bool should_disable_pointer_authentication() {
+    // We need to disable both on checkpoint and restore
+    // Add code here if CRaCEngine cannot restore PAC
+    return disable_pac;
+}
+#endif // LINUX && __aarch64__
 
 static pid_t g_child_pid = -1;
 
@@ -429,9 +451,21 @@ main(int argc, char **argv)
             return 1;
         }
     }
+    #endif /* not WIN32 */
+#ifdef __aarch64__
+    bool disable_pac = should_disable_pointer_authentication();
+    if (disable_pac) {
+        // PR_PAC_APGAKEY cannot be disabled through this syscall
+        if (prctl(PR_PAC_SET_ENABLED_KEYS, PR_PAC_APIAKEY | PR_PAC_APIBKEY | PR_PAC_APDAKEY | PR_PAC_APDBKEY, 0, 0, 0)) {
+            if (errno != EINVAL) { // Systems without PAC support return EINVAL
+                perror("prctl PR_PAC_SET_ENABLED_KEYS");
+                return 1;
+            }
+        }
+    }
+#endif // __aarch64__
 #endif /* LINUX */
-#endif /* not WIN32 */
-    return JLI_Launch(margc, margv,
+    int exit_code = JLI_Launch(margc, margv,
                    jargc, jargs,
                    0, NULL,
                    VERSION_STRING,
@@ -440,4 +474,8 @@ main(int argc, char **argv)
                    launcher,
                    jargc > 0,
                    cpwildcard, javaw, 0);
+    // If pointer authentication is used on aarch64 we must not return from
+    // current frame, we would get SIGILL.
+    exit(exit_code);
+    return exit_code;
 }

--- a/src/java.base/share/native/launcher/main.c
+++ b/src/java.base/share/native/launcher/main.c
@@ -111,7 +111,9 @@ static bool is_restore = false;
 static const int crac_min_pid_default = 128;
 static int crac_min_pid = 0;
 static bool is_min_pid_set = false;
+#ifdef __aarch64__
 static bool disable_pac = false;
+#endif // __aarch64__
 
 static inline const char *find_option(const char *arg, const char *vmoption) {
     const int len = strlen(vmoption);
@@ -143,10 +145,10 @@ static void parse_crac(const char *arg) {
 #define PR_PAC_SET_ENABLED_KEYS 60
 #endif // PR_PAC_SET_ENABLED_KEYS
 #ifndef PR_PAC_APIAKEY
-#define PR_PAC_APIAKEY			(1UL << 0)
-#define PR_PAC_APIBKEY			(1UL << 1)
-#define PR_PAC_APDAKEY			(1UL << 2)
-#define PR_PAC_APDBKEY			(1UL << 3)
+#define PR_PAC_APIAKEY (1UL << 0)
+#define PR_PAC_APIBKEY (1UL << 1)
+#define PR_PAC_APDAKEY (1UL << 2)
+#define PR_PAC_APDBKEY (1UL << 3)
 #endif // PR_PAC_APIKEY
 
 bool should_disable_pointer_authentication() {

--- a/src/java.base/share/native/launcher/main.c
+++ b/src/java.base/share/native/launcher/main.c
@@ -111,9 +111,9 @@ static bool is_restore = false;
 static const int crac_min_pid_default = 128;
 static int crac_min_pid = 0;
 static bool is_min_pid_set = false;
-#ifdef __aarch64__
+#if defined(LINUX) && defined(__aarch64__)
 static bool disable_pac = false;
-#endif // __aarch64__
+#endif // LINUX && __aarch64__
 
 static inline const char *find_option(const char *arg, const char *vmoption) {
     const int len = strlen(vmoption);
@@ -132,10 +132,10 @@ static void parse_crac(const char *arg) {
     } else if (!is_min_pid_set && (value = find_option(arg, "-XX:CRaCMinPid=")) != NULL) {
         crac_min_pid = atoi(value);
         is_min_pid_set = true;
-#ifdef __aarch64__
+#if defined(LINUX) && defined(__aarch64__)
     } else if (find_option(arg, "-XX:-UsePAC")) {
         disable_pac = true;
-#endif // aarch64
+#endif // LINUX && __aarch64__
     }
 }
 

--- a/src/java.base/share/native/launcher/main.c
+++ b/src/java.base/share/native/launcher/main.c
@@ -454,8 +454,7 @@ main(int argc, char **argv)
         }
     }
 #ifdef __aarch64__
-    bool disable_pac = should_disable_pointer_authentication();
-    if (disable_pac) {
+    if (should_disable_pointer_authentication()) {
         // PR_PAC_APGAKEY cannot be disabled through this syscall
         if (prctl(PR_PAC_SET_ENABLED_KEYS, PR_PAC_APIAKEY | PR_PAC_APIBKEY | PR_PAC_APDAKEY | PR_PAC_APDBKEY, 0, 0, 0)) {
             if (errno != EINVAL) { // Systems without PAC support return EINVAL

--- a/test/jdk/jdk/crac/CPUFeatures/PointerAuthenticationTest.java
+++ b/test/jdk/jdk/crac/CPUFeatures/PointerAuthenticationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Azul Systems, 385 Moffett Park Drive, Suite 115, Sunnyvale
+ * CA 94089 USA or visit www.azul.com if you need additional information or
+ * have any questions.
+ */
+import jdk.crac.management.CRaCMXBean;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+
+/*
+ * @test id=HAS_PACA
+ * @requires (os.family == "linux")
+ * @requires (os.arch == "aarch64" & vm.cpu.features ~= ".*\bpaca\b.*")
+ * @library /test/lib
+ * @build PointerAuthenticationTest
+ * @run driver jdk.test.lib.crac.CracTest     - true  pass
+ * @run driver jdk.test.lib.crac.CracTest     - false fail
+ * @run driver jdk.test.lib.crac.CracTest true      - pass
+ * @run driver jdk.test.lib.crac.CracTest false     - fail
+ * @run driver jdk.test.lib.crac.CracTest false true  fail
+ * @run driver jdk.test.lib.crac.CracTest false false pass
+ * @run driver jdk.test.lib.crac.CracTest true  true  pass
+ * @run driver jdk.test.lib.crac.CracTest true  false fail
+ */
+/*
+ * @test id=NO_PACA
+ * @requires (os.family == "linux")
+ * @requires (os.arch == "aarch64" & vm.cpu.features ~= ".*notpaca.*")
+ * @library /test/lib
+ * @build PointerAuthenticationTest
+ * @run driver jdk.test.lib.crac.CracTest     - true  fail
+ * @run driver jdk.test.lib.crac.CracTest     - false pass
+ * @run driver jdk.test.lib.crac.CracTest true      - fail
+ * @run driver jdk.test.lib.crac.CracTest false     - pass
+ * @run driver jdk.test.lib.crac.CracTest false true  fail
+ * @run driver jdk.test.lib.crac.CracTest false false pass
+ */
+public class PointerAuthenticationTest implements CracTest {
+
+    @CracTestArg(0)
+    String useBefore;
+
+    @CracTestArg(1)
+    String useAfter;
+
+    @CracTestArg(2)
+    String result;
+
+    private CracBuilder setUsePAC(CracBuilder builder, String use) {
+        return switch (use) {
+            case "-" -> builder;
+            case "true" -> builder.vmOption("-XX:+UsePAC");
+            case "false" -> builder.vmOption("-XX:-UsePAC");
+            case null, default -> throw new IllegalArgumentException(use);
+        };
+    }
+
+    @Override
+    public void test() throws Exception {
+        setUsePAC(new CracBuilder(), useBefore).doCheckpoint();
+        var rst = setUsePAC(new CracBuilder(), useAfter).doRestoreToAnalyze();
+        switch (result) {
+            case "pass" -> rst.shouldHaveExitValue(0);
+            case "fail" -> rst.shouldHaveExitValue(1)
+                    .stdoutShouldContain("Restore failed due to incompatible aarch64 CPU feature PACA");
+            case "crash" -> rst.shouldHaveExitValue(132); // SIGILL
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        CRaCMXBean.getCRaCMXBean().checkpointRestore();
+    }
+}


### PR DESCRIPTION
By default aarch64 machines that implement Pointer Authentication harden the security by in-kernel signing of stack pointers. Since the key used for signing cannot be introspected (by design), this could cause problems to some CRaC engines.

Let's add `-XX:-UsePAC` that will disable Pointer Authentication in launcher. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8385923](https://bugs.openjdk.org/browse/JDK-8385923): [CRaC] Option to disable pointer authentication (**Enhancement** - P4)


### Reviewers
 * [Timofei Pushkin](https://openjdk.org/census#tpushkin) (@TimPushkin - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/322/head:pull/322` \
`$ git checkout pull/322`

Update a local copy of the PR: \
`$ git checkout pull/322` \
`$ git pull https://git.openjdk.org/crac.git pull/322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 322`

View PR using the GUI difftool: \
`$ git pr show -t 322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/322.diff">https://git.openjdk.org/crac/pull/322.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/322#issuecomment-4629456262)
</details>
