### PR TITLE
8390453: [CRaC] Custom image constraints

### DIFF
--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -1599,7 +1599,7 @@ static void signal_sets_init() {
   // signals in a different way and having this signal blocked could interfere.
   const char *signal_engines[] = { "criuengine", "simengine", nullptr };
   for (int i = 0; signal_engines[i] != nullptr; ++i) {
-    if (strcmp(CRaCEngine, signal_engines[i]) == 0) {
+    if (CRaCEngine != nullptr && strcmp(CRaCEngine, signal_engines[i]) == 0) {
       sigaddset(&blocked_sigs, RESTORE_SIGNAL);
       break;
     }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2821,9 +2821,6 @@ jint Arguments::finalize_vm_init_args() {
   if (CRaCRestoreFrom && !process_flags_for_restore()) {
     return JNI_EINVAL;
   }
-  if (CRaCCheckpointTo && !crac::prepare_checkpoint()) {
-    return JNI_ERR;
-  }
 
   return JNI_OK;
 }

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -943,7 +943,7 @@ void crac::restore(crac_restore_data& restore_data) {
     case CracEngine::ApiStatus::ERR:
       return;
     case CracEngine::ApiStatus::UNSUPPORTED:
-      log_warning(crac)("Cannot verify image constraints (e.g. CPUFeatures) for restore with the selected CRaC engine");
+      log_warning(crac)("Cannot verify image constraints (CPU features, labels) for restore with the selected CRaC engine");
       break;
   }
 

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -326,27 +326,6 @@ int crac::checkpoint_restore(int *shmid) {
     return JVM_CHECKPOINT_ERROR;
   }
 
-  // Setup CPU arch & features only during the first checkpoint; the feature set
-  // cannot change after initial boot (and we don't support switching the engine).
-  if (_generation == 1 && !VM_Version::check_cpu_features_skip()) {
-    VM_Version::VM_Features current_features;
-    if (VM_Version::cpu_features_binary(&current_features)) {
-      switch (_engine->prepare_image_constraints_api()) {
-        case CracEngine::ApiStatus::OK:
-          if (!_engine->store_cpuinfo(&current_features)) {
-            return JVM_CHECKPOINT_ERROR;
-          }
-          break;
-        case CracEngine::ApiStatus::ERR:
-          return JVM_CHECKPOINT_ERROR;
-        case CracEngine::ApiStatus::UNSUPPORTED:
-          log_warning(crac)("Cannot store CPUFeatures for checkpoint "
-            "with the selected CRaC engine");
-          break;
-      }
-    }
-  }
-
   const int ret = _engine->checkpoint();
   if (ret != 0) {
     log_error(crac)("CRaC engine failed to checkpoint to %s: error %i", image_location, ret);
@@ -605,7 +584,39 @@ public:
     _t = nullptr;
     return tmp;
   }
+  T *get() {
+    return _t;
+  }
 };
+
+static bool apply_labels(const char* property, CracEngine* engine, bool (CracEngine::*func)(const char*, const char*)) {
+  const char* labels = Arguments::get_property(property);
+  if (labels == nullptr) {
+    return true;
+  }
+  char* dup = os::strdup_check_oom(labels);
+  char *ptr = dup;
+  char *key_value;
+  bool retval = true;
+  while ((key_value = strtok_r(ptr, ",", &ptr)) != nullptr) {
+    char *eq = strchr(key_value, '=');
+    const char *value = nullptr;
+    if (eq == nullptr) {
+      value = getenv(key_value);
+    } else {
+      eq[0] = '\0';
+      if (eq[1] == '$') {
+        value = getenv(eq + 2);
+      } else {
+        value = eq + 1;
+      }
+    }
+    // if value is nullptr (e.g. env unset) func should ignore the call
+    retval = (engine->*func)(key_value, value) && retval;
+  }
+  os::free(dup);
+  return retval;
+}
 
 bool crac::prepare_checkpoint() {
   precond(CRaCCheckpointTo != nullptr);
@@ -624,6 +635,35 @@ bool crac::prepare_checkpoint() {
   }
   if (fixed_path && (!ensure_checkpoint_dir(image_location, true) || !engine->configure_image_location(image_location))) {
     return false;
+  }
+
+  switch (engine->prepare_image_constraints_api()) {
+    case CracEngine::ApiStatus::OK: {
+      VM_Version::VM_Features current_features;
+      if (!VM_Version::check_cpu_features_skip() && VM_Version::cpu_features_binary(&current_features) &&
+          !engine->store_cpuinfo(&current_features)) {
+        return false;
+      }
+      char java_version_buf[64];
+      guarantee((size_t) os::snprintf(java_version_buf, sizeof(java_version_buf), "%d.%d.%d",
+        JDK_Version::current().major_version(), JDK_Version::current().minor_version(),
+        JDK_Version::current().security_version()) < sizeof(java_version_buf), "version must fit");
+      // TODO: more built-in identifiers?
+      if (!engine->set_label("version", Arguments::get_property("jdk.crac.app.version")) ||
+          !engine->set_label("java.version", java_version_buf)) {
+        log_error(crac)("Cannot set common image labels");
+        return false;
+      }
+      if (!apply_labels("jdk.crac.labels", engine.get(), &CracEngine::set_label)) {
+        log_error(crac)("Cannot set some labels from the 'jdk.crac.labels' property");
+        return false;
+      }
+    } break;
+    case CracEngine::ApiStatus::ERR:
+      return false;
+    case CracEngine::ApiStatus::UNSUPPORTED:
+      log_warning(crac)("Cannot store image tags with the selected CRaC engine");
+      break;
   }
 
   _engine = engine.extract();
@@ -892,12 +932,15 @@ void crac::restore(crac_restore_data& restore_data) {
         if (VM_Version::cpu_features_binary(&current_features)) {
           engine.require_cpuinfo(&current_features, exact);
         }
-        } break;
+        if (!apply_labels("jdk.crac.require-labels", &engine, &CracEngine::require_label)) {
+          log_error(crac)("Cannot enforce some labels from the 'jdk.crac.require-labels' property");
+          return;
+        }
+      } break;
       case CracEngine::ApiStatus::ERR:
         return;
       case CracEngine::ApiStatus::UNSUPPORTED:
-        log_warning(crac)("Cannot verify CPUFeatures for restore "
-          "with the selected CRaC engine");
+        log_warning(crac)("Cannot verify image constraints (e.g. CPUFeatures) for restore with the selected CRaC engine");
         break;
     }
   }

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -589,33 +589,38 @@ public:
   }
 };
 
