### PR TITLE
8389958: [CRaC] Exception when closing or ignoring pipes via resource policy

### DIFF
--- a/src/java.base/unix/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/PipeImpl.java
@@ -69,6 +69,7 @@ class PipeImpl
                     warnOpenResource(policy, PipeImpl.this.toString());
                     Core.getClaimedFDs().claimFd(source.getFD(), this, NO_EXCEPTION, source.getFD());
                     Core.getClaimedFDs().claimFd(sink.getFD(), this, NO_EXCEPTION, sink.getFD());
+                    break;
                 default:
                     throw new IllegalStateException("Unknown policy action " + action + " for " + PipeImpl.this, null);
             }


### PR DESCRIPTION
Removes an unintentional fall-through in pipes' resource policy handling.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389958](https://bugs.openjdk.org/browse/JDK-8389958): [CRaC] Exception when closing or ignoring pipes via resource policy (**Bug** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/338/head:pull/338` \
`$ git checkout pull/338`

Update a local copy of the PR: \
`$ git checkout pull/338` \
`$ git pull https://git.openjdk.org/crac.git pull/338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 338`

View PR using the GUI difftool: \
`$ git pr show -t 338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/338.diff">https://git.openjdk.org/crac/pull/338.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/338#issuecomment-5217454472)
</details>
