### PR TITLE
8389962: [CRaC] CompileReason::Reason_CRaC is mapped to a wrong name

### DIFF
--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -73,8 +73,8 @@ class CompileTask : public CHeapObj<mtCompiler> {
       "replay",
       "whitebox",
       "must_be_compiled",
-      "bootstrap",
-      "crac"
+      "crac",
+      "bootstrap"
     };
     return reason_names[compile_reason];
   }


### PR DESCRIPTION
The proper fix would be to remove the `"bootstrap"` name which is now unused, but that should be done in the mainline (UPD: addressed it now in https://github.com/openjdk/jdk/pull/32256). So for now I just swapped it's place with `"crac"`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389962](https://bugs.openjdk.org/browse/JDK-8389962): [CRaC] CompileReason::Reason_CRaC is mapped to a wrong name (**Bug** - P4)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/340/head:pull/340` \
`$ git checkout pull/340`

Update a local copy of the PR: \
`$ git checkout pull/340` \
`$ git pull https://git.openjdk.org/crac.git pull/340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 340`

View PR using the GUI difftool: \
`$ git pr show -t 340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/340.diff">https://git.openjdk.org/crac/pull/340.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/340#issuecomment-5217625658)
</details>
