### PR TITLE
8391957: [CRaC] Record restore-related metrics

### DIFF
--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1220,6 +1220,9 @@ JVM_GetCRaCScores(JNIEnv *env);
 JNIEXPORT void JNICALL
 JVM_RecordCRaCScores(JNIEnv *env, jobjectArray metrics, jdoubleArray values);
 
+JNIEXPORT jlong JNICALL
+JVM_GetUptimeSinceRestore(JNIEnv *env);
+
 #ifdef __cplusplus
 } /* extern "C" */
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3911,6 +3911,10 @@ JVM_ENTRY(void, JVM_RecordCRaCScores(JNIEnv *env, jobjectArray metrics, jdoubleA
   }
 JVM_END
 
+JVM_ENTRY(jlong, JVM_GetUptimeSinceRestore(JNIEnv *env))
+  return crac::uptime_since_restore();
+JVM_END
+
 JVM_ENTRY(void, JVM_VirtualThreadEndFirstTransition(JNIEnv* env, jobject vthread))
   oop vt = JNIHandles::resolve_external_guard(vthread);
   MountUnmountDisabler::end_transition(thread, vt, true /*is_mount*/, true /*is_thread_start*/);

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -63,7 +63,7 @@
 
 static jlong _restore_start_time;
 static jlong _restore_start_nanos;
-static jlong _restore_native_end_nanos = -1;
+static jlong _restore_native_end_nanos;
 
 CracEngine *crac::_engine = nullptr;
 unsigned int crac::_generation = 1;

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -625,6 +625,34 @@ static bool apply_labels(const char* labels, CracEngine* engine, bool (CracEngin
   return true;
 }
 
+static bool apply_constraints(CracEngine &engine, bool *exact) {
+  *exact = false;
+  // Since the check itself is delegated to the C/R Engine we will simply
+  // skip the check here.
+  bool ignore = VM_Version::check_cpu_features_skip();
+  if (CheckCPUFeatures == nullptr || !strcmp(CheckCPUFeatures, "compatible")) {
+    // default, compatible
+  } else if (!strcmp(CheckCPUFeatures, "skip")) {
+    ignore = true;
+  } else if (!strcmp(CheckCPUFeatures, "exact")) {
+    *exact = true;
+  } else {
+    log_error(crac)("Invalid value for -XX:CheckCPUFeatures=%s; available are 'compatible', 'exact' or 'skip'", CheckCPUFeatures);
+    return false;
+  }
+  if (!ignore) {
+    VM_Version::VM_Features current_features;
+    if (VM_Version::cpu_features_binary(&current_features)) {
+      engine.require_cpuinfo(&current_features, *exact);
+    }
+  }
+  if (!apply_labels(CRaCRequiredImageLabels, &engine, &CracEngine::require_label)) {
+    log_error(crac)("Cannot enforce some labels from CRaCRequiredImageLabels");
+    return false;
+  }
+  return true;
+}
+
 bool crac::prepare_checkpoint() {
   precond(CRaCCheckpointTo != nullptr);
 
@@ -660,6 +688,12 @@ bool crac::prepare_checkpoint() {
       }
       if (!apply_labels(CRaCImageLabels, engine.get(), &CracEngine::set_label)) {
         log_error(crac)("Cannot set some labels from CRaCImageLabels");
+        return false;
+      }
+      // We don't normally need constaints for the checkpoint itself; engine might use this
+      // to identify 'peer' images or 'peer' instances.
+      bool exact_ignored;
+      if (!apply_constraints(*engine.get(), &exact_ignored)) {
         return false;
       }
     } break;
@@ -920,31 +954,11 @@ void crac::restore(crac_restore_data& restore_data) {
 
   bool exact = false;
   switch (engine.prepare_image_constraints_api()) {
-    case CracEngine::ApiStatus::OK: {
-      // Since the check itself is delegated to the C/R Engine we will simply
-      // skip the check here.
-      bool ignore = VM_Version::check_cpu_features_skip();
-      if (CheckCPUFeatures == nullptr || !strcmp(CheckCPUFeatures, "compatible")) {
-        // default, compatible
-      } else if (!strcmp(CheckCPUFeatures, "skip")) {
-        ignore = true;
-      } else if (!strcmp(CheckCPUFeatures, "exact")) {
-        exact = true;
-      } else {
-        log_error(crac)("Invalid value for -XX:CheckCPUFeatures=%s; available are 'compatible', 'exact' or 'skip'", CheckCPUFeatures);
+    case CracEngine::ApiStatus::OK:
+      if (!apply_constraints(engine, &exact)) {
         return;
       }
-      if (!ignore) {
-        VM_Version::VM_Features current_features;
-        if (VM_Version::cpu_features_binary(&current_features)) {
-          engine.require_cpuinfo(&current_features, exact);
-        }
-      }
-      if (!apply_labels(CRaCRequiredImageLabels, &engine, &CracEngine::require_label)) {
-        log_error(crac)("Cannot enforce some labels from CRaCRequiredImageLabels");
-        return;
-      }
-    } break;
+      break;
     case CracEngine::ApiStatus::ERR:
       return;
     case CracEngine::ApiStatus::UNSUPPORTED:

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -63,6 +63,7 @@
 
 static jlong _restore_start_time;
 static jlong _restore_start_nanos;
+static jlong _restore_native_end_nanos = -1;
 
 CracEngine *crac::_engine = nullptr;
 unsigned int crac::_generation = 1;
@@ -362,6 +363,7 @@ int crac::checkpoint_restore(int *shmid) {
 #endif //LINUX
 
   crac::update_javaTimeNanos_offset();
+  crac::record_time_after_restore();
 
   if (CRaCTraceStartupTime) {
     tty->print_cr("STARTUPTIME " JLONG_FORMAT " restore-native", os::javaTimeNanos());
@@ -814,7 +816,7 @@ void crac::set_image_score(const char *metric, double value, TRAPS) {
 }
 
 GrowableArray<crac::score> crac::get_image_scores_from_jvm() {
-  GrowableArray<crac::score> scores(24);
+  GrowableArray<crac::score> scores(32);
 
   const double uptime = TimeHelper::counter_to_millis(os::elapsed_counter());
   // Estimated boot time - earlier than RuntimeMXBean.getStartTime(), unless javaTimeMillis jumps
@@ -824,7 +826,10 @@ GrowableArray<crac::score> crac::get_image_scores_from_jvm() {
   // Uptime since initial boot
   scores.append({"vm.uptimeSinceBoot", uptime});
   // Uptime since start of latest restore or -1 if not restored - same as CRaCMXBean.getUptimeSinceRestore()
-  scores.append({"vm.uptimeSinceRestore", _generation > 1 ? TimeHelper::counter_to_millis(crac::uptime_since_restore()) : -1});
+  scores.append({"vm.uptimeSinceRestore", static_cast<double>(_generation > 1 ? crac::uptime_since_restore() / NANOSECS_PER_MILLISEC : -1)});
+
+  scores.append({"vm.crac.generation", static_cast<double>(_generation)});
+  scores.append({"vm.restore.nativeTime", static_cast<double>(_generation > 1 ? (_restore_native_end_nanos - _restore_start_nanos) / NANOSECS_PER_MILLISEC : -1)});
 
   // Same as OperatingSystemMXBean.getProcessCpuTime() but in milliseconds
   scores.append({"vm.processCpuTime", os::elapsed_process_cpu_time() * 1000});
@@ -1072,6 +1077,10 @@ void crac::record_time_before_checkpoint() {
   _checkpoint_monotonic_nanos = os::javaTimeNanos();
   memset(_checkpoint_bootid, 0, UUID_LENGTH);
   read_bootid(_checkpoint_bootid);
+}
+
+void crac::record_time_after_restore() {
+  _restore_native_end_nanos = os::javaTimeNanos();
 }
 
 void crac::update_javaTimeNanos_offset() {

--- a/src/hotspot/share/runtime/crac.hpp
+++ b/src/hotspot/share/runtime/crac.hpp
@@ -87,6 +87,7 @@ private:
 
   static void record_time_before_checkpoint();
   static void update_javaTimeNanos_offset();
+  static void record_time_after_restore();
 
   static int checkpoint_restore(int *shmid);
 

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -1004,11 +1004,11 @@ static jlong get_long_attribute(jmmLongAttribute att) {
 
   case JMM_JVM_UPTIME_SINCE_RESTORE_MS:
     {
-      jlong ticks = crac::uptime_since_restore();
-      if (ticks == -1) {
+      jlong nanos = crac::uptime_since_restore();
+      if (nanos == -1) {
         return -1;
       }
-      return Management::ticks_to_ms(ticks);
+      return nanos / NANOSECS_PER_MILLISEC;
     }
 
   default:

--- a/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/mirror/Core.java
@@ -30,6 +30,7 @@ import jdk.internal.access.SharedSecrets;
 import jdk.internal.crac.ClaimedFDs;
 import jdk.internal.crac.JDKResource;
 import jdk.internal.crac.LoggerContainer;
+import jdk.internal.crac.Score;
 import jdk.internal.crac.mirror.impl.*;
 import jdk.internal.misc.InnocuousThread;
 import jdk.internal.module.Modules;
@@ -159,6 +160,9 @@ public class Core {
 
         return parsedNewArguments;
     }
+
+    // We cannot call CRaCMxBean from jdk.management module
+    private static native long getUptimeSinceRestore0();
 
     private static List<String> checkpointRestore1(long jcmdStream) throws CheckpointException, RestoreException {
         final ExceptionHolder<CheckpointException> checkpointException = new ExceptionHolder<>(CheckpointException::new);
@@ -292,6 +296,7 @@ public class Core {
                 checkpointInProgress = true;
                 newArguments = checkpointRestore1(jcmdStream);
             } finally {
+                Score.setScore("vm.restore.overallTime", getUptimeSinceRestore0());
                 if (FlagsHolder.TRACE_STARTUP_TIME) {
                     System.out.println("STARTUPTIME " + System.nanoTime() + " restore-finish");
                 }

--- a/src/java.base/share/native/libjava/CracCore.c
+++ b/src/java.base/share/native/libjava/CracCore.c
@@ -63,3 +63,8 @@ JNIEXPORT void JNICALL
 Java_jdk_internal_crac_Score_record(JNIEnv *env, jclass ignore, jobjectArray metrics, jdoubleArray values) {
     JVM_RecordCRaCScores(env, metrics, values);
 }
+
+JNIEXPORT jlong JNICALL
+Java_jdk_internal_crac_mirror_Core_getUptimeSinceRestore0(JNIEnv *env, jclass ignore) {
+    return JVM_GetUptimeSinceRestore(env);
+}


### PR DESCRIPTION
We are reporting metrics that describe JVM+application state & performance, the warmed-up-ness. The concept of metrics can be useful for engine extensions and management at different moments, though - therefore we can report restore times (native & Java) and current generation as metrics, and configure image constraints sooner than when we are attempting a restore. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8391957](https://bugs.openjdk.org/browse/JDK-8391957): [CRaC] Record restore-related metrics (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/crac.git pull/349/head:pull/349` \
`$ git checkout pull/349`

Update a local copy of the PR: \
`$ git checkout pull/349` \
`$ git pull https://git.openjdk.org/crac.git pull/349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 349`

View PR using the GUI difftool: \
`$ git pr show -t 349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/crac/pull/349.diff">https://git.openjdk.org/crac/pull/349.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/crac/pull/349#issuecomment-5584091707)
</details>
