### PR TITLE
8384382: [CRaC] Add jdk.jcmd to JRE builds

### DIFF
--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -44,7 +44,7 @@ ALL_MODULES := $(call FindAllModules) $(EXTRA_MODULES)
 $(eval $(call ReadImportMetaData))
 
 JRE_MODULES += $(filter $(ALL_MODULES), $(BOOT_MODULES) \
-    $(PLATFORM_MODULES) jdk.jdwp.agent)
+    $(PLATFORM_MODULES) jdk.jdwp.agent jdk.jcmd)
 JDK_MODULES += $(ALL_MODULES)
 
 JRE_MODULES_LIST := $(call CommaList, $(JRE_MODULES))

--- a/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
@@ -32,6 +32,7 @@ import jdk.internal.crac.JDKResource;
 import jdk.internal.crac.LoggerContainer;
 import jdk.internal.crac.mirror.impl.*;
 import jdk.internal.misc.InnocuousThread;
+import jdk.internal.module.Modules;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -340,7 +341,10 @@ public class Core {
 
     private static void tryStartManagementAgent() {
         try {
-            Class<?> agentClass = Class.forName("jdk.internal.agent.Agent");
+            // Force loading the module, needed when running in JRE. The classes will be
+            // loaded in the platform class loader (.getClassLoader() returns null)
+            Modules.loadModule("jdk.management.agent");
+            Class<?> agentClass = ClassLoader.getPlatformClassLoader().loadClass("jdk.internal.agent.Agent");
             Method startAgent = agentClass.getMethod("startAgent");
             startAgent.setAccessible(true);
             startAgent.invoke(null);

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -108,6 +108,7 @@ requires.properties= \
     vm.debug \
     vm.hasSA \
     vm.hasJFR \
+    vm.jdi \
     vm.jvmti \
     vm.cpu.features \
     container.support \

--- a/test/jdk/jdk/crac/jdwp/JdwpTransportTest.java
+++ b/test/jdk/jdk/crac/jdwp/JdwpTransportTest.java
@@ -39,8 +39,10 @@ import java.util.concurrent.TimeoutException;
 import static jdk.test.lib.Asserts.*;
 
 /**
- * @test ContextOrderTest
+ * @test JdwpTransportTest
+ * @comment requires jdk.jdi module (not available in JRE)
  * @library /test/lib
+ * @requires vm.jdi
  * @build JdwpTransportTest
  * @run driver/timeout=30 jdk.test.lib.crac.CracTest false false
  * @run driver/timeout=30 jdk.test.lib.crac.CracTest true false

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -112,6 +112,7 @@ public class VMProps implements Callable<Map<String, String>> {
         // so tests can be executed.
         map.put("vm.hasJFR", this::vmHasJFR);
         map.put("vm.hasDTrace", this::vmHasDTrace);
+        map.put("vm.jdi", this::vmJdi);
         map.put("vm.jvmti", this::vmHasJVMTI);
         map.put("vm.cpu.features", this::cpuFeatures);
         map.put("vm.pageSize", this::vmPageSize);
@@ -383,6 +384,13 @@ public class VMProps implements Callable<Map<String, String>> {
      */
     protected String vmHasDTrace() {
         return "" + WB.isDTraceIncluded();
+    }
+
+    /**
+     * @return "true" if the module jdk.jdi is present (can use it for attaching debugger)
+     */
+    protected String vmJdi() {
+        return Boolean.toString(ModuleLayer.boot().findModule("jdk.jdi").isPresent());
     }
 
     /**


### PR DESCRIPTION
JRE builds of CRaC should now include `jcmd`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8384382](https://bugs.openjdk.org/browse/JDK-8384382): [CRaC] Add jdk.jcmd to JRE builds (**Enhancement** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Contributors
 * Timofei Pushkin `<tpushkin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/336/head:pull/336` \
`$ git checkout pull/336`

Update a local copy of the PR: \
`$ git checkout pull/336` \
`$ git pull https://git.openjdk.org/crac.git pull/336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 336`

View PR using the GUI difftool: \
`$ git pr show -t 336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/336.diff">https://git.openjdk.org/crac/pull/336.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/336#issuecomment-5214407420)
</details>
