### PR TITLE
8389955: [CRaC] Off-by-one errors in criuengine

### DIFF
--- a/src/java.base/linux/native/libcriuengine/criuengine.cpp
+++ b/src/java.base/linux/native/libcriuengine/criuengine.cpp
@@ -678,7 +678,7 @@ static void maybe_reopen(int fd, int flags) {
   // fcntl should not return file creation flags, though
   assert((current_flags & (O_TRUNC | O_EXCL)) == 0);
   static const char deleted[] = " (deleted)";
-  if (!strcmp(target + len - sizeof(deleted), deleted)) {
+  if ((size_t) len >= sizeof(deleted) - 1 && !strcmp(target + len - (sizeof(deleted) - 1), deleted)) {
     // deleted file will be replaced by /dev/null to avoid accidentally overwriting
     // other file
     strcpy(target, "/dev/null");
@@ -816,7 +816,7 @@ int criuengine::checkpoint() {
       continue;
     } else if (fcntl(fake_fds[i], F_GET_SEALS) >= 0) {
       // this is memfd => not replaced, just close
-    } else if (dup2(fake_fds[i], i) < -1) {
+    } else if (dup2(fake_fds[i], i) < 0) {
       // you probably wouldn't see this message, though
       LOG("Failed to dup2(%d, %d): %s", fake_fds[i], i, strerror(errno));
     }

--- a/test/jdk/jdk/crac/fileDescriptors/DeletedStdinTest.java
+++ b/test/jdk/jdk/crac/fileDescriptors/DeletedStdinTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.Context;
+import jdk.crac.Resource;
+import jdk.crac.management.CRaCMXBean;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Container;
+import jdk.test.lib.Utils;
+import jdk.test.lib.containers.docker.Common;
+import jdk.test.lib.crac.CracContainerBuilder;
+import jdk.test.lib.crac.CracEngine;
+import jdk.test.lib.crac.CracTest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @test
+ * @bug 8389955
+ * @summary Test C/R of stdio FD pointing at a deleted file on a mount not visible in the current mount namespace.
+ * @requires os.family == "linux"
+ * @requires container.support
+ * @comment Static JDK eagerly loads X11 which is missing from the Docker image
+ * @requires !jdk.static
+ * @library /test/lib
+ * @modules java.base/jdk.internal.platform
+ * @build DeletedStdinTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class DeletedStdinTest implements CracTest {
+    private static final String TEST_SRC_VOLUME = "/testsrc";
+    private static final String WRAPPER = "deleted_stdin_wrapper.sh";
+
+    private static final Pattern MNT_ID_PATTERN = Pattern.compile("^mnt_id:\\s+(\\d+)$");
+
+    // Assert the wrapper works as intended
+    private static final Resource resource = new Resource() {
+        @Override
+        public void beforeCheckpoint(Context<? extends Resource> context) throws IOException {
+            final var stdinFilename = Files.readSymbolicLink(Path.of("/proc/self/fd/0")).toString();
+            Asserts.assertTrue(stdinFilename.endsWith(" (deleted)"), "Wrapper failed: stdin file was not deleted");
+
+            final int stdinMountId;
+            try (final var lines = Files.lines(Path.of("/proc/self/fdinfo/0"))) {
+                stdinMountId = lines.map(MNT_ID_PATTERN::matcher)
+                        .filter(Matcher::matches)
+                        .mapToInt(m -> Integer.parseInt(m.group(1)))
+                        .findAny()
+                        .orElseThrow(() -> new RuntimeException("mnt_id missing from stdin's fdinfo"));
+            }
+            try (final var lines = Files.lines(Path.of("/proc/self/mountinfo"))) {
+                lines.forEach(line -> {
+                    final var mountId = Integer.parseInt(line.split("\\s+")[0]);
+                    Asserts.assertNE(stdinMountId, mountId, "Wrapper failed: stdin's mount visible in JVM: " + line);
+                });
+            }
+        }
+
+        @Override
+        public void afterRestore(Context<? extends Resource> context) {
+        }
+    };
+
+    @Override
+    public void test() throws Exception {
+        final var builder = new CracContainerBuilder().engine(CracEngine.CRIU)
+                .inDockerImage(Common.imageName("deleted-stdin"))
+                .containerUsePrivileged(true)
+                .dockerOptions("--volume", Utils.TEST_SRC + ":" + TEST_SRC_VOLUME);
+        try {
+            builder.doCheckpointToAnalyze(
+                            Container.ENGINE_COMMAND, "exec", CracContainerBuilder.CONTAINER_NAME,
+                            Path.of(TEST_SRC_VOLUME, WRAPPER).toString(), CracContainerBuilder.DOCKER_JAVA
+                    )
+                    .shouldHaveExitValue(137)
+                    .shouldNotContain("Cannot reopen");
+            builder.doRestore();
+        } finally {
+            builder.ensureContainerKilled();
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Context.getGlobalContext().register(resource);
+        CRaCMXBean.getCRaCMXBean().checkpointRestore();
+    }
+}

--- a/test/jdk/jdk/crac/fileDescriptors/deleted_stdin_wrapper.sh
+++ b/test/jdk/jdk/crac/fileDescriptors/deleted_stdin_wrapper.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# Copyright (c) 2026, Azul Systems, Inc. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+
+# Make stdin point at a deleted file
+FILE=$(mktemp)
+exec <"$FILE"
+rm "$FILE"
+
+# Move Java process to a different mount namespace
+exec unshare --mount "$@"


### PR DESCRIPTION
Fixes two unrelated errors in `criuengine`:
- Miscalculation of the length of ` (deleted)` suffix
- Comparison of `dup2`'s return code against a wrong value (`dup2` cannot return values less than -1)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389955](https://bugs.openjdk.org/browse/JDK-8389955): [CRaC] Off-by-one errors in criuengine (**Bug** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/337/head:pull/337` \
`$ git checkout pull/337`

Update a local copy of the PR: \
`$ git checkout pull/337` \
`$ git pull https://git.openjdk.org/crac.git pull/337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 337`

View PR using the GUI difftool: \
`$ git pr show -t 337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/337.diff">https://git.openjdk.org/crac/pull/337.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/337#issuecomment-5217380659)
</details>
