### PR TITLE
8386599: [CRaC] jdk/crac/java/net/InetAddress/ResolveTest sometimes fails with container name conflict

### DIFF
--- a/test/lib/jdk/test/lib/crac/CracContainerBuilder.java
+++ b/test/lib/jdk/test/lib/crac/CracContainerBuilder.java
@@ -261,11 +261,13 @@ public class CracContainerBuilder extends CracBuilderBase<CracContainerBuilder> 
         DockerTestUtils.execute(Container.ENGINE_COMMAND, "kill", CONTAINER_NAME).getExitValue();
 
         // Docker needs some time to remove a container after kill
-        OutputAnalyzer oa;
-        do {
-            oa = DockerTestUtils.execute(Container.ENGINE_COMMAND, "ps");
-            oa.getExitValue();
-        } while (oa.getStdout().contains(CONTAINER_NAME));
+        while (
+            DockerTestUtils.execute(
+                Container.ENGINE_COMMAND, "inspect", "--type=container", CONTAINER_NAME
+            ).getExitValue() == 0
+        ) {
+            Thread.onSpinWait();
+        }
 
         List<String> cmd = prepareContainerCommand(imageName, List.of(options));
         System.err.println("Recreating docker container:\n" + String.join(" ", cmd));


### PR DESCRIPTION
A possible reason for the issue is that `docker ps` only lists running containers, so it is not sufficient for waiting until a container is removed. A stopped container would not be listed even though it still occupies the name.

`docker ps --all` would suffice, but I switched to `docker inspect` instead because it does not require parsing the output.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8386599](https://bugs.openjdk.org/browse/JDK-8386599): [CRaC] jdk/crac/java/net/InetAddress/ResolveTest sometimes fails with container name conflict (**Bug** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/323/head:pull/323` \
`$ git checkout pull/323`

Update a local copy of the PR: \
`$ git checkout pull/323` \
`$ git pull https://git.openjdk.org/crac.git pull/323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 323`

View PR using the GUI difftool: \
`$ git pr show -t 323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/323.diff">https://git.openjdk.org/crac/pull/323.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/323#issuecomment-4692268240)
</details>
