### PR TITLE
8391953: [CRaC] crlib_bitmap_comparison_t enum values have no unique prefix

### DIFF
--- a/src/hotspot/share/include/crlib/crlib_image_constraints.h
+++ b/src/hotspot/share/include/crlib/crlib_image_constraints.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Azul Systems, Inc. All rights reserved.
+ * Copyright (c) 2025, 2026 Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,9 @@
 #ifndef CRLIB_IMAGE_CONSTRAINTS_H
 #define CRLIB_IMAGE_CONSTRAINTS_H
 
+#include <stdbool.h>
+#include <stddef.h>
+
 #include "crlib.h"
 
 #ifdef __cplusplus
@@ -35,13 +38,12 @@ extern "C" {
 
 // When two bitmaps of different size are compared this behaves as if the shorter
 // bitmap was extended with zeros to the length of the longer bitmap.
-typedef enum {
-  EQUALS,
-  // Bitmap in image must be subset or equal to bitmap in constraint
-  SUBSET,
-  // Bitmap in image must be superset or equal to bitmap in constraint
-  SUPERSET,
-} crlib_bitmap_comparison_t;
+typedef unsigned int crlib_bitmap_comparison_t;
+#define CRLIB_BITMAP_CMP_EQUALS   0
+// Bitmap in image must be subset or equal to bitmap in constraint
+#define CRLIB_BITMAP_CMP_SUBSET   1
+// Bitmap in image must be superset or equal to bitmap in constraint
+#define CRLIB_BITMAP_CMP_SUPERSET 2
 
 // API for storing & verifying application-defined image characteristics, generally called tags.
 typedef const struct crlib_image_constraints {

--- a/src/hotspot/share/runtime/crac_engine.cpp
+++ b/src/hotspot/share/runtime/crac_engine.cpp
@@ -539,7 +539,7 @@ void CracEngine::require_cpuinfo(const VM_Version::VM_Features *current_features
   log_debug(crac)("cpufeatures_load user data %s from %s...", cpufeatures_name, CRaCRestoreFrom);
   _image_constraints_api->require_label(_conf, cpuarch_name, ARCHPROPNAME);
   _image_constraints_api->require_bitmap(_conf, cpufeatures_name,
-    reinterpret_cast<const unsigned char *>(current_features), sizeof(*current_features), exact ? EQUALS : SUBSET);
+    reinterpret_cast<const unsigned char *>(current_features), sizeof(*current_features), exact ? CRLIB_BITMAP_CMP_EQUALS : CRLIB_BITMAP_CMP_SUBSET);
 }
 
 void CracEngine::check_cpuinfo(const VM_Version::VM_Features *current_features, bool exact) const {

--- a/src/java.base/share/native/libcrcommon/image_constraints.cpp
+++ b/src/java.base/share/native/libcrcommon/image_constraints.cpp
@@ -157,7 +157,7 @@ static inline bool check_zeroes(const unsigned char* mem, size_t length) {
 
 bool ImageConstraints::Constraint::compare_bitmaps(const unsigned char* bitmap, size_t size) const {
   size_t common_size = data_size < size ? data_size : size;
-  if (comparison == EQUALS) {
+  if (comparison == CRLIB_BITMAP_CMP_EQUALS) {
     if (memcmp(data, bitmap, common_size)) {
       return false;
     }
@@ -170,7 +170,7 @@ bool ImageConstraints::Constraint::compare_bitmaps(const unsigned char* bitmap, 
   }
   const unsigned char* bm1 = bitmap, * bm2 = static_cast<const unsigned char*>(data);
   size_t s1 = size, s2 = data_size;
-  if (comparison == SUPERSET) {
+  if (comparison == CRLIB_BITMAP_CMP_SUPERSET) {
     bm1 = bm2;
     bm2 = bitmap;
     s1 = s2;

--- a/src/java.base/share/native/libcrcommon/image_constraints.hpp
+++ b/src/java.base/share/native/libcrcommon/image_constraints.hpp
@@ -121,7 +121,7 @@ public:
   bool set_bitmap(const char* name, const unsigned char* value, size_t length_bytes);
 
   bool require_label(const char* name, const char* value) {
-    return _constraints.add(Constraint(TagType::LABEL, strdup(name), strdup(value), strlen(value) + 1, EQUALS));
+    return _constraints.add(Constraint(TagType::LABEL, strdup(name), strdup(value), strlen(value) + 1, CRLIB_BITMAP_CMP_EQUALS));
   }
 
   bool require_bitmap(const char* name, const unsigned char* value, size_t length_bytes, crlib_bitmap_comparison_t comparison) {


### PR DESCRIPTION
Value names of the enum are unlikely to be unique which may lead to name clashes with other enums.
```
typedef enum {
  EQUALS,
  SUBSET,
  SUPERSET,
} crlib_bitmap_comparison_t;
```
The names should be prefixed with `CRLIB_BITMAP_CMP_*`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8391953](https://bugs.openjdk.org/browse/JDK-8391953): [CRaC] crlib_bitmap_comparison_t enum values have no unique prefix (**Task** - P4)


### Reviewers
 * [Timofei Pushkin](https://openjdk.org/census#tpushkin) (@TimPushkin - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/348/head:pull/348` \
`$ git checkout pull/348`

Update a local copy of the PR: \
`$ git checkout pull/348` \
`$ git pull https://git.openjdk.org/crac.git pull/348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 348`

View PR using the GUI difftool: \
`$ git pr show -t 348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/348.diff">https://git.openjdk.org/crac/pull/348.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/348#issuecomment-5582090899)
</details>
