### PR TITLE
8389929: [CRaC] Rename unused aarch64 CPU features to *_UNUSED

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -50,11 +50,11 @@ public:
     decl(SHA3,          sha3,       12) \
     decl(SHA512,        sha512,     13) \
     decl(SVE,           sve,        14) \
-    decl(SB,            sb,         15) \
+    decl(SB_UNUSED,     sb_unused,  15) \
     decl(PACA,          paca,       16) \
     decl(SVEBITPERM,    svebitperm, 17) \
     decl(SVE2,          sve2,       18) \
-    decl(STXR_PREFETCH_UNUSED, stxr_prefetch, 19)  \
+    decl(STXR_PREFETCH_UNUSED, stxr_prefetch_unused, 19)  \
     decl(A53MAC,        a53mac,     20) \
     decl(ECV,           ecv,        21) \
     decl(WFXT,          wfxt,       22) \


### PR DESCRIPTION
 CRaC keeps all the features listed so the `-XX:CPUFeatures=0xnum1,0xnum2` does not change across JDK versions. No longer used ones are therefore renamed to `*_UNUSED` so they are not accidentally used by some patch. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389929](https://bugs.openjdk.org/browse/JDK-8389929): [CRaC] Rename unused aarch64 CPU features to *_UNUSED (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/335/head:pull/335` \
`$ git checkout pull/335`

Update a local copy of the PR: \
`$ git checkout pull/335` \
`$ git pull https://git.openjdk.org/crac.git pull/335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 335`

View PR using the GUI difftool: \
`$ git pr show -t 335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/335.diff">https://git.openjdk.org/crac/pull/335.diff</a>

</details>