-static bool apply_labels(const char* property, CracEngine* engine, bool (CracEngine::*func)(const char*, const char*)) {
-  const char* labels = Arguments::get_property(property);
+static bool apply_labels(const char* labels, CracEngine* engine, bool (CracEngine::*func)(const char*, const char*)) {
   if (labels == nullptr) {
     return true;
   }
   char* dup = os::strdup_check_oom(labels);
   char *ptr = dup;
   char *key_value;
-  bool retval = true;
   while ((key_value = strtok_r(ptr, ",", &ptr)) != nullptr) {
     char *eq = strchr(key_value, '=');
     const char *value = nullptr;
+    const char *envvar = nullptr;
     if (eq == nullptr) {
-      value = getenv(key_value);
+      envvar = key_value;
+      value = getenv(envvar);
     } else {
       eq[0] = '\0';
       if (eq[1] == '$') {
-        value = getenv(eq + 2);
+        envvar = eq + 2;
+        value = getenv(envvar);
       } else {
         value = eq + 1;
       }
     }
-    // if value is nullptr (e.g. env unset) func should ignore the call
-    retval = (engine->*func)(key_value, value) && retval;
+    if (value == nullptr) {
+      log_warning(crac)("Environment variable %s used for label %s is not set.", envvar, key_value);
+    } else if (!(engine->*func)(key_value, value)) {
+      os::free(dup);
+      return false;
+    }
   }
   os::free(dup);
-  return retval;
+  return true;
 }
 
 bool crac::prepare_checkpoint() {
@@ -645,17 +650,14 @@ bool crac::prepare_checkpoint() {
         return false;
       }
       char java_version_buf[64];
-      guarantee((size_t) os::snprintf(java_version_buf, sizeof(java_version_buf), "%d.%d.%d",
-        JDK_Version::current().major_version(), JDK_Version::current().minor_version(),
-        JDK_Version::current().security_version()) < sizeof(java_version_buf), "version must fit");
+      JDK_Version::current().to_string(java_version_buf, sizeof(java_version_buf));
       // TODO: more built-in identifiers?
-      if (!engine->set_label("version", Arguments::get_property("jdk.crac.app.version")) ||
-          !engine->set_label("java.version", java_version_buf)) {
+      if (!engine->set_label("java.version", java_version_buf)) {
         log_error(crac)("Cannot set common image labels");
         return false;
       }
-      if (!apply_labels("jdk.crac.labels", engine.get(), &CracEngine::set_label)) {
-        log_error(crac)("Cannot set some labels from the 'jdk.crac.labels' property");
+      if (!apply_labels(CRaCImageLabels, engine.get(), &CracEngine::set_label)) {
+        log_error(crac)("Cannot set some labels from CRaCImageLabels");
         return false;
       }
     } break;
@@ -911,38 +913,38 @@ void crac::restore(crac_restore_data& restore_data) {
     return;
   }
 
-  // Since the check itself is delegated to the C/R Engine we will simply
-  // skip the check here.
-  bool ignore = VM_Version::check_cpu_features_skip();
   bool exact = false;
-  if (CheckCPUFeatures == nullptr || !strcmp(CheckCPUFeatures, "compatible")) {
-    // default, compatible
-  } else if (!strcmp(CheckCPUFeatures, "skip")) {
-    ignore = true;
-  } else if (!strcmp(CheckCPUFeatures, "exact")) {
-    exact = true;
-  } else {
-    log_error(crac)("Invalid value for -XX:CheckCPUFeatures=%s; available are 'compatible', 'exact' or 'skip'", CheckCPUFeatures);
-    return;
-  }
-  if (!ignore) {
-    switch (engine.prepare_image_constraints_api()) {
-      case CracEngine::ApiStatus::OK: {
+  switch (engine.prepare_image_constraints_api()) {
+    case CracEngine::ApiStatus::OK: {
+      // Since the check itself is delegated to the C/R Engine we will simply
+      // skip the check here.
+      bool ignore = VM_Version::check_cpu_features_skip();
+      if (CheckCPUFeatures == nullptr || !strcmp(CheckCPUFeatures, "compatible")) {
+        // default, compatible
+      } else if (!strcmp(CheckCPUFeatures, "skip")) {
+        ignore = true;
+      } else if (!strcmp(CheckCPUFeatures, "exact")) {
+        exact = true;
+      } else {
+        log_error(crac)("Invalid value for -XX:CheckCPUFeatures=%s; available are 'compatible', 'exact' or 'skip'", CheckCPUFeatures);
+        return;
+      }
+      if (!ignore) {
         VM_Version::VM_Features current_features;
         if (VM_Version::cpu_features_binary(&current_features)) {
           engine.require_cpuinfo(&current_features, exact);
         }
-        if (!apply_labels("jdk.crac.require-labels", &engine, &CracEngine::require_label)) {
-          log_error(crac)("Cannot enforce some labels from the 'jdk.crac.require-labels' property");
-          return;
-        }
-      } break;
-      case CracEngine::ApiStatus::ERR:
+      }
+      if (!apply_labels(CRaCRequiredImageLabels, &engine, &CracEngine::require_label)) {
+        log_error(crac)("Cannot enforce some labels from CRaCRequiredImageLabels");
         return;
-      case CracEngine::ApiStatus::UNSUPPORTED:
-        log_warning(crac)("Cannot verify image constraints (e.g. CPUFeatures) for restore with the selected CRaC engine");
-        break;
-    }
+      }
+    } break;
+    case CracEngine::ApiStatus::ERR:
+      return;
+    case CracEngine::ApiStatus::UNSUPPORTED:
+      log_warning(crac)("Cannot verify image constraints (e.g. CPUFeatures) for restore with the selected CRaC engine");
+      break;
   }
 
   switch (engine.prepare_restore_data_api()) {

--- a/src/hotspot/share/runtime/crac_engine.cpp
+++ b/src/hotspot/share/runtime/crac_engine.cpp
@@ -607,16 +607,10 @@ void CracEngine::check_cpuinfo(const VM_Version::VM_Features *current_features, 
 }
 
 bool CracEngine::set_label(const char* label, const char* value) {
-  if (value == nullptr) {
-    return true; // ignore empty labels for convenience
-  }
   return _image_constraints_api->set_label(_conf, label, value);
 }
 
 bool CracEngine::require_label(const char* label, const char* value) {
-  if (value == nullptr) {
-    return true; // for symmetry with set_label
-  }
   return _image_constraints_api->require_label(_conf, label, value);
 }
 

--- a/src/hotspot/share/runtime/crac_engine.cpp
+++ b/src/hotspot/share/runtime/crac_engine.cpp
@@ -58,6 +58,7 @@ VM_CONTROLLED_ENGINE_OPTS(DEFINE_OPT_VAR)
 #undef DEFINE_OPT_VAR
 
 static bool find_engine(const char *dll_dir, char *path, size_t path_size, char *name, size_t name_size) {
+  assert(CRaCEngine != nullptr, "must have engine set");
   const size_t engine_length = strlen(CRaCEngine);
   if (engine_length == 0) {
     log_error(crac)("CRaCEngine is empty");
@@ -606,7 +607,17 @@ void CracEngine::check_cpuinfo(const VM_Version::VM_Features *current_features, 
 }
 
 bool CracEngine::set_label(const char* label, const char* value) {
+  if (value == nullptr) {
+    return true; // ignore empty labels for convenience
+  }
   return _image_constraints_api->set_label(_conf, label, value);
+}
+
+bool CracEngine::require_label(const char* label, const char* value) {
+  if (value == nullptr) {
+    return true; // for symmetry with set_label
+  }
+  return _image_constraints_api->require_label(_conf, label, value);
 }
 
 CracEngine::ApiStatus CracEngine::prepare_image_score_api() {

--- a/src/hotspot/share/runtime/crac_engine.hpp
+++ b/src/hotspot/share/runtime/crac_engine.hpp
@@ -72,6 +72,7 @@ public:
 
   ApiStatus prepare_image_constraints_api();
   bool set_label(const char* label, const char* value);
+  bool require_label(const char* label, const char* value);
   bool store_cpuinfo(const VM_Version::VM_Features *current_features) const;
   void require_cpuinfo(const VM_Version::VM_Features *current_features, bool exact) const;
   void check_cpuinfo(const VM_Version::VM_Features *current_features, bool exact) const;

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2068,7 +2068,7 @@ const int ObjectAlignmentInBytes = 8;
           "to be recorded: label1=value,label2=$ENV,ENV (the last form "    \
           "sets label ENV from environment variable ENV)")                  \
                                                                             \
-  product(ccstr, CRaCRequiredImageLabels, nullptr, RESTORE_SETTABLE,         \
+  product(ccstr, CRaCRequiredImageLabels, nullptr, RESTORE_SETTABLE,        \
           "Labels that the image must have recorded in order for the "      \
           "checkpoint to succeed. Same format as CRaCImageLabels.")         \
                                                                             \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2064,6 +2064,14 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, CRaCPauseOnCheckpointError, false, DIAGNOSTIC,              \
           "Pauses the checkpoint when a problem is found on VM level.")     \
                                                                             \
+  product(ccstr, CRaCImageLabels, nullptr, "Comma-separated list of labels "\
+          "to be recorded: label1=value,label2=$ENV,ENV (the last form "    \
+          "sets label ENV from environment variable ENV)")                  \
+                                                                            \
+  product(ccstr, CRaCRequiredImageLabels, nullptr, RESTORE_SETTABLE,         \
+          "Labels that the image must have recorded in order for the "      \
+          "checkpoint to succeed. Same format as CRaCImageLabels.")         \
+                                                                            \
   product(ccstr, CPUFeatures, nullptr, "CPU feature set, "                  \
           "Limit set of CPU features to make the CRaC image compatible "    \
           "for running on a machine with different CPU:"                    \

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -623,6 +623,8 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   }
   Arguments::free_restore_only_data(); // Not needed anymore
 
+  // Preparations for checkpoint should be done only if we're not going to restore.
+  // Also this should be done only after VM_Version and JDK_Version are initialized.
   if (CRaCCheckpointTo && !crac::prepare_checkpoint()) {
     return JNI_ERR;
   }

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -623,6 +623,10 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   }
   Arguments::free_restore_only_data(); // Not needed anymore
 
+  if (CRaCCheckpointTo && !crac::prepare_checkpoint()) {
+    return JNI_ERR;
+  }
+
   // Have the WatcherThread read the release file in the background.
   ReadReleaseFileTask* read_task = new ReadReleaseFileTask();
   read_task->enroll();

--- a/src/java.base/unix/native/libsimengine/simengine_md.cpp
+++ b/src/java.base/unix/native/libsimengine/simengine_md.cpp
@@ -39,7 +39,7 @@
 int kickjvm(pid_t jvm, int code) {
     union sigval sv = { .sival_int = code };
     if (-1 == sigqueue(jvm, RESTORE_SIGNAL, sv)) {
-        LOG("sigqueue: %s", strerror(errno));
+        LOG("sigqueue PID %d: %s", jvm, strerror(errno));
         return 1;
     }
     return 0;

--- a/test/jdk/jdk/crac/constraints/RequiredLabelsTest.java
+++ b/test/jdk/jdk/crac/constraints/RequiredLabelsTest.java
@@ -1,0 +1,94 @@
+package constraints;/*
+ * Copyright (c) 2025, 2026, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Azul Systems, 385 Moffett Park Drive, Suite 115, Sunnyvale
+ * CA 94089 USA or visit www.azul.com if you need additional information or
+ * have any questions.
+ */
+
+import jdk.crac.management.CRaCMXBean;
+import jdk.test.lib.crac.*;
+
+import java.io.File;
+import java.nio.file.Path;
+
+/*
+ * @test
+ * @summary Check the jdk.crac.labels and jdk.crac.require-labels functionality
+ * @library /test/lib
+ * @build RequiredLabelsTest
+ * @run driver/timeout=15 jdk.test.lib.crac.CracTest foo=bar  foo=bar  true
+ * @run driver/timeout=15 jdk.test.lib.crac.CracTest foo=bar  -        true
+ * @run driver/timeout=15 jdk.test.lib.crac.CracTest -        foo=bar  false
+ * @run driver/timeout=15 jdk.test.lib.crac.CracTest foo=bar  foo=goo  false
+ * @run driver/timeout=15 jdk.test.lib.crac.CracTest foo=bar  foo=$BAR false
+ * @run driver/timeout=15 jdk.test.lib.crac.CracTest foo=$BAR foo=GOO  true
+ * @run driver/timeout=15 jdk.test.lib.crac.CracTest foo      foo=xxx  true
+ * @run driver/timeout=15 jdk.test.lib.crac.CracTest        - foo      false
+ * @run driver/timeout=15 jdk.test.lib.crac.CracTest foo,abc=def,ghi=$BAR abc=def,ghi=$BAR,foo=xxx true
+ * @run driver/timeout=15 jdk.test.lib.crac.CracTest foo,abc=def,ghi=$BAR abc=xxx,foo              false
+ */
+public class RequiredLabelsTest implements CracTest {
+    @CracTestArg(0)
+    String setLabels;
+
+    @CracTestArg(1)
+    String requireLabels;
+
+    @CracTestArg(2)
+    boolean shouldSucceed;
+
+    private static CracBuilder newPauseBuilder() {
+        return new CracBuilder().engine(CracEngine.SIMULATE).engineOptions("pause=true")
+                .env("BAR", "GOO")
+                .env("foo", "xxx");
+    }
+
+    @Override
+    public void test() throws Exception {
+        CracBuilder cpBuilder = newPauseBuilder();
+        if (!"-".equals(setLabels)) {
+            cpBuilder.javaOption("jdk.crac.labels", setLabels);
+        }
+        // Ensure that the pid file does not exist as leftover from previous test
+        //noinspection ResultOfMethodCallIgnored
+        cpBuilder.imageDir().resolve("pid").toFile().delete();
+
+        try (var cp = cpBuilder.startCheckpoint()) {
+            cp.waitForPausePid();
+
+            CracBuilder restoreBuilder = newPauseBuilder();
+            if (!"-".equals(requireLabels)) {
+                restoreBuilder.javaOption("jdk.crac.require-labels", requireLabels);
+            }
+            var restore = restoreBuilder.doRestoreToAnalyze();
+            if (shouldSucceed) {
+                restore.shouldHaveExitValue(0);
+            } else {
+                restore.shouldNotHaveExitValue(0);
+                newPauseBuilder().doRestore();
+            }
+            cp.waitForSuccess();
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        CRaCMXBean.getCRaCMXBean().checkpointRestore();
+    }
+}

--- a/test/jdk/jdk/crac/constraints/RequiredLabelsTest.java
+++ b/test/jdk/jdk/crac/constraints/RequiredLabelsTest.java
@@ -1,5 +1,5 @@
-package constraints;/*
- * Copyright (c) 2025, 2026, Azul Systems, Inc. All rights reserved.
+/*
+ * Copyright (c) 2026, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,7 +20,6 @@ package constraints;/*
  * CA 94089 USA or visit www.azul.com if you need additional information or
  * have any questions.
  */
-
 import jdk.crac.management.CRaCMXBean;
 import jdk.test.lib.crac.*;
 
@@ -32,6 +31,8 @@ import java.nio.file.Path;
  * @summary Check the jdk.crac.labels and jdk.crac.require-labels functionality
  * @library /test/lib
  * @build RequiredLabelsTest
+ * @comment simengine with pause=true is available only on Linux
+ * @requires os.family == "linux"
  * @run driver/timeout=15 jdk.test.lib.crac.CracTest foo=bar  foo=bar  true
  * @run driver/timeout=15 jdk.test.lib.crac.CracTest foo=bar  -        true
  * @run driver/timeout=15 jdk.test.lib.crac.CracTest -        foo=bar  false
@@ -39,9 +40,10 @@ import java.nio.file.Path;
  * @run driver/timeout=15 jdk.test.lib.crac.CracTest foo=bar  foo=$BAR false
  * @run driver/timeout=15 jdk.test.lib.crac.CracTest foo=$BAR foo=GOO  true
  * @run driver/timeout=15 jdk.test.lib.crac.CracTest foo      foo=xxx  true
- * @run driver/timeout=15 jdk.test.lib.crac.CracTest        - foo      false
+ * @run driver/timeout=15 jdk.test.lib.crac.CracTest -        foo      false
  * @run driver/timeout=15 jdk.test.lib.crac.CracTest foo,abc=def,ghi=$BAR abc=def,ghi=$BAR,foo=xxx true
  * @run driver/timeout=15 jdk.test.lib.crac.CracTest foo,abc=def,ghi=$BAR abc=xxx,foo              false
+ * @run driver/timeout=15 jdk.test.lib.crac.CracTest not_defined_env,abc=$NOT_DEFINED_ENV not_defined_env,abc=$NOT_DEFINED_ENV true
  */
 public class RequiredLabelsTest implements CracTest {
     @CracTestArg(0)
@@ -63,7 +65,7 @@ public class RequiredLabelsTest implements CracTest {
     public void test() throws Exception {
         CracBuilder cpBuilder = newPauseBuilder();
         if (!"-".equals(setLabels)) {
-            cpBuilder.javaOption("jdk.crac.labels", setLabels);
+            cpBuilder.vmOption("-XX:CRaCImageLabels=" + setLabels);
         }
         // Ensure that the pid file does not exist as leftover from previous test
         //noinspection ResultOfMethodCallIgnored
@@ -74,7 +76,7 @@ public class RequiredLabelsTest implements CracTest {
 
             CracBuilder restoreBuilder = newPauseBuilder();
             if (!"-".equals(requireLabels)) {
-                restoreBuilder.javaOption("jdk.crac.require-labels", requireLabels);
+                restoreBuilder.vmOption("-XX:CRaCRequiredImageLabels=" + requireLabels);
             }
             var restore = restoreBuilder.doRestoreToAnalyze();
             if (shouldSucceed) {


### PR DESCRIPTION
We can let the user define custom image constraints based on `jdk.crac.labels` and `jdk.crac.require-labels` properties, enforcing image choice on set strings or environment variables. This can help asserting e.g. the version of application in container image matches the CRaC image.

Along, we should record CPU features already in `crac::prepare_images()`, in case this is used in C/R API extension. This requires moving the method after `VM_Version` initialization. 

A small NPE fix is piggybacked.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8390453](https://bugs.openjdk.org/browse/JDK-8390453): [CRaC] Custom image constraints (**Enhancement** - P4)


### Reviewers
 * [Timofei Pushkin](https://openjdk.org/census#tpushkin) (@TimPushkin - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/343/head:pull/343` \
`$ git checkout pull/343`

Update a local copy of the PR: \
`$ git checkout pull/343` \
`$ git pull https://git.openjdk.org/crac.git pull/343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 343`

View PR using the GUI difftool: \
`$ git pr show -t 343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/343.diff">https://git.openjdk.org/crac/pull/343.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/343#issuecomment-5319483299)
</details>
