### PR TITLE
8390766: [CRaC] Improve restore error logging

### DIFF
--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -983,13 +983,12 @@ void crac::restore(crac_restore_data& restore_data) {
       break;
   }
 
-  const int ret = engine.restore();
-  if (ret != 0) {
-    log_error(crac)("CRaC engine failed to restore from %s: error %d", CRaCRestoreFrom, ret);
-    VM_Version::VM_Features current_features;
-    VM_Version::cpu_features_binary(&current_features); // ignore return value
-    engine.check_cpuinfo(&current_features, exact);
-  }
+  const int err = engine.restore(); // Does not return on success
+  log_error(crac)("CRaC engine failed to restore from %s (error code %d)", CRaCRestoreFrom, err);
+
+  VM_Version::VM_Features current_features;
+  VM_Version::cpu_features_binary(&current_features); // ignore return value
+  engine.check_cpuinfo(&current_features, exact);
 }
 
 bool CracRestoreParameters::read_from(int fd) {

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -617,7 +617,6 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   if (CRaCRestoreFrom) {
     crac::restore(restore_data);
     if (!CRaCIgnoreRestoreIfUnavailable) {
-      log_error(crac)("Failed to restore from %s", CRaCRestoreFrom);
       return JNI_ERR;
     }
   }

--- a/test/jdk/jdk/crac/CheckpointRestorePathTest.java
+++ b/test/jdk/jdk/crac/CheckpointRestorePathTest.java
@@ -102,8 +102,7 @@ public class CheckpointRestorePathTest implements CracTest {
         new CracBuilder().engine(CracEngine.SIMULATE).engineOptions("pause=true").imageDir(NON_EXISTENT_CR)
                 .doRestoreToAnalyze()
                 .shouldHaveExitValue(1)
-                .stdoutShouldContain("Cannot open CRaCRestoreFrom=" + NON_EXISTENT_CR)
-                .stdoutShouldContain("Failed to restore from " + NON_EXISTENT_CR);
+                .stdoutShouldContain("Cannot open CRaCRestoreFrom=" + NON_EXISTENT_CR);
     }
 
     void testRestoreNoImage() throws Exception {


### PR DESCRIPTION
- All return codes of `engine.restore()` are now treated equally (as an error code)
- Removed `"Failed to restore from %s"` from the VM startup code because `crac::restore()` already prints a more concrete error log by itself

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8390766](https://bugs.openjdk.org/browse/JDK-8390766): [CRaC] Improve restore error logging (**Enhancement** - P5)


### Reviewers
 * [Jan Kratochvil](https://openjdk.org/census#jkratochvil) (@jankratochvil - Committer)
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/346/head:pull/346` \
`$ git checkout pull/346`

Update a local copy of the PR: \
`$ git checkout pull/346` \
`$ git pull https://git.openjdk.org/crac.git pull/346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 346`

View PR using the GUI difftool: \
`$ git pr show -t 346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/346.diff">https://git.openjdk.org/crac/pull/346.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/346#issuecomment-5355483656)
</details>
