### PR TITLE
8391859: [CRaC] Test repeated checkpoint

### DIFF
--- a/test/jdk/jdk/crac/RepeatedCheckpointRestoreTest.java
+++ b/test/jdk/jdk/crac/RepeatedCheckpointRestoreTest.java
@@ -24,22 +24,35 @@
 import jdk.crac.management.CRaCMXBean;
 import jdk.test.lib.crac.CracBuilder;
 import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
 
 /**
  * @test
  * @requires os.family == "linux"
  * @library /test/lib
- * @build RepeatedCheckpointTest
- * @run driver jdk.test.lib.crac.CracTest
+ * @build RepeatedCheckpointRestoreTest
+ * @run driver jdk.test.lib.crac.CracTest false
+ * @run driver jdk.test.lib.crac.CracTest true
  */
-public class RepeatedCheckpointTest implements CracTest {
+public class RepeatedCheckpointRestoreTest implements CracTest {
     private static final int NUM_CHECKPOINTS = 3;
+
+    @CracTestArg(0)
+    boolean changeImageLocation;
 
     @Override
     public void test() throws Exception {
-        final var builder = new CracBuilder();
-        builder.engineOptions("keep_running=true").doCheckpointToAnalyze().shouldHaveExitValue(0);
-        builder.engineOptions().doRestore();
+        final var builder = new CracBuilder().imageDir("cr0");
+        builder.doCheckpoint();
+        for (int i = 1; i < NUM_CHECKPOINTS; i++) {
+            final var nextImageLocation = changeImageLocation ? "cr" + i : builder.imageDir().toString();
+            builder.clearVmOptions().vmOption("-XX:CRaCCheckpointTo=" + nextImageLocation);
+            try (final var p = builder.startRestore()) {
+                p.waitForCheckpointed();
+            }
+            builder.imageDir(nextImageLocation);
+        }
+        builder.clearVmOptions().doRestore();
     }
 
     @Override

--- a/test/jdk/jdk/crac/RepeatedCheckpointRestoreTest.java
+++ b/test/jdk/jdk/crac/RepeatedCheckpointRestoreTest.java
@@ -42,8 +42,8 @@ public class RepeatedCheckpointRestoreTest implements CracTest {
 
     @Override
     public void test() throws Exception {
-        final var builder = new CracBuilder().imageDir("cr0");
-        builder.doCheckpoint();
+        final var builder = new CracBuilder();
+        builder.imageDir("cr0").doCheckpoint();
         for (int i = 1; i < NUM_CHECKPOINTS; i++) {
             final var nextImageLocation = changeImageLocation ? "cr" + i : builder.imageDir().toString();
             builder.clearVmOptions().vmOption("-XX:CRaCCheckpointTo=" + nextImageLocation);

--- a/test/jdk/jdk/crac/RepeatedCheckpointTest.java
+++ b/test/jdk/jdk/crac/RepeatedCheckpointTest.java
@@ -46,11 +46,11 @@ public class RepeatedCheckpointTest implements CracTest {
         builder.doCheckpoint();
         for (int i = 1; i < NUM_CHECKPOINTS; i++) {
             final var nextImageLocation = changeImageLocation ? "cr" + i : builder.imageDir().toString();
-            builder.vmOption("-XX:CRaCCheckpointTo=" + nextImageLocation);
+            builder.clearVmOptions().vmOption("-XX:CRaCCheckpointTo=" + nextImageLocation);
             try (final var p = builder.startRestore()) {
                 p.waitForCheckpointed();
             }
-            builder.clearVmOptions().imageDir(nextImageLocation);
+            builder.imageDir(nextImageLocation);
         }
         builder.doRestore();
     }

--- a/test/jdk/jdk/crac/RepeatedCheckpointTest.java
+++ b/test/jdk/jdk/crac/RepeatedCheckpointTest.java
@@ -50,7 +50,7 @@ public class RepeatedCheckpointTest implements CracTest {
             try (final var p = builder.startRestore()) {
                 p.waitForCheckpointed();
             }
-            builder.imageDir(nextImageLocation);
+            builder.clearVmOptions().imageDir(nextImageLocation);
         }
         builder.doRestore();
     }

--- a/test/jdk/jdk/crac/RepeatedCheckpointTest.java
+++ b/test/jdk/jdk/crac/RepeatedCheckpointTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.crac.management.CRaCMXBean;
+import jdk.test.lib.crac.CracBuilder;
+import jdk.test.lib.crac.CracTest;
+import jdk.test.lib.crac.CracTestArg;
+
+/**
+ * @test
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @build RepeatedCheckpointTest
+ * @run driver jdk.test.lib.crac.CracTest false
+ * @run driver jdk.test.lib.crac.CracTest true
+ */
+public class RepeatedCheckpointTest implements CracTest {
+    private static final int NUM_CHECKPOINTS = 10;
+
+    @CracTestArg(0)
+    boolean changeImageLocation;
+
+    @Override
+    public void test() throws Exception {
+        final var builder = new CracBuilder().imageDir("cr0");
+        builder.doCheckpoint();
+        for (int i = 1; i < NUM_CHECKPOINTS; i++) {
+            final var nextImageLocation = changeImageLocation ? "cr" + i : builder.imageDir().toString();
+            builder.vmOption("-XX:CRaCCheckpointTo=" + nextImageLocation);
+            try (final var p = builder.startRestore()) {
+                p.waitForCheckpointed();
+            }
+            builder.imageDir(nextImageLocation);
+        }
+        builder.doRestore();
+    }
+
+    @Override
+    public void exec() throws Exception {
+        final var mxBean = CRaCMXBean.getCRaCMXBean();
+        for (int i = 0; i < NUM_CHECKPOINTS; i++) {
+            mxBean.checkpointRestore();
+        }
+    }
+}

--- a/test/jdk/jdk/crac/RepeatedCheckpointTest.java
+++ b/test/jdk/jdk/crac/RepeatedCheckpointTest.java
@@ -52,7 +52,7 @@ public class RepeatedCheckpointTest implements CracTest {
             }
             builder.imageDir(nextImageLocation);
         }
-        builder.doRestore();
+        builder.clearVmOptions().doRestore();
     }
 
     @Override

--- a/test/jdk/jdk/crac/RepeatedCheckpointTest.java
+++ b/test/jdk/jdk/crac/RepeatedCheckpointTest.java
@@ -25,6 +25,9 @@ import jdk.crac.management.CRaCMXBean;
 import jdk.test.lib.crac.CracBuilder;
 import jdk.test.lib.crac.CracTest;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 /**
  * @test
  * @requires os.family == "linux"
@@ -34,19 +37,28 @@ import jdk.test.lib.crac.CracTest;
  */
 public class RepeatedCheckpointTest implements CracTest {
     private static final int NUM_CHECKPOINTS = 3;
+    private static final Path DO_CHECKPOINTS_MARKER = Path.of("do-checkpoints-marker");
 
     @Override
     public void test() throws Exception {
-        final var builder = new CracBuilder();
-        builder.engineOptions("keep_running=true").doCheckpointToAnalyze().shouldHaveExitValue(0);
-        builder.engineOptions().doRestore();
+        Files.createFile(DO_CHECKPOINTS_MARKER);
+        new CracBuilder().imageDir("cr%g").engineOptions("keep_running=true")
+                .doCheckpointToAnalyze().shouldHaveExitValue(0);
+
+        Files.delete(DO_CHECKPOINTS_MARKER); // Do not create new checkpoints, we want to test the ones already created
+        final var restoreBuilder = new CracBuilder();
+        for (int i = 0; i < NUM_CHECKPOINTS; i++) {
+            restoreBuilder.imageDir("cr" + (i + 1)).doRestore(); // %g starts from 1
+        }
     }
 
     @Override
     public void exec() throws Exception {
         final var mxBean = CRaCMXBean.getCRaCMXBean();
-        for (int i = 0; i < NUM_CHECKPOINTS; i++) {
+        for (int i = 0; i < NUM_CHECKPOINTS && Files.exists(DO_CHECKPOINTS_MARKER); i++) {
+            System.out.println("Checkpoint #" + (i + 1));
             mxBean.checkpointRestore();
         }
+        System.out.println("Completed");
     }
 }

--- a/test/jdk/jdk/crac/newArgs/CheckpointInNewMainTest.java
+++ b/test/jdk/jdk/crac/newArgs/CheckpointInNewMainTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import jdk.crac.management.CRaCMXBean;
 import jdk.test.lib.crac.CracBuilder;
-import jdk.test.lib.crac.CracEngine;
 import jdk.test.lib.crac.CracTest;
 
 /**
@@ -43,7 +42,7 @@ public class CheckpointInNewMainTest implements CracTest {
 
     @Override
     public void test() throws Exception {
-        final var builder = new CracBuilder().engine(CracEngine.CRIU);
+        final var builder = new CracBuilder();
         // Checkpoint in the old main
         builder.doCheckpoint();
         // Restore from the old main and checkpoint in the new main

--- a/test/lib/jdk/test/lib/crac/CracBuilderBase.java
+++ b/test/lib/jdk/test/lib/crac/CracBuilderBase.java
@@ -124,7 +124,6 @@ public abstract class CracBuilderBase<T extends CracBuilderBase<T>> {
     }
 
     public T imageDir(String imageDir) {
-        assertEquals(DEFAULT_IMAGE_DIR, this.imageDir); // set once
         this.imageDir = imageDir;
         return self();
     }


### PR DESCRIPTION
Adds a test for repeated checkpoints (checkpoints after restore).

Also touches `jdk/crac/newArgs/CheckpointInNewMainTest` to remove the redundant engine specification — this is a pre-existing test that has already been exercising one repeated checkpoint but wasn't meant for that.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8391859](https://bugs.openjdk.org/browse/JDK-8391859): [CRaC] Test repeated checkpoint (**Task** - P3)


### Reviewers
 * [Radim Vansa](https://openjdk.org/census#rvansa) (@rvansa - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/347/head:pull/347` \
`$ git checkout pull/347`

Update a local copy of the PR: \
`$ git checkout pull/347` \
`$ git pull https://git.openjdk.org/crac.git pull/347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 347`

View PR using the GUI difftool: \
`$ git pr show -t 347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/347.diff">https://git.openjdk.org/crac/pull/347.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/347#issuecomment-5544870270)
</details>
