### PR TITLE
8390670: [CRaC] Fix restart of streaming JFR recordings

### DIFF
--- a/src/java.base/share/classes/jdk/internal/crac/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/Core.java
@@ -72,6 +72,7 @@ public class Core {
         SCORE(Score.getContext()),
         FILE_DESCRIPTORS(new BlockingOrderedContext<>()),
         PRE_FILE_DESCRIPTORS(new BlockingOrderedContext<>()),
+        POST_JFR(new BlockingOrderedContext<>()),
         // We use OrderedContext to not cause failure when PlatformRecorder tries to
         // register itself when the recording is started from JfrResource.
         JFR(new OrderedContext<>()),

--- a/src/jdk.jfr/share/classes/jdk/jfr/EventSettings.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/EventSettings.java
@@ -106,6 +106,11 @@ public abstract class EventSettings {
         }
 
         @Override
+        public void setPlatformRecording(Recording r, PlatformRecording pr) {
+            r.setInternal(pr);
+        }
+
+        @Override
         public PlatformEventType getPlatformEventType(EventType eventType) {
             return eventType.getPlatformEventType();
         }

--- a/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
@@ -50,7 +50,7 @@ import jdk.jfr.internal.WriteablePath;
  *
  * @since 9
  *
- * @crac The recording is automatically stopped on checkpoint & re-created on restore.
+ * @crac The recording is automatically stopped on checkpoint and re-created on restore.
  */
 public final class Recording implements Closeable {
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
@@ -49,6 +49,8 @@ import jdk.jfr.internal.WriteablePath;
  * {@snippet class="Snippets" region="RecordingOverview"}
  *
  * @since 9
+ *
+ * @crac The recording is automatically stopped on checkpoint & re-created on restore.
  */
 public final class Recording implements Closeable {
 
@@ -82,7 +84,7 @@ public final class Recording implements Closeable {
         }
     }
 
-    private final PlatformRecording internal;
+    private PlatformRecording internal;
 
     /**
      * Creates a recording with settings from a map of name-value pairs.
@@ -676,6 +678,10 @@ public final class Recording implements Closeable {
     // package private
     PlatformRecording getInternal() {
         return internal;
+    }
+
+    void setInternal(PlatformRecording pr) {
+        internal = pr;
     }
 
     private void setSetting(String id, String value) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
@@ -60,7 +60,7 @@ import jdk.jfr.internal.management.StreamBarrier;
  *
  * @since 14
  *
- * @crac The recording is automatically stopped on checkpoint & re-created on restore.
+ * @crac The recording is automatically stopped on checkpoint and re-created on restore.
  */
 public final class RecordingStream implements AutoCloseable, EventStream {
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
@@ -59,6 +59,8 @@ import jdk.jfr.internal.management.StreamBarrier;
  * {@snippet class="Snippets" region="RecordingStreamOverview"}
  *
  * @since 14
+ *
+ * @crac The recording is automatically stopped on checkpoint & re-created on restore.
  */
 public final class RecordingStream implements AutoCloseable, EventStream {
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -83,13 +83,19 @@ public final class PlatformRecorder {
         @Override
         public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
             synchronized (PlatformRecorder.this) {
-                ArrayList<PlatformRecording> copy = new ArrayList<>(recordings);
-                futureRecordings = copy.stream().map(r -> {
+                // Started, delayed and stopped + closed recordings can be left as-is
+                List<PlatformRecording> running = recordings.stream()
+                        .filter(r -> r.getState() == RecordingState.RUNNING).toList();
+                futureRecordings = running.stream().map(r -> {
                     // PlatformRecording has to have a matching Recording - otherwise we could not control those
                     // through jcmd
                     Recording rec = new Recording(r.getSettings());
-                    PlatformRecording pr = PrivateAccess.getInstance().getPlatformRecording(rec);
-                    if (r.getName().equals(String.valueOf(r.getId()))) {
+                    PrivateAccess access = PrivateAccess.getInstance();
+                    PlatformRecording pr = access.getPlatformRecording(rec);
+                    // Update the owning Recording (important if this was created programmatically)
+                    access.setPlatformRecording(r.getRecording(), pr);
+                    if (r.getName().equ
+                    als(String.valueOf(r.getId()))) {
                         // default name == id, use the new id as name as well
                         rec.setName(String.valueOf(rec.getId()));
                     } else {
@@ -113,8 +119,11 @@ public final class PlatformRecorder {
                     return pr;
                 }).collect(Collectors.toList());
                 recordings.removeAll(futureRecordings);
-                copy.forEach(r -> r.stop("Checkpoint"));
-                assert recordings.isEmpty();
+                running.forEach(r -> {
+                    r.stop("Checkpoint");
+                    r.close();
+                });
+                assert recordings.stream().allMatch(r -> r.getState() != RecordingState.RUNNING);
             }
         }
 
@@ -124,43 +133,50 @@ public final class PlatformRecorder {
                 futureRecordings.forEach(r -> {
                     recordings.add(r);
                     WriteablePath destination = r.getDestination();
-                    // The backup recording has to be moved before creating WriteablePath
-                    // (and touching the recording output file)
-                    try {
-                        File destFile = destination.getReal().toFile();
-                        if (destFile.exists()) {
-                            Path backup = null;
-                            for (int i = 0; backup == null && i < MAX_BACKUPS; ++i) {
-                                String name = destFile.getName();
-                                // Mission Control has issues opening recording files
-                                // that don't end with .jfr
-                                if (name.endsWith(".jfr")) {
-                                    name = name.substring(0, name.length() - 4) + "." + i + ".jfr";
-                                } else {
-                                    name = name + "." + i;
-                                }
-                                backup = destination.getReal().getParent().resolve(name);
-                                if (backup.toFile().exists()) {
-                                    backup = null;
-                                }
-                            }
-                            if (backup != null) {
-                                Files.move(destFile.toPath(), backup);
-                                Logger.log(JFR, INFO, "Backed up " + destFile + " to " + backup);
-                            }
+                    // This could be a streaming recording (see JEP-349) without actual destination
+                    if (destination != null) {
+                        // The backup recording has to be moved before creating WriteablePath
+                        // (and touching the recording output file)
+                        backupOriginalDestination(destination);
+                        try {
+                            // We need to invoke WriteablePath after restore to create the dump file.
+                            // Since we're creating another WriteablePath we can use the original specification
+                            r.setDestination(new WriteablePath(destination.getPath()));
+                        } catch (IOException e) {
+                            Logger.log(JFR, ERROR, "Cannot reset recording destination: " + e);
                         }
-                    } catch (IOException e) {
-                        Logger.log(JFR, ERROR, "Cannot backup previous recording: " + e);
-                    }
-                    try {
-                        // We need to invoke WriteablePath after restore to create the dump file.
-                        // Since we're creating another WriteablePath we can use the original specification
-                        r.setDestination(new WriteablePath(destination.getPath()));
-                    } catch (IOException e) {
-                        Logger.log(JFR, ERROR, "Cannot reset recording destination: " + e);
                     }
                     r.start();
                 });
+            }
+        }
+
+        private void backupOriginalDestination(WriteablePath original) {
+            try {
+                File destFile = original.getReal().toFile();
+                if (destFile.exists()) {
+                    Path backup = null;
+                    for (int i = 0; backup == null && i < MAX_BACKUPS; ++i) {
+                        String name = destFile.getName();
+                        // Mission Control has issues opening recording files
+                        // that don't end with .jfr
+                        if (name.endsWith(".jfr")) {
+                            name = name.substring(0, name.length() - 4) + "." + i + ".jfr";
+                        } else {
+                            name = name + "." + i;
+                        }
+                        backup = original.getReal().getParent().resolve(name);
+                        if (backup.toFile().exists()) {
+                            backup = null;
+                        }
+                    }
+                    if (backup != null) {
+                        Files.move(destFile.toPath(), backup);
+                        Logger.log(JFR, INFO, "Backed up " + destFile + " to " + backup);
+                    }
+                }
+            } catch (IOException e) {
+                Logger.log(JFR, ERROR, "Cannot backup previous recording: " + e);
             }
         }
     };

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -94,8 +94,7 @@ public final class PlatformRecorder {
                     PlatformRecording pr = access.getPlatformRecording(rec);
                     // Update the owning Recording (important if this was created programmatically)
                     access.setPlatformRecording(r.getRecording(), pr);
-                    if (r.getName().equ
-                    als(String.valueOf(r.getId()))) {
+                    if (r.getName().equals(String.valueOf(r.getId()))) {
                         // default name == id, use the new id as name as well
                         rec.setName(String.valueOf(rec.getId()));
                     } else {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PrivateAccess.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PrivateAccess.java
@@ -78,6 +78,8 @@ public abstract class PrivateAccess {
 
     public abstract PlatformRecording getPlatformRecording(Recording r);
 
+    public abstract void setPlatformRecording(Recording r, PlatformRecording pr);
+
     public abstract PlatformEventType getPlatformEventType(EventType eventType);
 
     public abstract boolean isConstantPool(ValueDescriptor v);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
@@ -25,6 +25,7 @@
 
 package jdk.jfr.internal.consumer;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -32,8 +33,14 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
+import jdk.internal.crac.Core;
+import jdk.internal.crac.JDKResource;
+import jdk.internal.crac.mirror.Context;
+import jdk.internal.crac.mirror.Resource;
 import jdk.jfr.Configuration;
 import jdk.jfr.RecordingState;
 import jdk.jfr.consumer.RecordedEvent;
@@ -50,7 +57,7 @@ import jdk.jfr.internal.management.StreamBarrier;
  * with chunk files.
  *
  */
-public final class EventDirectoryStream extends AbstractEventStream {
+public final class EventDirectoryStream extends AbstractEventStream implements JDKResource {
 
     private static final Comparator<? super RecordedEvent> EVENT_COMPARATOR = JdkJfrConsumer.instance().eventComparator();
 
@@ -63,6 +70,7 @@ public final class EventDirectoryStream extends AbstractEventStream {
     private RecordedEvent[] sortedCache;
     private int threadExclusionLevel = 0;
     private volatile Consumer<Long> onCompleteHandler;
+    private final ReentrantLock lock = new ReentrantLock();
 
     public EventDirectoryStream(
             Path p,
@@ -74,6 +82,7 @@ public final class EventDirectoryStream extends AbstractEventStream {
         this.repositoryFiles = new RepositoryFiles(p, allowSubDirectories);
         this.streamId.incrementAndGet();
         Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Stream " + streamId + " started.");
+        Core.Priority.POST_JFR.getContext().register(this);
     }
 
     @Override
@@ -142,7 +151,13 @@ public final class EventDirectoryStream extends AbstractEventStream {
             return;
         }
         currentChunkStartNanos = repositoryFiles.getTimestamp(path);
-        try (RecordingInput input = new RecordingInput(path.toFile())) {
+        lock.lock();
+        try (Closeable _ = () -> {
+                if (lock.isHeldByCurrentThread()) {
+                    lock.unlock();
+                }
+            };
+            RecordingInput input = new RecordingInput(path.toFile())) {
             input.setStreamed();
             currentParser = new ChunkParser(input, disp.parserConfiguration, parserState());
             long segmentStart = currentParser.getStartNanos() + currentParser.getChunkDuration();
@@ -170,6 +185,11 @@ public final class EventDirectoryStream extends AbstractEventStream {
                         return;
                     }
                 }
+                // avoid try-with-resources explicit close warning
+                RecordingInput ri = input;
+                ri.close();
+                lock.unlock();
+
                 long endNanos = currentParser.getStartNanos() + currentParser.getChunkDuration();
                 long endMillis = Instant.ofEpochSecond(0, endNanos).toEpochMilli();
 
@@ -212,6 +232,7 @@ public final class EventDirectoryStream extends AbstractEventStream {
                     return;
                 }
                 currentChunkStartNanos = repositoryFiles.getTimestamp(path);
+                lock.lock();
                 input.setFile(path);
                 onComplete(endChunkNanos);
                 currentParser = currentParser.newChunkParser();
@@ -282,5 +303,16 @@ public final class EventDirectoryStream extends AbstractEventStream {
     public StreamBarrier activateStreamBarrier() {
         barrier.activate();
         return barrier;
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        // Ensures that the thread in processRecursionSafe() does not have an open file
+        lock.lock();
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) throws Exception {
+        lock.unlock();
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RecordingInput.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RecordingInput.java
@@ -432,12 +432,14 @@ public final class RecordingInput implements DataInput, AutoCloseable {
     // Purpose of this method is to reuse block cache from a
     // previous RecordingInput
     public void setFile(Path path) throws IOException {
-        try {
-            file.close();
-        } catch (IOException e) {
-            // perhaps deleted
+        if (file != null) {
+            try {
+                file.close();
+            } catch (IOException e) {
+                // perhaps deleted
+            }
+            file = null;
         }
-        file = null;
         initialize(path.toFile());
     }
 

--- a/test/jdk/jdk/crac/jfr/FlightRecorderStreamingTest.java
+++ b/test/jdk/jdk/crac/jfr/FlightRecorderStreamingTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import jdk.crac.management.CRaCMXBean;
+import jdk.jfr.consumer.RecordingStream;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @test FlightRecorderStreamingTest
+ * @library /test/lib
+ * @requires (os.family == "linux")
+ * @build FlightRecorderStreamingTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class FlightRecorderStreamingTest implements CracTest {
+    public static final String JDK_CPULOAD = "jdk.CPULoad";
+
+    @Override
+    public void test() throws Exception {
+        new CracBuilder().doCheckpointAndRestore();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        AtomicReference<CountDownLatch> latch = new AtomicReference<>(new CountDownLatch(1));
+        try (var rs = new RecordingStream()) {
+            rs.enable(JDK_CPULOAD).withPeriod(Duration.ofMillis(1));
+            rs.onEvent(JDK_CPULOAD, _ -> latch.get().countDown());
+            rs.startAsync();
+            // Wait until we receive at least one event
+            latch.get().await();
+            CRaCMXBean.getCRaCMXBean().checkpointRestore();
+            // Wait for some new event to arrive
+            latch.set(new CountDownLatch(1));
+            latch.get().await();
+        }
+    }
+}

--- a/test/jdk/jdk/crac/jfr/RecordingNotRunningTest.java
+++ b/test/jdk/jdk/crac/jfr/RecordingNotRunningTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import jdk.crac.management.CRaCMXBean;
+import jdk.jfr.Recording;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+
+/**
+ * @test RecordingNotRunningTest
+ * @library /test/lib
+ * @requires (os.family == "linux")
+ * @build RecordingNotRunningTest
+ * @run driver jdk.test.lib.crac.CracTest
+ */
+public class RecordingNotRunningTest implements CracTest {
+    public static final String JDK_CPULOAD = "jdk.CPULoad";
+
+    @Override
+    public void test() throws Exception {
+        new CracBuilder().doCheckpointAndRestore();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        try (Recording stopped = createAndConfigure();
+             Recording notStarted = createAndConfigure();
+             Recording delayed = createAndConfigure()) {
+            stopped.start();
+            Thread.sleep(1000);
+            stopped.stop();
+
+            delayed.scheduleStart(Duration.ofDays(1));
+
+            CRaCMXBean.getCRaCMXBean().checkpointRestore();
+
+            notStarted.start();
+            notStarted.stop();
+            delayed.start();
+            delayed.stop();
+        }
+    }
+
+    private static Recording createAndConfigure() throws IOException {
+        Recording recording = new Recording();
+        recording.enable(JDK_CPULOAD).withPeriod(Duration.ofMillis(1));
+        // If the destination is not set we'd need to call close() explicitly after stop() and dump()
+        recording.setDestination(Path.of("recording.jfr"));
+        return recording;
+    }
+}


### PR DESCRIPTION
When a recording does not have its destination set we hit a NPE.

There's more problems beyond the NPE, though: the EventDirectoryStream used by RecordingStream can keep a file open.

Also, currently all recordings are attempted to be restarted (recreated). We should do that only with the running ones; not started and closed recordings can be left as-is. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8390670](https://bugs.openjdk.org/browse/JDK-8390670): [CRaC] Fix restart of streaming JFR recordings (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/345/head:pull/345` \
`$ git checkout pull/345`

Update a local copy of the PR: \
`$ git checkout pull/345` \
`$ git pull https://git.openjdk.org/crac.git pull/345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 345`

View PR using the GUI difftool: \
`$ git pr show -t 345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/345.diff">https://git.openjdk.org/crac/pull/345.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/345#issuecomment-5343401519)
</details>
