### PR TITLE
8389720: [CRaC] criuengine can't move out of JVM process hierarchy

### DIFF
--- a/src/java.base/linux/native/libcriuengine/criuengine.cpp
+++ b/src/java.base/linux/native/libcriuengine/criuengine.cpp
@@ -564,14 +564,14 @@ bool criuengine::execute_criu(const ArgsBuilder& args) const {
 
   // grand-child
   pid_t parent = getppid();
-  int tries = 300;
-  while (parent != 1 && 0 < tries--) {
-      usleep(10);
+  int tries = 0;
+  while (parent != 1 && tries < 100) { // 100 gives about 50ms of sleep in total
+      usleep(10 * (++tries));
       parent = getppid();
   }
 
   if (parent == parent_before) {
-    LOG("can't move out of JVM process hierarchy");
+    LOG("Cannot move out of JVM process hierarchy (%i retries)", tries);
     kickjvm(jvm_pid, -1);
     exit(0);
   }


### PR DESCRIPTION
Tried to fix the issue by increasing the amount of time `criuengine` waits for reparenting to occur from 3ms to about 50ms. Also extended the log in case the issue has a different root cause.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389720](https://bugs.openjdk.org/browse/JDK-8389720): [CRaC] criuengine can't move out of JVM process hierarchy (**Bug** - P4)


### Reviewers
 * [Jan Kratochvil](https://openjdk.org/census#jkratochvil) (@jankratochvil - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/333/head:pull/333` \
`$ git checkout pull/333`

Update a local copy of the PR: \
`$ git checkout pull/333` \
`$ git pull https://git.openjdk.org/crac.git pull/333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 333`

View PR using the GUI difftool: \
`$ git pr show -t 333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/333.diff">https://git.openjdk.org/crac/pull/333.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/333#issuecomment-5180623502)
</details>
