### PR TITLE
8386981: [CRaC] Drop deprecated CRAC_CRIU_* env vars

### DIFF
--- a/src/java.base/linux/native/libcriuengine/criuengine.cpp
+++ b/src/java.base/linux/native/libcriuengine/criuengine.cpp
@@ -115,7 +115,6 @@ class ArgsBuilder {
   const char* _args[32];
   const char** _next = _args;
   const char** const _end = _args + ARRAY_SIZE(_args) - 1;
-  char* _from_env = nullptr;
   char* _from_opts = nullptr;
   bool _failed = false;
 
@@ -138,7 +137,6 @@ public:
   }
 
   ~ArgsBuilder() {
-    free(_from_env);
     free(_from_opts);
   }
 
@@ -159,20 +157,10 @@ public:
 
   ArgsBuilder& append_all(const char* args) {
     // this method can be called only once
-    assert(_from_env == nullptr);
     assert(_from_opts == nullptr);
-
-    const char* criu_opts = getenv("CRAC_CRIU_OPTS");
-    if (criu_opts && criu_opts[0]) {
-      LOG("CRAC_CRIU_OPTS is deprecated, will be obsoleted in JDK 28 and removed in JDK 29. Use -XX:CRaCEngineOptions=args=...");
-      _from_env = strdup_checked(criu_opts);
-      if (_from_env == nullptr) {
-        _failed = true;
-        return *this;
-      }
-      fill_args("CRAC_CRIU_OPTS", _from_env);
+    if (getenv("CRAC_CRIU_OPTS") != nullptr) {
+      LOG("CRAC_CRIU_OPTS is obsolete and has no impact. Use -XX:CRaCEngineOptions=args=... instead. This warning will be removed in JDK 29.");
     }
-    // applying args later (these have higher priority)
     if (args != nullptr) {
       _from_opts = strdup_checked(args);
       if (_from_opts == nullptr) {
@@ -496,35 +484,32 @@ static char* get_relative_file(const char* rel) {
 }
 
 const char* criuengine::get_criu() {
-  char* criu = _criu_location;
-  if (criu == nullptr) {
-    criu = getenv("CRAC_CRIU_PATH");
-    if (criu != nullptr) {
-      LOG("CRAC_CRIU_PATH is deprecated, will be obsoleted in JDK 28 and removed in JDK 29. Use -XX:CRaCEngineOptions=criu_location=...");
-    }
+  if (_criu_location != nullptr) {
+    return check_criu_executable(_criu_location, false);
   }
-  if (criu != nullptr) {
-    return check_criu_executable(criu, false);
+  if (getenv("CRAC_CRIU_PATH") != nullptr) {
+    LOG("CRAC_CRIU_PATH is obsolete and has no impact. Use -XX:CRaCEngineOptions=criu_location=... instead. This warning will be removed in JDK 29.");
   }
   const char* const_path = getenv("PATH");
-  if (const_path == NULL) {
-    LOG("Error: cannot find CRIU: neither criu_location option nor PATH environment variable is set");
+  if (const_path == nullptr) {
+    LOG("Cannot find CRIU executable: neither criu_location option nor PATH environment variable is set");
     return nullptr;
   }
   char* path = strdup(const_path);
-  if (path == NULL) {
+  if (path == nullptr) {
     LOG("Cannot copy PATH; out of memory");
     return nullptr;
   }
   char* save_ptr = nullptr;
   char* prefix = strtok_r(path, ":", &save_ptr);
   while (prefix != nullptr) {
+    char* criu;
     if (asprintf(&criu, "%s/criu", prefix) < 0) {
       LOG("Cannot allocate string with CRIU location starting with %s", prefix);
     } else {
       if (check_criu_executable(criu, true) != nullptr) {
-        free(_criu_location);
         _criu_location = criu;
+        free(path);
         return _criu_location;
       }
       free(criu);
@@ -532,6 +517,7 @@ const char* criuengine::get_criu() {
     prefix = strtok_r(nullptr, ":", &save_ptr);
   }
   LOG("Cannot find CRIU executable: criu_location option not set, not found on PATH");
+  free(path);
   return nullptr;
 }
 

--- a/test/jdk/jdk/crac/engineOptions/CracCriuOptsTest.java
+++ b/test/jdk/jdk/crac/engineOptions/CracCriuOptsTest.java
@@ -25,45 +25,31 @@ import jdk.crac.management.CRaCMXBean;
 import jdk.test.lib.crac.CracBuilder;
 import jdk.test.lib.crac.CracEngine;
 import jdk.test.lib.crac.CracTest;
-import jdk.test.lib.crac.CracTestArg;
 
 /**
- * @test Testing CracEngineOptions influenced by CRAC_CRIU_OPTS env variable.
+ * @test Testing CracEngineOptions is not influenced by obsoleted CRAC_CRIU_OPTS env variable.
+ * @comment The remaining warning should be dropped together with this test in JDK 29.
  * @requires (os.family == "linux")
  * @library /test/lib
  * @build CracCriuOptsTest
- * @run driver jdk.test.lib.crac.CracTest NOT_SET
- * @run driver jdk.test.lib.crac.CracTest ENVVAR_USED
- * @run driver jdk.test.lib.crac.CracTest ALREADY_SET
+ * @run driver jdk.test.lib.crac.CracTest
  */
 
 public class CracCriuOptsTest implements CracTest {
-    private static final String CRAC_CRIU_OPTS = "CRAC_CRIU_OPTS";
     private static final String RESTORED = "RESTORED";
-
-    public enum Variant {
-        NOT_SET,
-        ENVVAR_USED,
-        ALREADY_SET
-    }
-
-    @CracTestArg
-    Variant variant;
 
     @Override
     public void test() throws Exception {
-        final CracBuilder builder = new CracBuilder().engine(CracEngine.CRIU)
-                .engineOptions("keep_running=true,print_command=true");
-        if (variant == Variant.ENVVAR_USED) {
-            builder.env(CRAC_CRIU_OPTS, "-v");
-        } else if (variant == Variant.ALREADY_SET) {
-            builder.env(CRAC_CRIU_OPTS, "-v -R");
+        if (Runtime.version().feature() >= 29) {
+            throw new IllegalStateException("This test should be removed together with all CRAC_CRIU_* mentions in JDK 29");
         }
+        final CracBuilder builder = new CracBuilder().engine(CracEngine.CRIU)
+                .engineOptions("print_command=true")
+                .env("CRAC_CRIU_OPTS", "-R");
         builder.doCheckpointToAnalyze()
-                .shouldHaveExitValue(0)
-                .stderrShouldContain(RESTORED);
-
-        builder.engineOptions().doRestore();
+                .shouldHaveExitValue(137)
+                .stderrShouldContain("CRAC_CRIU_OPTS is obsolete and has no impact")
+                .stderrShouldNotContain(RESTORED);
     }
 
     @Override


### PR DESCRIPTION
Removes the code that handles `CRAC_CRIU_OPTS` and `CRAC_CRIU_PATH` leaving just a warning.

I left a degenerate version of `CracCriuOptsTest` as a reminder for us to remove the warnings in JDK 29.

Also fixed a memory leak of `PATH` copy in neighboring code.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8386981](https://bugs.openjdk.org/browse/JDK-8386981): [CRaC] Drop deprecated CRAC_CRIU_* env vars (**Task** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/327/head:pull/327` \
`$ git checkout pull/327`

Update a local copy of the PR: \
`$ git checkout pull/327` \
`$ git pull https://git.openjdk.org/crac.git pull/327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 327`

View PR using the GUI difftool: \
`$ git pr show -t 327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/327.diff">https://git.openjdk.org/crac/pull/327.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/327#issuecomment-4752126366)
</details>
