### PR TITLE
8386890: [CRaC] Drop deprecated aliases of bundled engines

### DIFF
--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -1597,7 +1597,7 @@ static void signal_sets_init() {
 #ifdef LINUX
   // The signal is used with default simengine and criuengine library, other CRaCEngines might use
   // signals in a different way and having this signal blocked could interfere.
-  const char *signal_engines[] = { "criu", "criuengine", "sim", "simengine", "pause", "pauseengine", nullptr };
+  const char *signal_engines[] = { "criuengine", "simengine", nullptr };
   for (int i = 0; signal_engines[i] != nullptr; ++i) {
     if (strcmp(CRaCEngine, signal_engines[i]) == 0) {
       sigaddset(&blocked_sigs, RESTORE_SIGNAL);

--- a/src/hotspot/share/runtime/crac_engine.cpp
+++ b/src/hotspot/share/runtime/crac_engine.cpp
@@ -33,10 +33,12 @@
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"
 #include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/hashTable.hpp"
-#include "utilities/macros.hpp"
+#ifdef _WINDOWS
 #include "utilities/stringUtils.hpp"
+#endif // _WINDOWS
 
 #include <cstddef>
 #include <cstring>
@@ -53,108 +55,69 @@ static constexpr const char * const vm_controlled_engine_opts[] = {
 
 #define DEFINE_OPT_VAR(opt) static constexpr const char engine_opt_##opt[] = #opt;
 VM_CONTROLLED_ENGINE_OPTS(DEFINE_OPT_VAR)
-
-DEFINE_OPT_VAR(pause)
 #undef DEFINE_OPT_VAR
 
-#define SIMENGINE "simengine"
-
-#ifdef LINUX
-static bool is_pauseengine() {
-  assert(JDK_Version::current().major_version() < 28, "pauseengine shall be expired in JDK 28");
-  return !strcmp(CRaCEngine, "pause") || !strcmp(CRaCEngine, "pauseengine");
-}
-#endif // LINUX
-
-static bool find_engine(const char *dll_dir, char *path, size_t path_size, char *resolved_engine, size_t resolved_engine_size) {
+static bool find_engine(const char *dll_dir, char *path, size_t path_size, char *name, size_t name_size) {
   const size_t engine_length = strlen(CRaCEngine);
+  if (engine_length == 0) {
+    log_error(crac)("CRaCEngine is empty");
+    return false;
+  }
+
   // Try to interpret as a file path
   if (os::is_path_absolute(CRaCEngine)) {
-    if (engine_length + 1 > path_size) {
+    const char *last_slash = strrchr(CRaCEngine, *os::file_separator());
+    const char *basename = last_slash == nullptr ? CRaCEngine : last_slash + strlen(os::file_separator());
+    const size_t basename_length = strlen(basename);
+    if (basename_length <= strlen(JNI_LIB_PREFIX) + strlen(JNI_LIB_SUFFIX) ||
+        strncmp(basename, JNI_LIB_PREFIX, strlen(JNI_LIB_PREFIX)) != 0 ||
+        strcmp(CRaCEngine + engine_length - strlen(JNI_LIB_SUFFIX), JNI_LIB_SUFFIX) != 0) {
+      log_error(crac)("CRaCEngine=%s is not a library: expected " JNI_LIB_PREFIX "<name>" JNI_LIB_SUFFIX, CRaCEngine);
+      return false;
+    }
+
+    if (engine_length >= path_size) {
       log_error(crac)("CRaCEngine file path is too long: %s", CRaCEngine);
       return false;
     }
+    memcpy(path, CRaCEngine, engine_length + 1);
+
+    const size_t name_length = basename_length - strlen(JNI_LIB_PREFIX) - strlen(JNI_LIB_SUFFIX);
+    if (name_length >= name_size) {
+      log_error(crac)("CRaCEngine file name is too long: %s", basename);
+      return false;
+    }
+    memcpy(name, basename + strlen(JNI_LIB_PREFIX), name_length);
+    name[name_length] = '\0';
 
     if (!os::file_exists(CRaCEngine)) {
       log_error(crac)("CRaCEngine file does not exist: %s", CRaCEngine);
       return false;
     }
 
-    strcpy(path, CRaCEngine);
-
-    const char *last_slash = strrchr(CRaCEngine, *os::file_separator());
-    const char *basename;
-    if (last_slash == nullptr) {
-      basename = CRaCEngine;
-    } else {
-      basename = last_slash + strlen(os::file_separator());
-    }
-    if (strlen(basename) <= strlen(JNI_LIB_PREFIX) + strlen(JNI_LIB_SUFFIX) ||
-        strncmp(basename, JNI_LIB_PREFIX, strlen(JNI_LIB_PREFIX)) ||
-        strcmp(CRaCEngine + engine_length - strlen(JNI_LIB_SUFFIX), JNI_LIB_SUFFIX)) {
-      log_error(crac)("CRaCEngine=%s is not a library: expected " JNI_LIB_PREFIX "<name>" JNI_LIB_SUFFIX, CRaCEngine);
-      return false;
-    }
-
-    size_t engine_name_length = strlen(basename) - strlen(JNI_LIB_PREFIX) - strlen(JNI_LIB_SUFFIX);
-    if (engine_name_length < resolved_engine_size) {
-      memcpy(resolved_engine, basename + strlen(JNI_LIB_PREFIX), engine_name_length);
-      resolved_engine[engine_name_length] = '\0';
-      log_debug(crac)("Found CRaCEngine %s in %s", resolved_engine, CRaCEngine);
-      return true;
-    } else {
-      log_error(crac)("CRaCEngine name is too long: %s", basename);
-      return false;
-    }
+    log_debug(crac)("Found CRaCEngine %s in %s", name, CRaCEngine);
+    return true;
   }
 
-#ifdef LINUX
-  if (is_pauseengine()) {
-    assert(sizeof(SIMENGINE) <= resolved_engine_size, "must be");
-    memcpy(resolved_engine, SIMENGINE, sizeof(SIMENGINE));
-    log_warning(crac)("-XX:CRaCEngine=pause/pauseengine is deprecated and will be removed in version 28; use -XX:CRaCEngine=simengine -XX:CRaCEngineOptions=pause=true");
-  } else /* intentional line break */
-#endif // LINUX
-  if (engine_length == 0) {
-    log_error(crac)("CRaCEngine is empty");
-    return false;
-  } else if (engine_length < resolved_engine_size) {
-    memcpy(resolved_engine, CRaCEngine, engine_length);
-    resolved_engine[engine_length] = '\0';
-  } else {
+  // Try to interpret as a name of a bundled engine
+
+  if (engine_length >= name_size) {
     log_error(crac)("CRaCEngine name is too long: %s", CRaCEngine);
     return false;
   }
+  memcpy(name, CRaCEngine, engine_length);
+  name[engine_length] = '\0';
+  log_debug(crac)("Resolved engine name '%s'", name);
 
   if (is_vm_statically_linked()) {
-    if (!strcmp("sim", resolved_engine)) {
-      assert(sizeof(SIMENGINE) <= resolved_engine_size, "must be");
-      assert(JDK_Version::current().major_version() < 28, "shall be expired in JDK 28");
-      memcpy(resolved_engine, SIMENGINE, sizeof(SIMENGINE));
-      log_warning(crac)("Engine name '%s' (without the engine suffix) is deprecated and will be removed in version 28, please use -XX:CRaCEngine=%s", CRaCEngine, resolved_engine);
-    }
-    log_debug(crac)("VM is statically linked, not doing any library lookup");
-    os::jvm_path(path, static_cast<jint>(path_size)); // points to bin/java for static JDK
+    log_debug(crac)("VM is statically linked, not doing library lookup for bundled engines");
+    path[0] = '\0'; // Means look inside the JVM
     return true;
   }
 
-  log_debug(crac)("Resolved engine name '%s'", resolved_engine);
-  // Try to interpret as a library name
-  if (os::dll_locate_lib(path, path_size, dll_dir, resolved_engine)) {
-    log_debug(crac)("Found CRaCEngine %s in %s", resolved_engine, path);
+  if (os::dll_locate_lib(path, path_size, dll_dir, name)) {
+    log_debug(crac)("Found CRaCEngine %s in %s", name, path);
     return true;
-  }
-  // Alternative for engines without the `engine` suffix.
-  // Let's just skip it with weird long engine parameter.
-  // Note: resource mark allocation is not possible here (too early in JVM boot)
-  if (strlen(CRaCEngine) + strlen("engine") + 1 <= resolved_engine_size) {
-    os::snprintf_checked(resolved_engine, resolved_engine_size, "%sengine", CRaCEngine);
-    if (os::dll_locate_lib(path, path_size, dll_dir, resolved_engine)) {
-      assert(JDK_Version::current().major_version() < 28, "shall be expired in JDK 28");
-      log_debug(crac)("Found CRaCEngine %s in %s", resolved_engine, path);
-      log_warning(crac)("Engine name '%s' (without the engine suffix) is deprecated and will be removed in version 28, please use -XX:CRaCEngine=%s", CRaCEngine, resolved_engine);
-      return true;
-    }
   }
 
   log_error(crac)("Did not find CRaCEngine %s in %s", CRaCEngine, dll_dir);
@@ -192,17 +155,6 @@ static crlib_conf_t *create_conf(const crlib_api_t &api, bool for_restore) {
   if (CRaCEngineOptions != nullptr && (!strcmp(CRaCEngineOptions, "help") || !strncmp(CRaCEngineOptions, "help=", 5))) {
     return conf;
   }
-
-#ifdef LINUX
-  if (is_pauseengine()) {
-    guarantee(api.can_configure(conf, engine_opt_pause), "simengine must support option 'pause'");
-    if (!api.configure(conf, engine_opt_pause, "true")) {
-      log_error(crac)("simengine failed to configure: '%s' = 'true'", engine_opt_pause);
-      api.destroy_conf(conf);
-      return nullptr;
-    }
-  }
-#endif // LINUX
 
   const char *extra_options = for_restore ? CRaCRestoreEngineOptions : CRaCCheckpointEngineOptions;
   const size_t main_options_len = CRaCEngineOptions != nullptr ? strlen(CRaCEngineOptions) : 0;
@@ -266,6 +218,20 @@ static crlib_conf_t *create_conf(const crlib_api_t &api, bool for_restore) {
   return conf;
 }
 
+class DllGuard {
+private:
+  void* _dll;
+public:
+  DllGuard(void* dll) : _dll(dll) {}
+  ~DllGuard() {
+    if (_dll != nullptr) {
+      os::dll_unload(_dll);
+    }
+  }
+  NONCOPYABLE(DllGuard);
+  void deactivate() { _dll = nullptr; }
+};
+
 CracEngine::CracEngine(bool for_restore) {
   if (CRaCEngine == nullptr) {
     log_error(crac)("CRaCEngine must not be empty");
@@ -292,60 +258,46 @@ CracEngine::CracEngine(bool for_restore) {
   }
 
   char path[JVM_MAXPATHLEN];
-  // In static builds the name of API entry function may differ
-  char resolved_engine_func[sizeof(CRLIB_API_FUNC) + MAX_ENGINE_LENGTH];
-  memcpy(resolved_engine_func, CRLIB_API_FUNC, sizeof(CRLIB_API_FUNC));
-  if (is_vm_statically_linked()) {
-    resolved_engine_func[sizeof(CRLIB_API_FUNC) - 1] = '_';
-  }
-
   if (!find_engine(dll_dir, path, sizeof(path), _name, sizeof(_name))) {
     log_error(crac)("Cannot find CRaC engine %s", CRaCEngine);
     return;
   }
   postcond(_name[0] != '\0');
-  postcond(path[0] != '\0');
-  memcpy(resolved_engine_func + sizeof(CRLIB_API_FUNC), _name, strlen(_name) + 1);
 
-  char error_buf[1024];
-  void * const lib = is_vm_statically_linked() ? os::get_default_process_handle() : os::dll_load(path, error_buf, sizeof(error_buf));
-  if (lib == nullptr) {
-    log_error(crac)("Cannot load CRaC engine library from %s: %s", path, error_buf);
-    return;
-  }
-
-  using api_func_t = decltype(&CRLIB_API);
-  auto api_func = reinterpret_cast<api_func_t>(os::dll_lookup(lib, resolved_engine_func));
-  if (api_func == nullptr) {
-    if (is_vm_statically_linked()) {
-      log_warning(crac)("Cannot load CRaC engine API entrypoint '%s' from %s", resolved_engine_func, path);
-      // Maybe the deprecated short name was used, in that case find_engine did not amend the 'engine'
-      assert(JDK_Version::current().major_version() < 28, "shall be expired in JDK 28");
-      static constexpr const char engine_suffix[] = "engine";
-      if (strlen(resolved_engine_func) + sizeof(engine_suffix) <= sizeof(resolved_engine_func)) {
-        strcat(resolved_engine_func, engine_suffix);
-        // resolved_engine_func should be concat(CRLIB_API_FUNC, _name) so the check above should already do
-        assert(strlen(_name) + sizeof(engine_suffix) <= sizeof(_name), "name too long");
-        strcat(_name, engine_suffix);
-        api_func = reinterpret_cast<api_func_t>(os::dll_lookup(lib, resolved_engine_func));
-        if (api_func != nullptr) {
-          log_warning(crac)("Engine name '%s' (without the engine suffix) is deprecated and will be removed in version 28, please use -XX:CRaCEngine=%s",
-            CRaCEngine, resolved_engine_func + sizeof(CRLIB_API_FUNC));
-        }
-      }
-    }
-    if (api_func == nullptr) {
-      log_error(crac)("Cannot load CRaC engine API entrypoint '%s' from %s", resolved_engine_func, path);
-      os::dll_unload(lib);
+  // Empty path means the engine is bundled inside the JVM (normally the case of static JVM build).
+  // In such case its API function has a suffix to avoid name conflicts among bundled engines.
+  void* lib;
+  char api_func_name[sizeof(CRLIB_API_FUNC) + MAX_ENGINE_LENGTH];
+  memcpy(api_func_name, CRLIB_API_FUNC, sizeof(CRLIB_API_FUNC));
+  if (path[0] != '\0') {
+    char error_buf[1024];
+    lib = os::dll_load(path, error_buf, sizeof(error_buf));
+    if (lib == nullptr) {
+      log_error(crac)("Cannot load CRaC engine library %s: %s", path, error_buf);
       return;
     }
+  } else {
+    lib = os::get_default_process_handle();
+    if (lib == nullptr) {
+      log_error(crac)("Cannot get process handle of self");
+      return;
+    }
+    api_func_name[sizeof(CRLIB_API_FUNC) - 1] = '_';
+    memcpy(api_func_name + sizeof(CRLIB_API_FUNC), _name, strlen(_name) + 1);
+  }
+  DllGuard lib_guard(lib);
+
+  using api_func_t = decltype(&CRLIB_API);
+  const auto api_func = reinterpret_cast<api_func_t>(os::dll_lookup(lib, api_func_name));
+  if (api_func == nullptr) {
+    log_error(crac)("Cannot load CRaC engine API entrypoint '%s' from %s", api_func_name, path[0] != '\0' ? path : "the JVM");
+    return;
   }
 
   crlib_api_t * const api = api_func(CRLIB_API_VERSION, sizeof(crlib_api_t));
   if (api == nullptr) {
     log_error(crac)("CRaC engine failed to initialize its API (version %i). "
                     "Maybe this version is not supported?", CRLIB_API_VERSION);
-    os::dll_unload(lib);
     return;
   }
   if (api->create_conf == nullptr || api->destroy_conf == nullptr ||
@@ -353,16 +305,15 @@ CracEngine::CracEngine(bool for_restore) {
       api->can_configure == nullptr || api->configure == nullptr ||
       api->get_extension == nullptr) {
     log_error(crac)("CRaC engine provided invalid API");
-    os::dll_unload(lib);
     return;
   }
 
   crlib_conf_t * const conf = create_conf(*api, for_restore);
   if (conf == nullptr) {
-    os::dll_unload(lib);
     return;
   }
 
+  lib_guard.deactivate();
   _lib = lib;
   _api = api;
   _conf = conf;

--- a/test/jdk/jdk/crac/CheckpointRestorePathTest.java
+++ b/test/jdk/jdk/crac/CheckpointRestorePathTest.java
@@ -23,9 +23,7 @@
  * questions.
  */
 
-import jdk.crac.Core;
 import jdk.crac.management.CRaCMXBean;
-import jdk.test.lib.Platform;
 import jdk.test.lib.crac.CracBuilder;
 import jdk.test.lib.crac.CracEngine;
 import jdk.test.lib.crac.CracTest;
@@ -94,14 +92,14 @@ public class CheckpointRestorePathTest implements CracTest {
     void testRestoreEmpty() throws Exception {
         // Empty CRaCRestoreFrom should result in default java usage output
         // as if the VM option was missing (we won't test that case)
-        new CracBuilder().engine(CracEngine.PAUSE).imageDir("")
+        new CracBuilder().engine(CracEngine.SIMULATE).engineOptions("pause=true").imageDir("")
                 .doRestoreToAnalyze()
                 .shouldHaveExitValue(1)
                 .stderrShouldContain("Usage: java");
     }
 
     void testRestoreNoDir() throws Exception {
-        new CracBuilder().engine(CracEngine.PAUSE).imageDir(NON_EXISTENT_CR)
+        new CracBuilder().engine(CracEngine.SIMULATE).engineOptions("pause=true").imageDir(NON_EXISTENT_CR)
                 .doRestoreToAnalyze()
                 .shouldHaveExitValue(1)
                 .stdoutShouldContain("Cannot open CRaCRestoreFrom=" + NON_EXISTENT_CR)
@@ -117,7 +115,7 @@ public class CheckpointRestorePathTest implements CracTest {
     }
 
     void testRestoreNoImage(boolean skipMetadataChecks, String errMessage) throws Exception {
-        CracBuilder builder = new CracBuilder().engine(CracEngine.PAUSE);
+        CracBuilder builder = new CracBuilder().engine(CracEngine.SIMULATE).engineOptions("pause=true");
         if (builder.imageDir().toFile().exists()) {
             FileUtils.deleteFileTreeWithRetry(builder.imageDir());
         }

--- a/test/jdk/jdk/crac/VMOptionsTest.java
+++ b/test/jdk/jdk/crac/VMOptionsTest.java
@@ -26,7 +26,6 @@ import com.sun.management.VMOption;
 
 import jdk.crac.*;
 import jdk.crac.management.CRaCMXBean;
-import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 import jdk.test.lib.crac.CracBuilder;
 import jdk.test.lib.crac.CracTest;
@@ -34,7 +33,6 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -94,7 +92,6 @@ public class VMOptionsTest implements CracTest {
     };
 
     private static final List<VMOptionSpec> OPTIONS_CHECKPOINT = List.of(
-        VMOptionSpec.ofStr("CRaCEngine", bundledEnginePath("criuengine"), false),
         VMOptionSpec.ofStr("CRaCEngineOptions", "args=-v1", false),
         VMOptionSpec.ofStr("CRaCCheckpointEngineOptions", "print_command=false", false),
         VMOptionSpec.ofStr("CRaCCheckpointTo", new CracBuilder().imageDir().toString(), true),
@@ -109,18 +106,9 @@ public class VMOptionsTest implements CracTest {
         VMOptionSpec.ofBool("UnlockExperimentalVMOptions", true, true)
     );
 
-    private static String bundledEnginePath(String engineName) {
-        if (Platform.isStatic()) {
-            return engineName; // In static builds Bundled engines are built into the JVM and cannot be loaded via a path
-        }
-        final var path = Path.of(Utils.TEST_JDK, Platform.isWindows() ? "bin" : "lib", System.mapLibraryName(engineName)).toAbsolutePath();
-        assertTrue(Files.exists(path), "Cannot find bundled engine " + engineName + ": " + path + " does not exist");
-        return path.toString();
-    }
-
     @Override
     public void test() throws Exception {
-        final var builder = new CracBuilder().javaOption("test.jdk", Utils.TEST_JDK); // Makes TEST_JDK available in exec
+        final var builder = new CracBuilder();
         setVmOptions(builder, OPTIONS_CHECKPOINT);
         builder.doCheckpoint();
 

--- a/test/jdk/jdk/crac/VMOptionsTest.java
+++ b/test/jdk/jdk/crac/VMOptionsTest.java
@@ -26,6 +26,7 @@ import com.sun.management.VMOption;
 
 import jdk.crac.*;
 import jdk.crac.management.CRaCMXBean;
+import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 import jdk.test.lib.crac.CracBuilder;
 import jdk.test.lib.crac.CracTest;
@@ -33,6 +34,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -92,7 +94,7 @@ public class VMOptionsTest implements CracTest {
     };
 
     private static final List<VMOptionSpec> OPTIONS_CHECKPOINT = List.of(
-        VMOptionSpec.ofStr("CRaCEngine", "criu", false),
+        VMOptionSpec.ofStr("CRaCEngine", bundledEnginePath("criuengine"), false),
         VMOptionSpec.ofStr("CRaCEngineOptions", "args=-v1", false),
         VMOptionSpec.ofStr("CRaCCheckpointEngineOptions", "print_command=false", false),
         VMOptionSpec.ofStr("CRaCCheckpointTo", new CracBuilder().imageDir().toString(), true),
@@ -107,9 +109,18 @@ public class VMOptionsTest implements CracTest {
         VMOptionSpec.ofBool("UnlockExperimentalVMOptions", true, true)
     );
 
+    private static String bundledEnginePath(String engineName) {
+        if (Platform.isStatic()) {
+            return engineName; // In static builds Bundled engines are built into the JVM and cannot be loaded via a path
+        }
+        final var path = Path.of(Utils.TEST_JDK, Platform.isWindows() ? "bin" : "lib", System.mapLibraryName(engineName)).toAbsolutePath();
+        assertTrue(Files.exists(path), "Cannot find bundled engine " + engineName + ": " + path + " does not exist");
+        return path.toString();
+    }
+
     @Override
     public void test() throws Exception {
-        final var builder = new CracBuilder();
+        final var builder = new CracBuilder().javaOption("test.jdk", Utils.TEST_JDK); // Makes TEST_JDK available in exec
         setVmOptions(builder, OPTIONS_CHECKPOINT);
         builder.doCheckpoint();
 

--- a/test/jdk/jdk/crac/engine/CheckCPUFeaturesMessageTest.java
+++ b/test/jdk/jdk/crac/engine/CheckCPUFeaturesMessageTest.java
@@ -26,11 +26,8 @@ import jdk.test.lib.Utils;
 import jdk.test.lib.crac.CracBuilder;
 import jdk.test.lib.crac.CracEngine;
 import jdk.test.lib.crac.CracTest;
-import jdk.test.lib.crac.CracTestArg;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.util.FileUtils;
-
-import java.lang.reflect.Method;
 
 /*
  * @test
@@ -78,7 +75,7 @@ public class CheckCPUFeaturesMessageTest implements CracTest {
     @Override
     public void test() throws Exception {
         CracBuilder builder = new CracBuilder()
-                .engine(CracEngine.PAUSE)
+                .engine(CracEngine.SIMULATE).engineOptions("pause=true")
                 .vmOption("-XX:CPUFeatures=generic");
         if (builder.imageDir().toFile().exists()) {
             FileUtils.deleteFileTreeWithRetry(builder.imageDir());

--- a/test/jdk/jdk/crac/engine/CheckCPUFeaturesTest.java
+++ b/test/jdk/jdk/crac/engine/CheckCPUFeaturesTest.java
@@ -67,7 +67,7 @@ public class CheckCPUFeaturesTest implements CracTest {
             success = success || "fail-x86".equals(result);
         }
 
-        CracBuilder builder = new CracBuilder().engine(CracEngine.PAUSE);
+        CracBuilder builder = new CracBuilder().engine(CracEngine.SIMULATE).engineOptions("pause=true");
         if (builder.imageDir().toFile().exists()) {
             FileUtils.deleteFileTreeWithRetry(builder.imageDir());
         }

--- a/test/jdk/jdk/crac/engine/SimenginePauseTest.java
+++ b/test/jdk/jdk/crac/engine/SimenginePauseTest.java
@@ -39,7 +39,7 @@ public class SimenginePauseTest implements CracTest {
 
     @Override
     public void test() throws Exception {
-        final CracBuilder builder = new CracBuilder().engine(CracEngine.PAUSE);
+        final CracBuilder builder = new CracBuilder().engine(CracEngine.SIMULATE).engineOptions("pause=true");
         try (var process = builder.startCheckpoint()) {
             process.waitForPausePid();
             Thread.sleep(PAUSE_TIME_MS);

--- a/test/jdk/jdk/crac/engine/SimenginePauseTest.java
+++ b/test/jdk/jdk/crac/engine/SimenginePauseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
+ * Copyright (c) 2026, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,13 +28,13 @@ import static jdk.test.lib.Asserts.*;
 
 /*
  * @test
- * @summary pauseengine should pause the execution of the checkpointed process.
+ * @summary simengine with pause option should pause the execution of the checkpointed process.
  * @requires (os.family == "linux")
  * @library /test/lib
- * @build PauseEngineTest
+ * @build SimenginePauseTest
  * @run driver jdk.test.lib.crac.CracTest
  */
-public class PauseEngineTest implements CracTest {
+public class SimenginePauseTest implements CracTest {
     private static final long PAUSE_TIME_MS = 5000;
 
     @Override

--- a/test/jdk/jdk/crac/engineOptions/ParsingTest.java
+++ b/test/jdk/jdk/crac/engineOptions/ParsingTest.java
@@ -61,12 +61,8 @@ public class ParsingTest {
 
     @Test
     public void test_engines() throws Exception {
-        test("sim", Collections.emptyList(), 0, List.of("Engine name 'sim' (without the engine suffix) is deprecated"), List.of("[error]"));
         test("simengine");
         if (Platform.isLinux()) {
-            test("pause", Collections.emptyList(), 0, List.of("pauseengine is deprecated"), List.of("[error]"));
-            test("pauseengine", Collections.emptyList(), 0, List.of("pauseengine is deprecated"), List.of("[error"));
-            test("criu", Collections.emptyList(), 0, List.of("Engine name 'criu' (without the engine suffix) is deprecated"), List.of("[error]"));
             test("criuengine");
         }
 
@@ -79,8 +75,10 @@ public class ParsingTest {
 
         if (Platform.isStatic()) {
             test("unknown", null, 1, "Cannot load CRaC engine API entrypoint");
+            test("sim", null, 1, "Cannot load CRaC engine API entrypoint");
         } else {
             test("unknown", null, 1, "Cannot find CRaC engine unknown");
+            test("sim", null, 1, "Cannot find CRaC engine sim");
             test("simengine,--arg", null, 1, "Cannot find CRaC engine simengine,--arg");
             test("one two", null, 1, "Cannot find CRaC engine one two");
         }

--- a/test/jdk/jdk/crac/score/ImageScoreTest.java
+++ b/test/jdk/jdk/crac/score/ImageScoreTest.java
@@ -64,7 +64,7 @@ public class ImageScoreTest implements CracTest {
 
     @Override
     public void test() throws Exception {
-        final CracBuilder builder = new CracBuilder().engine(CracEngine.PAUSE);
+        final CracBuilder builder = new CracBuilder().engine(CracEngine.SIMULATE).engineOptions("pause=true");
         builder.vmOption("-XX:" + (usePerfData ? '+' : '-') + "UsePerfData");
         builder.vmOption("--add-opens=java.base/jdk.internal.crac=ALL-UNNAMED");
 

--- a/test/lib/jdk/test/lib/crac/CracBuilderBase.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilderBase.java
@@ -280,10 +280,7 @@ public abstract class CracBuilderBase<T extends CracBuilderBase<T>> {
         List<String> cmd = new ArrayList<>(javaPrefix.length > 0 ? Arrays.asList(javaPrefix) : getDefaultJavaPrefix());
         cmd.add("-ea");
         if (engine != null) {
-            cmd.add("-XX:CRaCEngine=" + engine.name);
-            if (!engine.options.isEmpty()) {
-                cmd.add("-XX:CRaCEngineOptions=" + engine.options);
-            }
+            cmd.add("-XX:CRaCEngine=" + engine.engine);
         }
         if (engineOptions != null) {
             cmd.add("-XX:CRaCEngineOptions=" + String.join(",", engineOptions));

--- a/test/lib/jdk/test/lib/crac/CracBuilderBase.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilderBase.java
@@ -280,7 +280,10 @@ public abstract class CracBuilderBase<T extends CracBuilderBase<T>> {
         List<String> cmd = new ArrayList<>(javaPrefix.length > 0 ? Arrays.asList(javaPrefix) : getDefaultJavaPrefix());
         cmd.add("-ea");
         if (engine != null) {
-            cmd.add("-XX:CRaCEngine=" + engine.engine);
+            cmd.add("-XX:CRaCEngine=" + engine.name);
+            if (!engine.options.isEmpty()) {
+                cmd.add("-XX:CRaCEngineOptions=" + engine.options);
+            }
         }
         if (engineOptions != null) {
             cmd.add("-XX:CRaCEngineOptions=" + String.join(",", engineOptions));

--- a/test/lib/jdk/test/lib/crac/CracEngine.java
+++ b/test/lib/jdk/test/lib/crac/CracEngine.java
@@ -1,15 +1,12 @@
 package jdk.test.lib.crac;
 
 public enum CracEngine {
-    CRIU("criuengine", ""),
-    PAUSE("simengine", "pause=true"),
-    SIMULATE("simengine", "");
+    CRIU("criuengine"),
+    SIMULATE("simengine");
 
-    public final String name;
-    public final String options;
+    public final String engine;
 
-    CracEngine(String name, String options) {
-        this.name = name;
-        this.options = options;
+    CracEngine(String engine) {
+        this.engine = engine;
     }
 }

--- a/test/lib/jdk/test/lib/crac/CracEngine.java
+++ b/test/lib/jdk/test/lib/crac/CracEngine.java
@@ -1,13 +1,15 @@
 package jdk.test.lib.crac;
 
 public enum CracEngine {
-    CRIU("criuengine"),
-    PAUSE("pauseengine"),
-    SIMULATE("simengine");
+    CRIU("criuengine", ""),
+    PAUSE("simengine", "pause=true"),
+    SIMULATE("simengine", "");
 
-    public final String engine;
+    public final String name;
+    public final String options;
 
-    CracEngine(String engine) {
-        this.engine = engine;
+    CracEngine(String name, String options) {
+        this.name = name;
+        this.options = options;
     }
 }

--- a/test/lib/jdk/test/lib/crac/CracProcess.java
+++ b/test/lib/jdk/test/lib/crac/CracProcess.java
@@ -165,7 +165,7 @@ public class CracProcess implements Closeable {
     }
 
     public void waitForPausePid() throws IOException, InterruptedException {
-        assertEquals(CracEngine.PAUSE, engine, "Pause PID file not created in this configuration");
+        assertEquals(CracEngine.SIMULATE, engine, "Pause PID file not created in this configuration");
 
         // (at least on Windows) we need to wait to avoid os::prepare_checkpoint() interference with mkdir/rmdir calls
         Thread.sleep(500);
@@ -347,7 +347,7 @@ public class CracProcess implements Closeable {
     }
 
     public void clearPausePid() throws IOException {
-        assertEquals(CracEngine.PAUSE, engine, "Pause PID file not created in this configuration");
+        assertEquals(CracEngine.SIMULATE, engine, "Pause PID file not created in this configuration");
         Files.delete(imageDir.resolve(PAUSE_PID_FILE));
     }
 }

--- a/test/lib/jdk/test/lib/crac/CracProcess.java
+++ b/test/lib/jdk/test/lib/crac/CracProcess.java
@@ -160,12 +160,12 @@ public class CracProcess implements Closeable {
             assertEquals(137, exitValue, "Checkpointed process was not killed as expected.");
             System.err.printf("Process %d completed with exit value %d%n", process.pid(), exitValue);
         } else {
-            fail("With engine " + engine.engine + " use the async version.");
+            fail("With engine " + engine + " use the async version.");
         }
     }
 
     public void waitForPausePid() throws IOException, InterruptedException {
-        assertEquals(CracEngine.PAUSE, engine, "Pause PID file is created only with pauseengine");
+        assertEquals(CracEngine.PAUSE, engine, "Pause PID file not created in this configuration");
 
         // (at least on Windows) we need to wait to avoid os::prepare_checkpoint() interference with mkdir/rmdir calls
         Thread.sleep(500);
@@ -347,7 +347,7 @@ public class CracProcess implements Closeable {
     }
 
     public void clearPausePid() throws IOException {
-        assertEquals(CracEngine.PAUSE, engine, "Pause PID file is created only with pauseengine");
+        assertEquals(CracEngine.PAUSE, engine, "Pause PID file not created in this configuration");
         Files.delete(imageDir.resolve(PAUSE_PID_FILE));
     }
 }


### PR DESCRIPTION
`criu`, `sim`, `pause`, `pauseengine` are no longer recognized as names of bundled CRaC engines.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8386890](https://bugs.openjdk.org/browse/JDK-8386890): [CRaC] Drop deprecated aliases of bundled engines (**Task** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/326/head:pull/326` \
`$ git checkout pull/326`

Update a local copy of the PR: \
`$ git checkout pull/326` \
`$ git pull https://git.openjdk.org/crac.git pull/326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 326`

View PR using the GUI difftool: \
`$ git pr show -t 326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/326.diff">https://git.openjdk.org/crac/pull/326.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/326#issuecomment-4751196432)
</details>
