### PR TITLE
8389721: [CRaC] ConcurrentModificationException in LinuxWatchService

### DIFF
--- a/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
@@ -248,6 +248,7 @@ class LinuxWatchService
                 assert checkpointState == CheckpointRestoreState.RESTORE_TRANSITION;
                 if (thisState == CheckpointRestoreState.CHECKPOINTED) {
                     initFDs();
+                    Map<Integer,LinuxWatchKey> newDescriptors = new HashMap<>();
                     for (Map.Entry<Integer,LinuxWatchKey> entry : wdToKey.entrySet()) {
                         Integer oldDescriptor = entry.getKey();
                         LinuxWatchKey oldKey = entry.getValue();
@@ -257,15 +258,14 @@ class LinuxWatchService
                         if (!(Files.exists(dir) && Files.isDirectory(dir))){
                             System.getLogger(Poller.class.getName()).log(System.Logger.Level.WARNING, "CRaC Restore WatchService: path " +
                                 dir.toString() + " does not exist, skip re-register of WatchKey ");
-                            wdToKey.remove(oldDescriptor);
                             continue;
                         }
                         try (NativeBuffer buffer =
                             NativeBuffers.asNativeBuffer(dir.getByteArrayForSysCalls())) {
                             wd = inotifyAddWatch(ifd, buffer.address(), oldKey.getMask());
                             LinuxWatchKey key = new LinuxWatchKey(dir, watcher, ifd, wd, oldKey.getMask());
-                            wdToKey.remove(oldDescriptor);
-                            wdToKey.put(wd, key);
+                            newDescriptors.put(wd, key);
+
                             } catch (UnixException x) {
                                 if (x.errno() == ENOSPC) {
                                     throw new IOException("User limit of inotify watches reached");
@@ -273,6 +273,9 @@ class LinuxWatchService
                                 throw new IOException("Can't re-register LinuxWatchKey");
                             }
                     }
+                    wdToKey.clear();
+                    wdToKey.putAll(newDescriptors);
+
                     checkpointState = CheckpointRestoreState.NORMAL_OPERATION;
                     this.notifyAll();
                 }

--- a/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
@@ -265,13 +265,12 @@ class LinuxWatchService
                             wd = inotifyAddWatch(ifd, buffer.address(), oldKey.getMask());
                             LinuxWatchKey key = new LinuxWatchKey(dir, watcher, ifd, wd, oldKey.getMask());
                             newDescriptors.put(wd, key);
-
-                            } catch (UnixException x) {
-                                if (x.errno() == ENOSPC) {
-                                    throw new IOException("User limit of inotify watches reached");
-                                }
-                                throw new IOException("Can't re-register LinuxWatchKey");
+                        } catch (UnixException x) {
+                            if (x.errno() == ENOSPC) {
+                                throw new IOException("User limit of inotify watches reached");
                             }
+                            throw new IOException("Can't re-register LinuxWatchKey");
+                        }
                     }
                     wdToKey.clear();
                     wdToKey.putAll(newDescriptors);


### PR DESCRIPTION
We iterate a map in a for-loop and modify the map at the same time (remove/add items). That causes incorrect map iterating.

Tested on apps that use the LinuxWatchService.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389721](https://bugs.openjdk.org/browse/JDK-8389721): [CRaC] ConcurrentModificationException in LinuxWatchService (**Bug** - P4)


### Reviewers
 * [Timofei Pushkin](https://openjdk.org/census#tpushkin) (@TimPushkin - Committer)
 * [Jan Kratochvil](https://openjdk.org/census#jkratochvil) (@jankratochvil - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/334/head:pull/334` \
`$ git checkout pull/334`

Update a local copy of the PR: \
`$ git checkout pull/334` \
`$ git pull https://git.openjdk.org/crac.git pull/334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 334`

View PR using the GUI difftool: \
`$ git pr show -t 334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/334.diff">https://git.openjdk.org/crac/pull/334.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/334#issuecomment-5193725645)
</details>
