### PR TITLE
8387084: [CRaC] Fixup docs of bundled engines

### DIFF
--- a/src/java.base/linux/native/libcriuengine/README.md
+++ b/src/java.base/linux/native/libcriuengine/README.md
@@ -25,7 +25,7 @@ There is one line per tag created through the `crlib_image_constraints_t` interf
 
 ### Image Score
 
-Image Score records metadata that should assist with selecting the best image before restore. For each metric recorded through the `crlib_image_score_t` interface this file contains one line in format `<metric-name>=<floating-point-value>`, e.g.
+Image Score records metadata that should assist with selecting the best image before restore into text file `score` in the checkpoint directory. For each metric recorded through the `crlib_image_score_t` interface this file contains one line in format `<metric-name>=<floating-point-value>`, e.g.
 
 ```
 java.cls.loadedClasses=204.000000

--- a/src/java.base/share/native/libsimengine/README.md
+++ b/src/java.base/share/native/libsimengine/README.md
@@ -4,4 +4,4 @@ This library implements the C/R API (see `src/hotspot/share/include/crlib/`) use
 
 ## Extensions
 
-For development purposes, SimEngine implements the "Image Constraints" and "Image Score" extensions to the same extent as CRIU Engine (see `src/hotspot/share/native/libcriuengine`) - in fact the implementation is shared. See the README.md in there for details about the format.
+For development purposes, SimEngine implements the "Image Constraints" and "Image Score" extensions to the same extent as CRIU Engine (see `src/java.base/linux/native/libcriuengine/`) - in fact the implementation is shared. See the README.md in there for details about the format.


### PR DESCRIPTION
- SimEngine's doc used a wrong path to reference CRIU Engine.
- CRIU Engine's doc didn't name the file where score is stored

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8387084](https://bugs.openjdk.org/browse/JDK-8387084): [CRaC] Fixup docs of bundled engines (**Bug** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/328/head:pull/328` \
`$ git checkout pull/328`

Update a local copy of the PR: \
`$ git checkout pull/328` \
`$ git pull https://git.openjdk.org/crac.git pull/328/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 328`

View PR using the GUI difftool: \
`$ git pr show -t 328`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/328.diff">https://git.openjdk.org/crac/pull/328.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/328#issuecomment-4777933813)
</details>
