### PR TITLE
8388144: [CRaC] CRIU fails to restore jdk/crac/SecureRandom/InterlockTest

### DIFF
--- a/test/jdk/jdk/crac/SecureRandom/InterlockTest.java
+++ b/test/jdk/jdk/crac/SecureRandom/InterlockTest.java
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Azul Systems, Inc.  All Rights Reserved.
+// Copyright 2019, 2026 Azul Systems, Inc.  All Rights Reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it under
@@ -24,23 +24,37 @@ import jdk.crac.Resource;
 import jdk.crac.RestoreException;
 import jdk.crac.management.CRaCMXBean;
 import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracEngine;
 import jdk.test.lib.crac.CracTest;
 import jdk.test.lib.crac.CracTestArg;
 
 import java.security.SecureRandom;
 
 /*
- * @test
- * @summary Verify that secure random is not interlocked during checkpoint/restore.
- * @requires (os.family == "linux")
+ * @test id=SHA1PRNG
+ * @summary Verify that SHA1PRNG secure random is not interlocked during checkpoint/restore.
  * @library /test/lib
  * @build InterlockTest
  * @run driver/timeout=60 jdk.test.lib.crac.CracTest SHA1PRNG 100
+ */
+/*
+ * @test id=NativePRNGNonBlocking
+ * @summary Verify that NativePRNGNonBlocking secure random is not interlocked during checkpoint/restore.
+ * @requires (os.family != "windows")
+ * @library /test/lib
+ * @build InterlockTest
  * @run driver/timeout=60 jdk.test.lib.crac.CracTest NativePRNGNonBlocking 100
+ */
+/*
+ * @test id=NativePRNG
+ * @summary Verify that NativePRNG secure random is not interlocked during checkpoint/restore.
+ * @requires (os.family != "windows")
+ * @library /test/lib
+ * @build InterlockTest
  * @run driver/timeout=60 jdk.test.lib.crac.CracTest NativePRNG 100
  */
 
-/* NativePRNGBlocking is exluded as on some machines /dev/random is exhausted
+/* NativePRNGBlocking is excluded as on some machines /dev/random is exhausted
  * too soon, making the test running too long. */
 
 public class InterlockTest implements Resource, CracTest {
@@ -123,7 +137,7 @@ public class InterlockTest implements Resource, CracTest {
 
     @Override
     public void test() throws Exception {
-        new CracBuilder().doCheckpointAndRestore();
+        new CracBuilder().engine(CracEngine.SIMULATE).doCheckpoint();
     }
 
     @Override


### PR DESCRIPTION
I'm not sure why exactly the test was failing with CRIU but it looks like it does not need CRIU specifically as it tests Java code in CRaC callbacks. So I made it to run on `simengine`, and also on all platforms instead of just Linux.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8388144](https://bugs.openjdk.org/browse/JDK-8388144): [CRaC] CRIU fails to restore jdk/crac/SecureRandom/InterlockTest (**Bug** - P4)


### Reviewers
 * [Alexey Bakhtin](https://openjdk.org/census#abakhtin) (@alexeybakhtin - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/330/head:pull/330` \
`$ git checkout pull/330`

Update a local copy of the PR: \
`$ git checkout pull/330` \
`$ git pull https://git.openjdk.org/crac.git pull/330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 330`

View PR using the GUI difftool: \
`$ git pr show -t 330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/330.diff">https://git.openjdk.org/crac/pull/330.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/330#issuecomment-4959966449)
</details>
