### PR TITLE
8389961: [CRaC] FdsInfo::same_fd calls unspecified fcntl operations

### DIFF
--- a/src/hotspot/os/linux/crac_linux.cpp
+++ b/src/hotspot/os/linux/crac_linux.cpp
@@ -148,7 +148,7 @@ bool FdsInfo::same_fd(int i1, int i2) {
   const int new_flags2 = fcntl(fi2->fd, F_GETFL);
   const bool are_same = new_flags1 == new_flags2;
 
-  fcntl(fi2->fd, flags1);
+  fcntl(fi1->fd, F_SETFL, flags1);
 
   return are_same;
 }


### PR DESCRIPTION
Fixes the erroneous call so that it restores the flags of the first FD as it seemingly was supposed to be doing.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389961](https://bugs.openjdk.org/browse/JDK-8389961): [CRaC] FdsInfo::same_fd calls unspecified fcntl operations (**Bug** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/339/head:pull/339` \
`$ git checkout pull/339`

Update a local copy of the PR: \
`$ git checkout pull/339` \
`$ git pull https://git.openjdk.org/crac.git pull/339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 339`

View PR using the GUI difftool: \
`$ git pr show -t 339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/339.diff">https://git.openjdk.org/crac/pull/339.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/339#issuecomment-5217537253)
</details>
