### PR TITLE
8390529: [CRaC] Treat local JARs opened via URL as persistent

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/jar/URLJarFile.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jar/URLJarFile.java
@@ -36,6 +36,13 @@ import java.util.jar.*;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipEntry;
 import java.security.CodeSigner;
+
+import jdk.internal.access.SharedSecrets;
+import jdk.internal.crac.Core;
+import jdk.internal.crac.JDKResource;
+import jdk.internal.crac.LoggerContainer;
+import jdk.internal.crac.mirror.Context;
+import jdk.internal.crac.mirror.Resource;
 import sun.net.www.ParseUtil;
 
 /* URL jar file is a common JarFile subtype used for JarURLConnection */
@@ -47,6 +54,7 @@ public class URLJarFile extends JarFile {
     private Manifest superMan;
     private Attributes superAttr;
     private Map<String, Attributes> superEntries;
+    private final JDKResource cracResource;
 
     static JarFile getJarFile(URL url, URLJarFileCloseController closeController) throws IOException {
         if (ParseUtil.isLocalFileURL(url)) {
@@ -63,12 +71,30 @@ public class URLJarFile extends JarFile {
             throws IOException {
         super(file, true, ZipFile.OPEN_READ | ZipFile.OPEN_DELETE, version);
         this.closeController = closeController;
+        // We don't assign the resource that would mark the file as persistent because it is deleted
+        // by the time we do a checkpoint. That's also why we use a separate resource rather than extending PersistentJarFile.
+        // In the future we could automatically copy that file to persist it during checkpoint
+        // (creating a hard link to deleted file is intentionally defunct on modern OS) and delete after restore.
+        this.cracResource = null;
     }
 
     private URLJarFile(URL url, URLJarFileCloseController closeController, Runtime.Version version)
             throws IOException {
         super(new File(ParseUtil.decode(url.getFile())), true, ZipFile.OPEN_READ, version);
         this.closeController = closeController;
+        this.cracResource = new JDKResource() {
+            @Override
+            public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+                LoggerContainer.info(URLJarFile.this.getName() + " is recorded as always available on restore");
+                SharedSecrets.getJavaUtilZipFileAccess().beforeCheckpoint(URLJarFile.this);
+            }
+
+            @Override
+            public void afterRestore(Context<? extends Resource> context) throws Exception {
+                // noop
+            }
+        };
+        Core.Priority.NORMAL.getContext().register(this.cracResource);
     }
 
     /**

--- a/test/jdk/jdk/crac/java/net/URL/OpenStreamTest.java
+++ b/test/jdk/jdk/crac/java/net/URL/OpenStreamTest.java
@@ -27,7 +27,6 @@ import jdk.test.lib.crac.CracEngine;
 import jdk.test.lib.crac.CracTest;
 import jdk.test.lib.util.JarUtils;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -76,10 +75,15 @@ public class OpenStreamTest implements CracTest {
         assertTrue(testjar.toFile().exists());
 
         URL url = new URL("jar:" + testjar.toUri().toURL() + "!/test.txt");
-        try (AutoCloseable _ = () -> assertTrue(testjar.toFile().delete());
-             InputStream inputStream = url.openStream()) {
+        try (InputStream inputStream = url.openStream()) {
             CRaCMXBean.getCRaCMXBean().checkpointRestore();
             assertEquals(TEST_STRING.length(), inputStream.readAllBytes().length);
         }
+        // On Windows the cleanup fails (that's why we don't assert that the delete() succeeds):
+        // the file is still open (and on Windowss it cannot be deleted). This is because the underlying
+        // JarFile is left cached despite the stream that got it opened is properly closed above.
+        // This is rather unrelated to what this test is asserting, though.
+        //noinspection ResultOfMethodCallIgnored
+        testjar.toFile().delete();
     }
 }

--- a/test/jdk/jdk/crac/java/net/URL/OpenStreamTest.java
+++ b/test/jdk/jdk/crac/java/net/URL/OpenStreamTest.java
@@ -21,9 +21,11 @@
  * questions.
  */
 import jdk.crac.management.CRaCMXBean;
+import jdk.test.lib.Utils;
 import jdk.test.lib.crac.CracBuilder;
 import jdk.test.lib.crac.CracEngine;
 import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.util.JarUtils;
 
 import java.io.Closeable;
 import java.io.File;
@@ -48,16 +50,16 @@ public class OpenStreamTest implements CracTest {
     @Override
     public void test() throws Exception {
         // no restore with simengine
-        new CracBuilder().engine(CracEngine.SIMULATE).doCheckpointToAnalyze().shouldHaveExitValue(0);
+        new CracBuilder().engine(CracEngine.SIMULATE).doCheckpoint();
     }
 
     private static Path createTestJar() throws IOException {
-        Path temp = Files.createTempDirectory(OpenStreamTest.class.getName());
+        Path temp = Utils.createTempDirectory(OpenStreamTest.class.getName());
         Path testFilePath = temp.resolve("test.txt");
         try {
             Files.writeString(testFilePath, TEST_STRING);
             Path jarfile = Path.of("test.jar");
-            jdk.test.lib.util.JarUtils.createJarFile(jarfile, temp, "test.txt");
+            JarUtils.createJarFile(jarfile, temp, "test.txt");
             return jarfile;
         } finally {
             File testTxt = testFilePath.toFile();
@@ -80,5 +82,4 @@ public class OpenStreamTest implements CracTest {
             assertEquals(TEST_STRING.length(), inputStream.readAllBytes().length);
         }
     }
-
 }

--- a/test/jdk/jdk/crac/java/net/URL/OpenStreamTest.java
+++ b/test/jdk/jdk/crac/java/net/URL/OpenStreamTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import jdk.crac.management.CRaCMXBean;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracEngine;
+import jdk.test.lib.crac.CracTest;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static jdk.test.lib.Asserts.assertEquals;
+import static jdk.test.lib.Asserts.assertTrue;
+
+/*
+ * @test
+ * @library /test/lib
+ * @build OpenStreamTest
+ * @run driver/timeout=15 jdk.test.lib.crac.CracTest
+ */
+public class OpenStreamTest implements CracTest {
+    public static final String TEST_STRING = "test\n";
+
+    @Override
+    public void test() throws Exception {
+        // no restore with simengine
+        new CracBuilder().engine(CracEngine.SIMULATE).doCheckpointToAnalyze().shouldHaveExitValue(0);
+    }
+
+    private static Path createTestJar() throws IOException {
+        Path temp = Files.createTempDirectory(OpenStreamTest.class.getName());
+        Path testFilePath = temp.resolve("test.txt");
+        try {
+            Files.writeString(testFilePath, TEST_STRING);
+            Path jarfile = Path.of("test.jar");
+            jdk.test.lib.util.JarUtils.createJarFile(jarfile, temp, "test.txt");
+            return jarfile;
+        } finally {
+            File testTxt = testFilePath.toFile();
+            if (testTxt.exists()) {
+                assert testTxt.delete();
+            }
+            assert temp.toFile().delete();
+        }
+    }
+
+    @Override
+    public void exec() throws Exception {
+        Path testjar = createTestJar();
+
+        URL url = new URL("jar:file:test.jar!/test.txt");
+        try (InputStream inputStream = url.openStream()) {
+            CRaCMXBean.getCRaCMXBean().checkpointRestore();
+            assertEquals(TEST_STRING.length(), inputStream.readAllBytes().length);
+        } finally {
+            assertTrue(testjar.toFile().delete());
+        }
+    }
+
+}

--- a/test/jdk/jdk/crac/java/net/URL/OpenStreamTest.java
+++ b/test/jdk/jdk/crac/java/net/URL/OpenStreamTest.java
@@ -25,6 +25,7 @@ import jdk.test.lib.crac.CracBuilder;
 import jdk.test.lib.crac.CracEngine;
 import jdk.test.lib.crac.CracTest;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -61,22 +62,22 @@ public class OpenStreamTest implements CracTest {
         } finally {
             File testTxt = testFilePath.toFile();
             if (testTxt.exists()) {
-                assert testTxt.delete();
+                assertTrue(testTxt.delete());
             }
-            assert temp.toFile().delete();
+            assertTrue(temp.toFile().delete());
         }
     }
 
     @Override
     public void exec() throws Exception {
         Path testjar = createTestJar();
+        assertTrue(testjar.toFile().exists());
 
-        URL url = new URL("jar:file:test.jar!/test.txt");
-        try (InputStream inputStream = url.openStream()) {
+        URL url = new URL("jar:" + testjar.toUri().toURL() + "!/test.txt");
+        try (AutoCloseable _ = () -> assertTrue(testjar.toFile().delete());
+             InputStream inputStream = url.openStream()) {
             CRaCMXBean.getCRaCMXBean().checkpointRestore();
             assertEquals(TEST_STRING.length(), inputStream.readAllBytes().length);
-        } finally {
-            assertTrue(testjar.toFile().delete());
         }
     }
 


### PR DESCRIPTION
If a JAR file is opened through java.net.URL.openStream() this should be treated the same way as other resources opened through URLClassPath or through modules - excluded from the FD checks. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8390529](https://bugs.openjdk.org/browse/JDK-8390529): [CRaC] Treat local JARs opened via URL as persistent (**Bug** - P4)


### Reviewers
 * [Timofei Pushkin](https://openjdk.org/census#tpushkin) (@TimPushkin - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/344/head:pull/344` \
`$ git checkout pull/344`

Update a local copy of the PR: \
`$ git checkout pull/344` \
`$ git pull https://git.openjdk.org/crac.git pull/344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 344`

View PR using the GUI difftool: \
`$ git pr show -t 344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/344.diff">https://git.openjdk.org/crac/pull/344.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/344#issuecomment-5330104147)
</details>
